### PR TITLE
feat: improve raw mode with typed fences and split keybindings

### DIFF
--- a/lua/parley/dispatcher.lua
+++ b/lua/parley/dispatcher.lua
@@ -157,8 +157,8 @@ local query = function(buf, provider, payload, handler, on_exit, callback)
 				-- First response should include the code block start marker
 				if qt.response == "" then
 					-- Initial response with opening code fence
-					qt.response = "```json\n" .. qt.raw_response
-					handler(qid, "```json\n" .. lines_chunk)
+					qt.response = '```json {"type": "response"}\n' .. qt.raw_response
+					handler(qid, '```json {"type": "response"}\n' .. lines_chunk)
 				else
 					-- Subsequent responses just add the new content
 					qt.response = qt.response .. lines_chunk

--- a/lua/parley/init.lua
+++ b/lua/parley/init.lua
@@ -641,12 +641,18 @@ M.setup = function(opts)
 		string.format("<cmd>%sToggleWebSearch<CR>", M.config.cmd_prefix),
 		{ noremap = true, silent = true, desc = "Toggle web_search tool" }
 	)
-	-- bind <C-g>r to toggle raw request/response mode
+	-- bind <C-g>r to toggle raw request mode, <C-g>R to toggle raw response mode
 	vim.keymap.set(
 		"n",
 		"<C-g>r",
-		string.format("<cmd>%sToggleRaw<CR>", M.config.cmd_prefix),
-		{ noremap = true, silent = true, desc = "Toggle raw request/response mode" }
+		string.format("<cmd>%sToggleRawRequest<CR>", M.config.cmd_prefix),
+		{ noremap = true, silent = true, desc = "Toggle raw request mode" }
+	)
+	vim.keymap.set(
+		"n",
+		"<C-g>R",
+		string.format("<cmd>%sToggleRawResponse<CR>", M.config.cmd_prefix),
+		{ noremap = true, silent = true, desc = "Toggle raw response mode" }
 	)
 
 	-- Setup lualine integration if lualine is enabled
@@ -2802,16 +2808,14 @@ M._build_messages = function(opts)
 				local question_content = exchange.question.content
 				local file_content = ""
 
-				-- Check if we're in raw request mode
-				local parse_raw_request = config.raw_mode and config.raw_mode.parse_raw_request
-
-				-- Handle raw request mode - parse JSON input from code blocks
-				if parse_raw_request then
-					-- Check if content contains a JSON code block
-					local json_content = question_content:match("%s*```json%s*(.-)\n```")
+				-- Handle raw request mode - parse JSON from typed code fences
+				-- Look for ```json {"type": "request"} fences; when present, use as raw payload
+				-- regardless of parse_raw_request toggle (the fence metadata is authoritative)
+				do
+					local json_content = question_content:match('```json%s+{"type":%s*"request"}%s*\n(.-)\n```')
 
 					if json_content then
-						logger.debug("Found JSON content in question, using raw request mode")
+						logger.debug("Found typed JSON request block in question, using raw request mode")
 
 						-- Try to parse the JSON
 						local success, payload = pcall(vim.json.decode, json_content)
@@ -3096,26 +3100,25 @@ M.chat_respond = function(params, callback, override_free_cursor, force)
 	-- Compute payload once for both display and query
 	local final_payload = raw_payload or M.dispatcher.prepare_payload(messages, agent_info.model, agent_info.provider)
 
-	-- In raw mode, insert the request payload into the buffer before the response
+	-- In raw request mode, insert the request payload after the question, before the agent response
+	-- Skip if the question already contains a typed request fence (raw_payload was parsed from it)
 	local raw_request_offset = 0
-	if M.config.raw_mode and M.config.raw_mode.show_raw_response then
+	if M.config.raw_mode and M.config.raw_mode.parse_raw_request and not raw_payload then
 		local json_str = vim.json.encode(final_payload)
-		-- Pretty-print via vim.inspect-style manual formatting
+		-- Pretty-print via python3 json.tool
 		local ok, formatted = pcall(function()
 			return vim.fn.system({ "python3", "-m", "json.tool" }, json_str)
 		end)
 		if not ok or vim.v.shell_error ~= 0 then
 			formatted = json_str
 		end
-		local request_lines = { "**Request:**", "", "```json" }
+		local request_lines = { '', '```json {"type": "request"}' }
 		for line in formatted:gmatch("[^\n]+") do
 			table.insert(request_lines, line)
 		end
 		table.insert(request_lines, "```")
-		table.insert(request_lines, "")
-		table.insert(request_lines, "**Response:**")
-		table.insert(request_lines, "")
-		vim.api.nvim_buf_set_lines(buf, response_line + 3, response_line + 3, false, request_lines)
+		-- Insert right before the agent header (at response_line, pushing agent header down)
+		vim.api.nvim_buf_set_lines(buf, response_line, response_line, false, request_lines)
 		raw_request_offset = #request_lines
 	end
 

--- a/lua/parley/lualine.lua
+++ b/lua/parley/lualine.lua
@@ -193,8 +193,16 @@ M.create_component = function(parley_instance)
         end
         display_name = display_name .. (supported and "[w]" or "[w?]")
       end
-      if parley.config.raw_mode and (parley.config.raw_mode.show_raw_response or parley.config.raw_mode.parse_raw_request) then
-        display_name = display_name .. "[r]"
+      if parley.config.raw_mode then
+        local raw_req = parley.config.raw_mode.parse_raw_request
+        local raw_resp = parley.config.raw_mode.show_raw_response
+        if raw_req and raw_resp then
+          display_name = display_name .. "[rR]"
+        elseif raw_req then
+          display_name = display_name .. "[r]"
+        elseif raw_resp then
+          display_name = display_name .. "[R]"
+        end
       end
       
       -- Show agent name with icon (spinner if busy)

--- a/tests/unit/build_messages_spec.lua
+++ b/tests/unit/build_messages_spec.lua
@@ -396,21 +396,21 @@ describe("_build_messages: header config overrides", function()
 end)
 
 describe("_build_messages: raw request mode", function()
-    it("when parse_raw_request is true and question contains JSON block, stores raw_payload", function()
+    it("when question contains typed JSON request fence, stores raw_payload", function()
         local json_question = [[
 What do you think?
-```json
+
+```json {"type": "request"}
 {"model": "gpt-4", "messages": [{"role": "user", "content": "custom"}]}
 ```
 ]]
         local ex = exchange(json_question)
         ex.question.line_start = 10
-        
+
         local pc = parsed_chat({ ex })
-        
+
         local config_with_raw = vim.deepcopy(parley.config)
-        config_with_raw.raw_mode = { parse_raw_request = true }
-        
+
         local messages = parley._build_messages({
             parsed_chat = pc,
             start_index = 1,
@@ -421,11 +421,187 @@ What do you think?
             helpers = stub_helpers,
             logger = stub_logger
         })
-        
+
         -- The raw_payload should be attached to the exchange
         assert.is_not_nil(ex.question.raw_payload)
         assert.equals("table", type(ex.question.raw_payload))
         assert.equals("gpt-4", ex.question.raw_payload.model)
+    end)
+
+    it("ignores plain JSON fences without type:request metadata", function()
+        local json_question = [[
+Here is some JSON:
+
+```json
+{"model": "gpt-4", "messages": [{"role": "user", "content": "custom"}]}
+```
+]]
+        local ex = exchange(json_question)
+        ex.question.line_start = 10
+
+        local pc = parsed_chat({ ex })
+
+        local config_with_raw = vim.deepcopy(parley.config)
+
+        local messages = parley._build_messages({
+            parsed_chat = pc,
+            start_index = 1,
+            end_index = 100,
+            exchange_idx = 1,
+            agent = agent(),
+            config = config_with_raw,
+            helpers = stub_helpers,
+            logger = stub_logger
+        })
+
+        -- No raw_payload should be set since the fence lacks type:request
+        assert.is_nil(ex.question.raw_payload)
+    end)
+
+    it("parses typed request fence even when parse_raw_request config is false", function()
+        local json_question = [[
+What do you think?
+
+```json {"type": "request"}
+{"model": "gpt-4", "messages": [{"role": "user", "content": "override"}]}
+```
+]]
+        local ex = exchange(json_question)
+        ex.question.line_start = 10
+
+        local pc = parsed_chat({ ex })
+
+        -- Explicitly set parse_raw_request to false
+        local config_no_raw = vim.deepcopy(parley.config)
+        config_no_raw.raw_mode = { parse_raw_request = false }
+
+        parley._build_messages({
+            parsed_chat = pc,
+            start_index = 1,
+            end_index = 100,
+            exchange_idx = 1,
+            agent = agent(),
+            config = config_no_raw,
+            helpers = stub_helpers,
+            logger = stub_logger
+        })
+
+        -- Typed fence should be detected regardless of parse_raw_request toggle
+        assert.is_not_nil(ex.question.raw_payload)
+        assert.equals("override", ex.question.raw_payload.messages[1].content)
+    end)
+
+    it("stores complete payload structure from typed request fence", function()
+        local json_question = [[
+Test question
+
+```json {"type": "request"}
+{"model": "gpt-4o", "messages": [{"role": "system", "content": "sys"}, {"role": "user", "content": "hello"}], "temperature": 0.5}
+```
+]]
+        local ex = exchange(json_question)
+        ex.question.line_start = 10
+
+        local pc = parsed_chat({ ex })
+
+        parley._build_messages({
+            parsed_chat = pc,
+            start_index = 1,
+            end_index = 100,
+            exchange_idx = 1,
+            agent = agent(),
+            config = vim.deepcopy(parley.config),
+            helpers = stub_helpers,
+            logger = stub_logger
+        })
+
+        assert.is_not_nil(ex.question.raw_payload)
+        assert.equals("gpt-4o", ex.question.raw_payload.model)
+        assert.equals(2, #ex.question.raw_payload.messages)
+        assert.equals("system", ex.question.raw_payload.messages[1].role)
+        assert.equals("user", ex.question.raw_payload.messages[2].role)
+        assert.equals(0.5, ex.question.raw_payload.temperature)
+    end)
+
+    it("handles invalid JSON in typed request fence gracefully", function()
+        local json_question = [[
+Test question
+
+```json {"type": "request"}
+{this is not valid json}
+```
+]]
+        local ex = exchange(json_question)
+        ex.question.line_start = 10
+
+        local pc = parsed_chat({ ex })
+
+        -- Should not error out
+        parley._build_messages({
+            parsed_chat = pc,
+            start_index = 1,
+            end_index = 100,
+            exchange_idx = 1,
+            agent = agent(),
+            config = vim.deepcopy(parley.config),
+            helpers = stub_helpers,
+            logger = stub_logger
+        })
+
+        -- raw_payload should remain nil since JSON was invalid
+        assert.is_nil(ex.question.raw_payload)
+    end)
+
+    it("ignores response type fences and only matches request type", function()
+        local json_question = [[
+Test question
+
+```json {"type": "response"}
+{"id": "chatcmpl-123", "choices": [{"message": {"content": "hello"}}]}
+```
+]]
+        local ex = exchange(json_question)
+        ex.question.line_start = 10
+
+        local pc = parsed_chat({ ex })
+
+        parley._build_messages({
+            parsed_chat = pc,
+            start_index = 1,
+            end_index = 100,
+            exchange_idx = 1,
+            agent = agent(),
+            config = vim.deepcopy(parley.config),
+            helpers = stub_helpers,
+            logger = stub_logger
+        })
+
+        -- Response type fence should not be treated as a request payload
+        assert.is_nil(ex.question.raw_payload)
+    end)
+
+    it("builds normal messages when question has no typed fence", function()
+        local ex = exchange("Just a normal question")
+        ex.question.line_start = 10
+
+        local pc = parsed_chat({ ex })
+
+        local messages = parley._build_messages({
+            parsed_chat = pc,
+            start_index = 1,
+            end_index = 100,
+            exchange_idx = 1,
+            agent = agent(),
+            config = vim.deepcopy(parley.config),
+            helpers = stub_helpers,
+            logger = stub_logger
+        })
+
+        -- No raw_payload, normal message building
+        assert.is_nil(ex.question.raw_payload)
+        assert.equals(2, #messages) -- system + user
+        assert.equals("user", messages[2].role)
+        assert.is_true(messages[2].content:find("Just a normal question") ~= nil)
     end)
 end)
 


### PR DESCRIPTION
## Summary
- Add metadata attributes to code fences (`{"type": "request"}` / `{"type": "response"}`) for machine-identifiable raw blocks
- Place raw request JSON after the question content, before the agent header
- Allow editing and re-sending typed request fences as raw payloads (skip duplicate insertion when fence already exists)
- Split keybindings: `<C-g>r` for raw request mode, `<C-g>R` for raw response mode
- Update lualine indicator: `[r]` request only, `[R]` response only, `[rR]` both

## Test plan
- [x] `make test` passes (all 7 raw mode unit tests + full suite)
- [ ] Manual: toggle raw request with `<C-g>r`, verify lualine shows `[r]`
- [ ] Manual: toggle raw response with `<C-g>R`, verify lualine shows `[R]`
- [ ] Manual: send question with raw request on, verify typed fence appears after question
- [ ] Manual: edit fenced request JSON and re-send, verify edited payload is used
- [ ] Manual: normal mode (no raw) works unchanged

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)