### PR TITLE
feat: add ChatReview command to review any text file

### DIFF
--- a/lua/parley/config.lua
+++ b/lua/parley/config.lua
@@ -258,6 +258,7 @@ local config = {
 	chat_shortcut_open_file = { modes = { "n", "i" }, shortcut = "<C-g>o" },
 	-- global shortcuts (available in any buffer)
 	global_shortcut_new = { modes = { "n", "i" }, shortcut = "<C-g>c" },
+	global_shortcut_review = { modes = { "n" }, shortcut = "<C-g>C" },
 	global_shortcut_finder = { modes = { "n", "i" }, shortcut = "<C-g>f" },
 	-- shortcut for adding chat references in markdown files
 	global_shortcut_add_chat_ref = { modes = { "n", "i" }, shortcut = "<C-g>a" },

--- a/lua/parley/init.lua
+++ b/lua/parley/init.lua
@@ -388,6 +388,14 @@ M.setup = function(opts)
 		end
 	end
 
+	if M.config.global_shortcut_review then
+		for _, mode in ipairs(M.config.global_shortcut_review.modes) do
+			vim.keymap.set(mode, M.config.global_shortcut_review.shortcut, function()
+				M.cmd.ChatReview({})
+			end, { silent = true, desc = "Review current file in new Chat" })
+		end
+	end
+
 	-- Set up global shortcuts for note-taking
 	if M.config.global_shortcut_note_new then
 		for _, mode in ipairs(M.config.global_shortcut_note_new.modes) do
@@ -2176,7 +2184,7 @@ end
 ---@param system_prompt string | nil # system prompt to use
 ---@param agent table | nil # obtained from get_agent
 ---@return number # buffer number
-M.new_chat = function(system_prompt, agent)
+M.new_chat = function(system_prompt, agent, initial_question)
 	local filename = M.config.chat_dir .. "/" .. M.logger.now() .. ".md"
 
 	-- encode as json if model is a table
@@ -2221,6 +2229,15 @@ M.new_chat = function(system_prompt, agent)
 	-- escape underscores (for markdown)
 	template = template:gsub("_", "\\_")
 
+	-- If an initial question is provided, append it after the user prefix
+	-- (done after underscore escaping so file paths in @@references stay intact)
+	if initial_question then
+		template = template:gsub(
+			M.config.chat_user_prefix .. "%s*$",
+			M.config.chat_user_prefix .. " " .. initial_question
+		)
+	end
+
 	-- strip leading and trailing newlines
 	template = template:gsub("^%s*(.-)%s*$", "%1") .. "\n"
 
@@ -2239,6 +2256,17 @@ end
 M.cmd.ChatNew = function(params, system_prompt, agent)
 	-- Simple version that just creates a new chat
 	return M.new_chat(system_prompt, agent)
+end
+
+-- Create a new chat pre-populated with a review question for the current file
+M.cmd.ChatReview = function(params)
+	local file_path = vim.api.nvim_buf_get_name(0)
+	if file_path == "" then
+		M.logger.warning("No file associated with current buffer")
+		return
+	end
+	local question = "proof read the following file:\n\n@@" .. file_path
+	return M.new_chat(nil, nil, question)
 end
 
 -- Function to create a new note


### PR DESCRIPTION
## Summary
- Adds `<C-g>C` global shortcut and `:ParleyChatReview` command that creates a new chat pre-populated with a proof-read question referencing the current file via `@@` syntax
- Extends `M.new_chat()` to accept an optional `initial_question` parameter
- Inserts the question after underscore escaping to preserve file paths in `@@` references

Closes #19

## Test plan
- [x] All existing tests pass (`make test` — 0 failures)
- [ ] Open a text file, press `<C-g>C`, verify new chat is created with `💬: proof read the following file:` and `@@/path/to/file`
- [ ] Submit the chat with `<C-g><C-g>` and verify the LLM receives the file content

🤖 Generated with [Claude Code](https://claude.com/claude-code)