### PR TITLE
feat: auto-select OAuth provider for well-known URLs

### DIFF
--- a/lua/parley/google_drive.lua
+++ b/lua/parley/google_drive.lua
@@ -481,7 +481,7 @@ end
 -- Get a valid access token, refreshing or re-authenticating as needed
 ---@param config table # google_drive config
 ---@param callback function # called with access_token string or nil
-M.get_access_token = function(config, callback)
+M.get_access_token = function(config, callback, url)
     M.load_tokens(function(tokens)
         if tokens and not M.is_token_expired(tokens) then
             callback(tokens.access_token)
@@ -497,7 +497,8 @@ M.get_access_token = function(config, callback)
                     M._prompt_auth(
                         config,
                         "Google OAuth: Token refresh failed. Please re-authenticate.",
-                        callback
+                        callback,
+                        url
                     )
                 end
             end)
@@ -506,7 +507,8 @@ M.get_access_token = function(config, callback)
             M._prompt_auth(
                 config,
                 "Google OAuth: No saved credentials. Please authenticate to access Google Drive files.",
-                callback
+                callback,
+                url
             )
         end
     end)
@@ -550,19 +552,75 @@ M._classify_api_error = function(error_code)
     return "other"
 end
 
+-- Map of URL host patterns to OAuth provider names.
+-- Used to auto-select the correct provider without prompting the user.
+local url_provider_map = {
+    { pattern = "docs%.google%.com/", provider = "google" },
+    { pattern = "drive%.google%.com/", provider = "google" },
+}
+
+-- Detect the OAuth provider for a URL based on well-known host patterns.
+---@param url string|nil # the URL to check
+---@return string|nil # provider name (e.g. "google") or nil if unknown
+M._detect_provider_for_url = function(url)
+    if not url or type(url) ~= "string" then
+        return nil
+    end
+    for _, entry in ipairs(url_provider_map) do
+        if url:match(entry.pattern) then
+            return entry.provider
+        end
+    end
+    return nil
+end
+
 -- Prompt the user to authenticate with an OAuth provider via vim.ui.select.
+-- When a url is provided and matches a well-known provider, skips the picker.
 -- Extensible: add future providers (MS OAuth, etc.) to the providers table.
 ---@param config table # google_drive config
 ---@param reason string # human-readable reason shown to the user
 ---@param callback function # called with access_token (string) or nil if cancelled
-M._prompt_auth = function(config, reason, callback)
+---@param url string|nil # optional URL to auto-detect provider
+M._prompt_auth = function(config, reason, callback, url)
+    -- Provider list (add entries here for future OAuth providers)
+    local providers = {
+        { name = "Google Drive (OAuth)", provider = "google" },
+    }
+
+    -- Helper: authenticate with a given provider entry
+    local function auth_with_provider(selected)
+        if selected.provider == "google" then
+            M.authenticate(config, function(tokens)
+                if tokens then
+                    callback(tokens.access_token)
+                else
+                    callback(nil)
+                end
+            end)
+        else
+            logger.warning("OAuth provider " .. selected.provider .. " not yet implemented")
+            callback(nil)
+        end
+    end
+
+    -- Auto-detect provider from URL
+    local detected = M._detect_provider_for_url(url)
+    if detected then
+        for _, p in ipairs(providers) do
+            if p.provider == detected then
+                vim.schedule(function()
+                    vim.api.nvim_echo({{ reason, "WarningMsg" }}, true, {})
+                    logger.debug("Auto-selected OAuth provider: " .. p.name)
+                    auth_with_provider(p)
+                end)
+                return
+            end
+        end
+    end
+
+    -- Fall back to picker when provider can't be auto-detected
     vim.schedule(function()
         vim.api.nvim_echo({{ reason, "WarningMsg" }}, true, {})
-
-        -- Provider list (add entries here for future OAuth providers)
-        local providers = {
-            { name = "Google Drive (OAuth)", provider = "google" },
-        }
 
         local display_items = {}
         for _, p in ipairs(providers) do
@@ -584,18 +642,7 @@ M._prompt_auth = function(config, reason, callback)
                 return
             end
 
-            if selected.provider == "google" then
-                M.authenticate(config, function(tokens)
-                    if tokens then
-                        callback(tokens.access_token)
-                    else
-                        callback(nil)
-                    end
-                end)
-            else
-                logger.warning("OAuth provider " .. selected.provider .. " not yet implemented")
-                callback(nil)
-            end
+            auth_with_provider(selected)
         end)
     end)
 end
@@ -654,7 +701,8 @@ M.fetch_content = function(url, config, callback)
                             else
                                 callback(nil, "Google Drive API: " .. err_msg)
                             end
-                        end
+                        end,
+                        url
                     )
                     return
                 end
@@ -734,7 +782,7 @@ M.fetch_content = function(url, config, callback)
             return
         end
         do_fetch(access_token, true)
-    end)
+    end, url)
 end
 
 return M

--- a/tests/unit/google_drive_spec.lua
+++ b/tests/unit/google_drive_spec.lua
@@ -265,6 +265,36 @@ describe("helper: URL detection", function()
     end)
 end)
 
+describe("google_drive: auto-detect OAuth provider from URL", function()
+    it("M1: detects Google for docs.google.com URL", function()
+        assert.equals("google", gd._detect_provider_for_url("https://docs.google.com/document/d/abc123/edit"))
+    end)
+
+    it("M2: detects Google for drive.google.com URL", function()
+        assert.equals("google", gd._detect_provider_for_url("https://drive.google.com/file/d/abc123/view"))
+    end)
+
+    it("M3: detects Google for Google Sheets URL", function()
+        assert.equals("google", gd._detect_provider_for_url("https://docs.google.com/spreadsheets/d/abc123/edit"))
+    end)
+
+    it("M4: detects Google for Google Slides URL", function()
+        assert.equals("google", gd._detect_provider_for_url("https://docs.google.com/presentation/d/abc123/edit"))
+    end)
+
+    it("M5: returns nil for unknown URL", function()
+        assert.is_nil(gd._detect_provider_for_url("https://example.com/file.txt"))
+    end)
+
+    it("M6: returns nil for nil input", function()
+        assert.is_nil(gd._detect_provider_for_url(nil))
+    end)
+
+    it("M7: returns nil for non-string input", function()
+        assert.is_nil(gd._detect_provider_for_url(123))
+    end)
+end)
+
 describe("google_drive: API error classification", function()
     it("L1: classifies 401 as auth error", function()
         assert.equals("auth", gd._classify_api_error(401))


### PR DESCRIPTION
## Summary
- Skip the OAuth provider picker for Google Drive/Docs URLs since the provider is unambiguous
- Add `_detect_provider_for_url()` using a `url_provider_map` table for extensibility
- Thread the URL through `get_access_token` and `_prompt_auth` so auto-detection works on both initial auth and retry-on-error paths
- Fall back to the picker for unknown URLs

## Test plan
- [x] All existing tests pass (`make test`)
- [x] 7 new tests for `_detect_provider_for_url` (M1-M7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)