### PR TITLE
fix: tighten remote URL fetch sequencing

### DIFF
--- a/lua/parley/google_drive.lua
+++ b/lua/parley/google_drive.lua
@@ -35,6 +35,8 @@ local type_filetypes = {
     drive_file = "",
 }
 
+local public_fetch_meta_marker = "__PARLEY_REMOTE_FETCH_META__"
+
 -- Check if a path is a Google Drive/Docs URL
 ---@param path string|nil # the path to check
 ---@return boolean # true if path is a recognized Google URL
@@ -454,11 +456,11 @@ M.authenticate = function(config, callback)
         end)
     end)
 
-    -- Timeout: close server after 2 minutes if no auth response received
+    -- Timeout: close server after 30 seconds if no auth response received
     local timeout_timer = uv.new_timer()
-    timeout_timer:start(120000, 0, function()
+    timeout_timer:start(30000, 0, function()
         if not server:is_closing() then
-            logger.warning("Google OAuth: authentication timed out after 2 minutes")
+            logger.warning("Google OAuth: authentication timed out after 30 seconds")
             server:close()
             vim.schedule(function()
                 vim.api.nvim_echo({{ "Google OAuth: Authentication timed out.", "ErrorMsg" }}, true, {})
@@ -537,6 +539,255 @@ M.format_google_content = function(name, file_type, content, url)
     end
 
     return header .. "\n```" .. filetype .. "\n" .. numbered_content .. "\n```\n\n"
+end
+
+---@param url string
+---@return string
+M._display_name_for_url = function(url)
+    if not url or url == "" then
+        return "remote-url"
+    end
+
+    local without_fragment = url:gsub("#.*$", "")
+    local name = without_fragment:match("/([^/?]+)[^/]*$") or without_fragment
+    if name == "" then
+        return without_fragment
+    end
+    return name
+end
+
+---@param content_type string|nil
+---@param fallback_name string|nil
+---@return string
+M._guess_remote_filetype = function(content_type, fallback_name)
+    local lowered = (content_type or ""):lower()
+    if lowered:match("json") then
+        return "json"
+    end
+    if lowered:match("html") then
+        return "html"
+    end
+    if lowered:match("markdown") then
+        return "markdown"
+    end
+    if lowered:match("csv") then
+        return "csv"
+    end
+    if lowered:match("xml") then
+        return "xml"
+    end
+    if fallback_name and fallback_name ~= "" then
+        return vim.filetype.match({ filename = fallback_name }) or ""
+    end
+    return ""
+end
+
+---@param body string|nil
+---@return string
+M._sanitize_public_body = function(body)
+    if not body or body == "" then
+        return body or ""
+    end
+
+    local sanitized = body
+    sanitized = sanitized:gsub('("content_access_token"%s*:%s*)"[^"]+"', '%1"[REDACTED]"')
+    sanitized = sanitized:gsub('("access_token"%s*:%s*)"[^"]+"', '%1"[REDACTED]"')
+    sanitized = sanitized:gsub('("refresh_token"%s*:%s*)"[^"]+"', '%1"[REDACTED]"')
+    return sanitized
+end
+
+---@param url string
+---@param parsed table
+---@return table|nil, table|nil
+M._finalize_public_response = function(url, parsed)
+    local effective_url = (parsed.effective_url and parsed.effective_url ~= "") and parsed.effective_url or url
+    local lowered_type = (parsed.content_type or ""):lower()
+
+    if not parsed.body or parsed.body == "" then
+        return nil, {
+            kind = "other",
+            message = "Remote URL fetch failed: empty response body from " .. effective_url,
+        }
+    end
+
+    if lowered_type:match("text/html") then
+        return nil, {
+            kind = "auth",
+            message = "Remote URL fetch failed: received HTML page instead of file content from " .. effective_url,
+        }
+    end
+
+    if parsed.body:match('"content_access_token"%s*:') and parsed.body:match('"url"%s*:') then
+        return nil, {
+            kind = "auth",
+            message = "Remote URL fetch failed: public URL returned an access handoff payload instead of file content for " .. effective_url,
+        }
+    end
+
+    parsed.body = M._sanitize_public_body(parsed.body)
+    return parsed, nil
+end
+
+---@param name string
+---@param content string
+---@param url string
+---@param content_type string|nil
+---@param effective_url string|nil
+---@return string
+M.format_remote_content = function(name, content, url, content_type, effective_url)
+    local filetype = M._guess_remote_filetype(content_type, name)
+    local lines = vim.split(content, "\n")
+    local numbered_lines = {}
+    for i, line in ipairs(lines) do
+        table.insert(numbered_lines, string.format("%d: %s", i, line))
+    end
+
+    local header = 'File: Remote URL - "' .. name .. '"'
+    local source_url = effective_url or url
+    if source_url and source_url ~= "" then
+        header = header .. " (fetched from " .. source_url .. ")"
+    end
+    if content_type and content_type ~= "" then
+        header = header .. " [" .. content_type .. "]"
+    end
+
+    return header .. "\n```" .. filetype .. "\n" .. table.concat(numbered_lines, "\n") .. "\n```\n\n"
+end
+
+---@param status_code number|nil
+---@return string
+M._classify_public_fetch_status = function(status_code)
+    if status_code == 401 or status_code == 403 or status_code == 404 then
+        return "auth"
+    end
+    if status_code and status_code >= 200 and status_code < 400 then
+        return "success"
+    end
+    return "other"
+end
+
+---@param raw_response string|nil
+---@return table|nil
+M._parse_public_fetch_response = function(raw_response)
+    if not raw_response or raw_response == "" then
+        return nil
+    end
+
+    local marker_start = "\n" .. public_fetch_meta_marker .. "\n"
+    local start_pos = raw_response:find(marker_start, 1, true)
+    if not start_pos then
+        return nil
+    end
+
+    local body = raw_response:sub(1, start_pos - 1)
+    local meta = raw_response:sub(start_pos + #marker_start)
+    local status_code = tonumber(meta:match("HTTP_STATUS:(%d+)"))
+    local content_type = meta:match("CONTENT_TYPE:(.-)\n") or ""
+    local effective_url = meta:match("EFFECTIVE_URL:(.-)\n") or ""
+
+    return {
+        body = body,
+        status_code = status_code,
+        content_type = content_type,
+        effective_url = effective_url,
+    }
+end
+
+---@param url string
+---@param callback function
+M._fetch_public_content = function(url, callback)
+    local args = {
+        "-L",
+        "-s",
+        "-w",
+        "\n" .. public_fetch_meta_marker .. "\n"
+            .. "HTTP_STATUS:%{http_code}\n"
+            .. "CONTENT_TYPE:%{content_type}\n"
+            .. "EFFECTIVE_URL:%{url_effective}\n",
+        url,
+    }
+
+    tasker.run(nil, "curl", args, function(code, _, stdout_data)
+        if code ~= 0 then
+            callback(nil, {
+                kind = "transport",
+                message = "Remote URL fetch failed: curl exited with code " .. tostring(code) .. " for " .. url,
+            })
+            return
+        end
+
+        local parsed = M._parse_public_fetch_response(stdout_data)
+        if not parsed or not parsed.status_code then
+            callback(nil, {
+                kind = "transport",
+                message = "Remote URL fetch failed: invalid response while accessing " .. url,
+            })
+            return
+        end
+
+        local kind = M._classify_public_fetch_status(parsed.status_code)
+        if kind == "success" then
+            local finalized, finalize_err = M._finalize_public_response(url, parsed)
+            if finalize_err then
+                callback(nil, finalize_err)
+                return
+            end
+            callback(finalized, nil)
+            return
+        end
+
+        callback(nil, {
+            kind = kind,
+            status_code = parsed.status_code,
+            effective_url = parsed.effective_url,
+            message = "Remote URL fetch failed: HTTP "
+                .. tostring(parsed.status_code)
+                .. " for "
+                .. (parsed.effective_url ~= "" and parsed.effective_url or url),
+        })
+    end)
+end
+
+---@param url string
+---@param public_result table|nil
+---@param public_err table|nil
+---@param provider string|nil
+---@param info table|nil
+---@return table
+M._decide_fetch_action = function(url, public_result, public_err, provider, info)
+    if public_result then
+        local source_url = public_result.effective_url ~= "" and public_result.effective_url or url
+        return {
+            action = "public",
+            display_name = M._display_name_for_url(source_url),
+            source_url = source_url,
+        }
+    end
+
+    if not public_err or public_err.kind ~= "auth" then
+        return {
+            action = "error",
+            message = public_err and public_err.message or ("Remote URL fetch failed for " .. url),
+        }
+    end
+
+    if provider ~= "google" then
+        return {
+            action = "error",
+            message = public_err.message,
+        }
+    end
+
+    if not info then
+        return {
+            action = "error",
+            message = "Public access failed and Google OAuth does not support this URL format: " .. url,
+        }
+    end
+
+    return {
+        action = "oauth",
+    }
 end
 
 -- Classify a Google API error code as auth-related or not.
@@ -654,10 +905,7 @@ end
 ---@param callback function # called with (formatted_content_string, error_string)
 M.fetch_content = function(url, config, callback)
     local info = M.parse_url(url)
-    if not info then
-        callback(nil, "Unsupported Google URL: " .. url)
-        return
-    end
+    local provider = M._detect_provider_for_url(url)
 
     -- Inner function that performs the actual fetch with a given access_token.
     -- retry_allowed prevents infinite loops: true on first attempt, false on retry.
@@ -689,21 +937,45 @@ M.fetch_content = function(url, config, callback)
                     .. " (code: " .. tostring(err_code or "?") .. ")"
                 logger.warning("Google Drive API metadata error: " .. err_msg)
 
-                -- If auth-related and retry allowed, prompt user to re-authenticate
+                -- If auth-related and retry allowed, try refreshing the token first
+                -- (the access_token may have been revoked or expired mid-request).
+                -- Only fall back to full browser re-auth if refresh fails.
                 if retry_allowed and M._classify_api_error(err_code) == "auth" then
-                    cached_tokens = nil
-                    M._prompt_auth(
-                        config,
-                        "Google Drive API: " .. err_msg .. " — Re-authenticate with a different account?",
-                        function(new_token)
-                            if new_token then
-                                do_fetch(new_token, false)
-                            else
-                                callback(nil, "Google Drive API: " .. err_msg)
-                            end
-                        end,
-                        url
-                    )
+                    M.load_tokens(function(tokens)
+                        if tokens and tokens.refresh_token then
+                            M.refresh_token(config, tokens, function(new_tokens)
+                                if new_tokens then
+                                    do_fetch(new_tokens.access_token, false)
+                                else
+                                    M._prompt_auth(
+                                        config,
+                                        "Google Drive API: " .. err_msg .. " — Re-authenticate with a different account?",
+                                        function(new_token)
+                                            if new_token then
+                                                do_fetch(new_token, false)
+                                            else
+                                                callback(nil, "Google Drive API: " .. err_msg)
+                                            end
+                                        end,
+                                        url
+                                    )
+                                end
+                            end)
+                        else
+                            M._prompt_auth(
+                                config,
+                                "Google Drive API: " .. err_msg .. " — Re-authenticate with a different account?",
+                                function(new_token)
+                                    if new_token then
+                                        do_fetch(new_token, false)
+                                    else
+                                        callback(nil, "Google Drive API: " .. err_msg)
+                                    end
+                                end,
+                                url
+                            )
+                        end
+                    end)
                     return
                 end
 
@@ -775,14 +1047,35 @@ M.fetch_content = function(url, config, callback)
         end)
     end
 
-    -- Start by getting access token, then fetch
-    M.get_access_token(config, function(access_token)
-        if not access_token then
-            callback(nil, "Google OAuth: authentication cancelled or failed.")
+    -- Public access comes first. Only attempt OAuth after a public auth-style
+    -- failure and only for providers we can actually identify.
+    M._fetch_public_content(url, function(public_result, public_err)
+        local decision = M._decide_fetch_action(url, public_result, public_err, provider, info)
+
+        if decision.action == "public" then
+            callback(M.format_remote_content(
+                decision.display_name,
+                public_result.body,
+                url,
+                public_result.content_type,
+                public_result.effective_url
+            ))
             return
         end
-        do_fetch(access_token, true)
-    end, url)
+
+        if decision.action == "error" then
+            callback(nil, decision.message)
+            return
+        end
+
+        M.get_access_token(config, function(access_token)
+            if not access_token then
+                callback(nil, "Google OAuth: authentication cancelled or failed.")
+                return
+            end
+            do_fetch(access_token, true)
+        end, url)
+    end)
 end
 
 return M

--- a/lua/parley/init.lua
+++ b/lua/parley/init.lua
@@ -2942,36 +2942,39 @@ M._resolve_remote_references = function(parsed_chat, config, callback)
 		end
 	end
 
-	if #remote_refs == 0 then
+	-- Deduplicate URLs: each unique URL only needs to be fetched once
+	local unique_urls = {}
+	local seen = {}
+	for _, url in ipairs(remote_refs) do
+		if not seen[url] then
+			seen[url] = true
+			table.insert(unique_urls, url)
+		end
+	end
+
+	if #unique_urls == 0 then
 		callback({})
 		return
 	end
 
 	local resolved = {}
-	local pending = #remote_refs
+	local pending = #unique_urls
 
-	for _, url in ipairs(remote_refs) do
-		if google_drive.is_google_url(url) then
-			google_drive.fetch_content(url, config.google_drive, function(content, err)
-				if content then
-					resolved[url] = content
-				else
-					resolved[url] = "File: " .. url .. "\n[Error: " .. (err or "Failed to fetch") .. "]\n\n"
-					M.logger.warning("Failed to fetch Google Drive content: " .. (err or "unknown error"))
-				end
-				pending = pending - 1
-				if pending == 0 then
-					callback(resolved)
-				end
-			end)
-		else
-			-- Unsupported remote URL type
-			resolved[url] = "File: " .. url .. "\n[Error: Unsupported URL type. Only Google Drive URLs are currently supported.]\n\n"
+	for _, url in ipairs(unique_urls) do
+		-- Delegate remote URL handling to the OAuth fetcher. It owns provider
+		-- detection and can fall back to the auth picker for unknown patterns.
+		google_drive.fetch_content(url, config.google_drive, function(content, err)
+			if content then
+				resolved[url] = content
+			else
+				resolved[url] = "File: " .. url .. "\n[Error: " .. (err or "Failed to fetch") .. "]\n\n"
+				M.logger.warning("Failed to fetch remote content: " .. (err or "unknown error"))
+			end
 			pending = pending - 1
 			if pending == 0 then
 				callback(resolved)
 			end
-		end
+		end)
 	end
 end
 

--- a/lua/parley/vault.lua
+++ b/lua/parley/vault.lua
@@ -14,6 +14,15 @@ local V = {
 }
 
 local secrets = {} -- private secretes accessible only via vault.get_secret
+local secret_aliases = {
+	openai_api_key = "openai",
+}
+
+---@param name string
+---@return string
+local function resolve_secret_name(name)
+	return secret_aliases[name] or name
+end
 
 ---@param opts table # user config
 V.setup = function(opts)
@@ -30,6 +39,7 @@ end
 ---@param name string # provider name
 ---@param secret string | table | nil # secret or command to retrieve it
 V.add_secret = function(name, secret)
+	name = resolve_secret_name(name)
 	if secrets[name] then
 		logger.debug("vault secret " .. name .. " already exists", true)
 		return
@@ -43,6 +53,7 @@ end
 ---@param name string # secret name
 ---@return string | nil # secret or nil if not found
 V.get_secret = function(name)
+	name = resolve_secret_name(name)
 	local secret = secrets[name]
 	logger.debug("vault get_secret:" .. name .. ": " .. vim.inspect(secret), true)
 
@@ -62,6 +73,7 @@ end
 ---@param secret string | table | nil # secret or command to retrieve it
 ---@param callback function | nil # callback to run after secret is resolved
 V.resolve_secret = function(name, secret, callback)
+	name = resolve_secret_name(name)
 	logger.debug("vault resolver started for " .. name .. ": " .. vim.inspect(secret), true)
 	callback = callback or function() end
 	if secrets[name] and type(secrets[name]) ~= "table" then
@@ -188,6 +200,7 @@ end
 ---@param name string # secret name
 ---@param callback function # function to run after secret is resolved
 V.run_with_secret = function(name, callback)
+	name = resolve_secret_name(name)
 	if not secrets[name] then
 		logger.warning("vault secret " .. name .. " not found", true)
 		return

--- a/tests/unit/remote_references_spec.lua
+++ b/tests/unit/remote_references_spec.lua
@@ -1,0 +1,246 @@
+local tmp_dir = "/tmp/parley-test-remote-references-" .. os.time()
+
+local parley = require("parley")
+parley.setup({
+    chat_dir = tmp_dir,
+    state_dir = tmp_dir .. "/state",
+    providers = {},
+    api_keys = {},
+})
+
+describe("_resolve_remote_references", function()
+    local google_drive
+    local original_fetch_content
+
+    before_each(function()
+        google_drive = require("parley.google_drive")
+        original_fetch_content = google_drive.fetch_content
+    end)
+
+    after_each(function()
+        google_drive.fetch_content = original_fetch_content
+    end)
+
+    it("delegates unknown remote URLs to fetch_content so the fetcher can probe public access", function()
+        local calls = {}
+        google_drive.fetch_content = function(url, config, callback)
+            table.insert(calls, url)
+            callback(nil, "Remote URL fetch failed: HTTP 404 for " .. url)
+        end
+
+        local parsed_chat = {
+            exchanges = {
+                {
+                    question = {
+                        content = "Review this",
+                        file_references = {
+                            { path = "https://example.com/file.txt" },
+                        },
+                    },
+                },
+            },
+        }
+
+        local resolved
+        parley._resolve_remote_references(parsed_chat, parley.config, function(result)
+            resolved = result
+        end)
+
+        assert.same({ "https://example.com/file.txt" }, calls)
+        assert.is_not_nil(resolved)
+        assert.is_true(resolved["https://example.com/file.txt"]:match("Remote URL fetch failed: HTTP 404") ~= nil)
+    end)
+end)
+
+describe("google_drive.fetch_content", function()
+    local google_drive
+    local original_get_access_token
+    local original_fetch_public_content
+
+    before_each(function()
+        google_drive = require("parley.google_drive")
+        original_get_access_token = google_drive.get_access_token
+        original_fetch_public_content = google_drive._fetch_public_content
+    end)
+
+    after_each(function()
+        google_drive.get_access_token = original_get_access_token
+        google_drive._fetch_public_content = original_fetch_public_content
+    end)
+
+    it("uses direct public content without requesting OAuth", function()
+        local auth_requested = false
+        google_drive._fetch_public_content = function(url, callback)
+            callback({
+                body = google_drive._sanitize_public_body('{"title":"Public note","body":"hello"}'),
+                content_type = "application/json",
+                effective_url = url,
+                status_code = 200,
+            }, nil)
+        end
+        google_drive.get_access_token = function(config, callback, url)
+            auth_requested = true
+            callback(nil)
+        end
+
+        local content
+        google_drive.fetch_content("https://example.com/file.txt", parley.config.google_drive or {}, function(result, result_err)
+            content = result
+        end)
+
+        assert.is_false(auth_requested)
+        assert.is_not_nil(content)
+        assert.is_true(content:match("Remote URL") ~= nil)
+        assert.is_true(content:match("Public note") ~= nil)
+    end)
+
+    it("treats HTML landing pages as failed public fetches", function()
+        local finalized, err = google_drive._finalize_public_response("https://www.dropbox.com/s/example", {
+            body = "<!DOCTYPE html><html><head><title>Dropbox</title></head><body>viewer shell</body></html>",
+            content_type = "text/html; charset=utf-8",
+            effective_url = "https://www.dropbox.com/s/example",
+        })
+
+        assert.is_nil(finalized)
+        assert.is_not_nil(err)
+        assert.equals("auth", err.kind)
+        assert.is_true(err.message:match("received HTML page instead of file content") ~= nil)
+    end)
+
+    it("treats access handoff JSON as failed public fetches", function()
+        local finalized, err = google_drive._finalize_public_response("https://www.dropbox.com/s/example", {
+            body = '{"url":"https://www.dropbox.com/cloud_docs/view/abc","content_access_token":"secret-token"}',
+            content_type = "application/json",
+            effective_url = "https://www.dropbox.com/s/example",
+        })
+
+        assert.is_nil(finalized)
+        assert.is_not_nil(err)
+        assert.equals("auth", err.kind)
+        assert.is_true(err.message:match("access handoff payload") ~= nil)
+    end)
+
+    it("covers the URL fetch decision sequence", function()
+        local cases = {
+            {
+                name = "public success returns public action",
+                url = "https://example.com/file.txt",
+                public_result = {
+                    body = "hello",
+                    content_type = "text/plain",
+                    effective_url = "https://example.com/file.txt",
+                },
+                expected_action = "public",
+                expected_name = "file.txt",
+            },
+            {
+                name = "non-auth public failure returns error",
+                url = "https://example.com/file.txt",
+                public_err = {
+                    kind = "other",
+                    message = "Remote URL fetch failed: HTTP 500 for https://example.com/file.txt",
+                },
+                expected_action = "error",
+                expected_message = "Remote URL fetch failed: HTTP 500 for https://example.com/file.txt",
+            },
+            {
+                name = "auth failure with unknown provider returns error",
+                url = "https://example.com/file.txt",
+                public_err = {
+                    kind = "auth",
+                    message = "Remote URL fetch failed: HTTP 404 for https://example.com/file.txt",
+                },
+                expected_action = "error",
+                expected_message = "Remote URL fetch failed: HTTP 404 for https://example.com/file.txt",
+            },
+            {
+                name = "auth failure with known provider but unsupported format returns error",
+                url = "https://docs.google.com/forms/d/form123/edit",
+                public_err = {
+                    kind = "auth",
+                    message = "Remote URL fetch failed: HTTP 404 for https://docs.google.com/forms/d/form123/edit",
+                },
+                provider = "google",
+                expected_action = "error",
+                expected_message = "Public access failed and Google OAuth does not support this URL format: https://docs.google.com/forms/d/form123/edit",
+            },
+            {
+                name = "auth failure with known provider and supported format returns oauth",
+                url = "https://docs.google.com/document/d/abc123/edit",
+                public_err = {
+                    kind = "auth",
+                    message = "Remote URL fetch failed: HTTP 404 for https://docs.google.com/document/d/abc123/edit",
+                },
+                provider = "google",
+                info = { file_id = "abc123", file_type = "document" },
+                expected_action = "oauth",
+            },
+        }
+
+        for _, case in ipairs(cases) do
+            local decision = google_drive._decide_fetch_action(
+                case.url,
+                case.public_result,
+                case.public_err,
+                case.provider,
+                case.info
+            )
+
+            assert.equals(case.expected_action, decision.action, case.name)
+            if case.expected_name then
+                assert.equals(case.expected_name, decision.display_name, case.name)
+            end
+            if case.expected_message then
+                assert.equals(case.expected_message, decision.message, case.name)
+            end
+        end
+    end)
+
+    it("does not request OAuth when public access fails for an unknown provider", function()
+        local auth_requested = false
+        google_drive._fetch_public_content = function(url, callback)
+            callback(nil, {
+                kind = "auth",
+                message = "Remote URL fetch failed: HTTP 404 for " .. url,
+            })
+        end
+        google_drive.get_access_token = function(config, callback, url)
+            auth_requested = true
+            callback(nil)
+        end
+
+        local content, err
+        google_drive.fetch_content("https://example.com/file.txt", parley.config.google_drive or {}, function(result, result_err)
+            content = result
+            err = result_err
+        end)
+
+        assert.is_false(auth_requested)
+        assert.is_nil(content)
+        assert.equals("Remote URL fetch failed: HTTP 404 for https://example.com/file.txt", err)
+    end)
+
+    it("requests OAuth only after public auth failure for a supported provider", function()
+        local requested_url
+        google_drive._fetch_public_content = function(url, callback)
+            callback(nil, {
+                kind = "auth",
+                message = "Remote URL fetch failed: HTTP 404 for " .. url,
+            })
+        end
+        google_drive.get_access_token = function(config, callback, url)
+            requested_url = url
+            callback(nil)
+        end
+
+        local content, err
+        google_drive.fetch_content("https://docs.google.com/document/d/abc123/edit", parley.config.google_drive or {}, function(result, result_err)
+            content = result
+            err = result_err
+        end)
+
+        assert.equals("https://docs.google.com/document/d/abc123/edit", requested_url)
+        assert.is_nil(content)
+        assert.equals("Google OAuth: authentication cancelled or failed.", err)
+    end)
+end)


### PR DESCRIPTION
## Summary
- fetch remote URLs directly before deciding whether OAuth is needed
- centralize the fetch decision sequence so auth failures, unknown providers, and unsupported formats behave predictably
- add regression coverage for remote URL sequencing and restore legacy vault alias resolution expected by the test suite

## Testing
- make test