### PR TITLE
Migrate chat headers to front matter format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .aider*
 tasks/*
 !tasks/lessons.md
+.nvimlog

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,7 @@ Parley.nvim is a Neovim plugin that provides a streamlined LLM chat interface wi
 - Run tests for one spec: `make test-spec SPEC=chat/lifecycle` (uses `specs/traceability.yaml` mapping)
 - Run tests for changed specs: `make test-changed` (runs mapped tests for changed `specs/*/*.md` files)
 - For minor spec-scoped changes, prefer `test-spec`/`test-changed` first; run full `make test` before merge when risk is broader.
+- Clean hermetic test env artifacts: `make test-clean-env`
 - Refresh SSE fixtures: `ANTHROPIC_API_KEY=... OPENAI_API_KEY=... make fixtures`
 - Test files live in `tests/unit/` (pure logic, no Neovim APIs) and `tests/integration/` (full Neovim runtime)
 - Lint: None specified (consider using luacheck or lua-formatter if needed)

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,21 @@
-.PHONY: test test-spec test-changed fixtures model-check model-checker
+.PHONY: test test-spec test-changed fixtures model-check model-checker test-clean-env
 
 PLENARY = ~/.local/share/nvim/lazy/plenary.nvim
+REAL_HOME = $(HOME)
+TEST_HOME = $(CURDIR)/.test-home
+TEST_XDG = $(CURDIR)/.test-xdg
+TEST_TMP = $(CURDIR)/.test-tmp
+TEST_ENV = HOME="$(TEST_HOME)" XDG_DATA_HOME="$(TEST_XDG)/data" XDG_STATE_HOME="$(TEST_XDG)/state" XDG_CACHE_HOME="$(TEST_XDG)/cache" TMPDIR="$(TEST_TMP)" NVIM_TEST_PLENARY="$(REAL_HOME)/.local/share/nvim/lazy/plenary.nvim"
+
+define PREP_TEST_ENV
+mkdir -p "$(TEST_HOME)" "$(TEST_XDG)/data" "$(TEST_XDG)/state" "$(TEST_XDG)/cache" "$(TEST_TMP)"
+endef
 
 # Run all tests (unit + integration) via plenary in headless Neovim.
 # Each spec file runs sequentially to avoid state bleed.
 test:
-	nvim --headless --noplugin -u tests/minimal_init.vim \
+	@$(PREP_TEST_ENV)
+	@$(TEST_ENV) nvim --headless --noplugin -u tests/minimal_init.vim \
 	  -c "PlenaryBustedDirectory tests/ {sequential = true}" \
 	  -c "qa!"
 
@@ -16,7 +26,8 @@ test-spec:
 		echo "Usage: make test-spec SPEC=chat/lifecycle"; \
 		exit 1; \
 	fi
-	@tests="$$(scripts/spec_test_map.sh list-tests "$(SPEC)")"; \
+	@$(PREP_TEST_ENV); \
+	tests="$$(scripts/spec_test_map.sh list-tests "$(SPEC)")"; \
 	if [ -z "$$tests" ]; then \
 		echo "No tests mapped for spec: $(SPEC)"; \
 		echo "Update specs/traceability.yaml to add mappings."; \
@@ -24,7 +35,7 @@ test-spec:
 	fi; \
 	for test_file in $$tests; do \
 		echo "Running $$test_file"; \
-		nvim -n --headless --noplugin -u tests/minimal_init.vim \
+		$(TEST_ENV) nvim -n --headless --noplugin -u tests/minimal_init.vim \
 		  -c "PlenaryBustedFile $$test_file" \
 		  -c "qa!" || exit $$?; \
 	done
@@ -33,7 +44,8 @@ test-spec:
 # Uses tracked and untracked file changes since feature-branch base
 # (default base ref: remote/main, fallback origin/main, then main).
 test-changed:
-	@changed_specs="$$(scripts/spec_test_map.sh list-changed-specs)"; \
+	@$(PREP_TEST_ENV); \
+	changed_specs="$$(scripts/spec_test_map.sh list-changed-specs)"; \
 	if [ -z "$$changed_specs" ]; then \
 		echo "No changed spec files under specs/*/*.md"; \
 		exit 0; \
@@ -59,7 +71,7 @@ test-changed:
 	fi; \
 	for test_file in $$all_tests; do \
 		echo "Running $$test_file"; \
-		nvim -n --headless --noplugin -u tests/minimal_init.vim \
+		$(TEST_ENV) nvim -n --headless --noplugin -u tests/minimal_init.vim \
 		  -c "PlenaryBustedFile $$test_file" \
 		  -c "qa!" || exit $$?; \
 	done
@@ -67,7 +79,8 @@ test-changed:
 # Refresh SSE fixture files from real APIs.
 # Requires ANTHROPIC_API_KEY, OPENAI_API_KEY, GOOGLEAI_API_KEY in environment.
 fixtures:
-	nvim --headless --noplugin -u tests/minimal_init.vim \
+	@$(PREP_TEST_ENV)
+	@$(TEST_ENV) nvim --headless --noplugin -u tests/minimal_init.vim \
 	  -c "luafile scripts/record_fixtures.lua" \
 	  -c "qa!"
 
@@ -78,3 +91,6 @@ model-check:
 
 # Backward-compatible alias.
 model-checker: model-check
+
+test-clean-env:
+	rm -rf "$(TEST_HOME)" "$(TEST_XDG)" "$(TEST_TMP)"

--- a/lua/parley/chat_parser.lua
+++ b/lua/parley/chat_parser.lua
@@ -21,6 +21,53 @@ local logger = require("parley.logger")
 
 local M = {}
 
+local function trim(str)
+	return (str:gsub("^%s*(.-)%s*$", "%1"))
+end
+
+---Find the header/trancript separator index.
+---Supports:
+---1) Legacy format: metadata lines followed by a single `---`.
+---2) Front matter format: opening `---`, metadata, closing `---`.
+---@param lines table
+---@return number|nil
+M.find_header_end = function(lines)
+	if not lines or #lines == 0 then
+		return nil
+	end
+
+	if trim(lines[1]) == "---" then
+		for i = 2, #lines do
+			if trim(lines[i]) == "---" then
+				return i
+			end
+		end
+		return nil
+	end
+
+	for i, line in ipairs(lines) do
+		if trim(line) == "---" then
+			return i
+		end
+	end
+
+	return nil
+end
+
+local function parse_header_key_value(line)
+	local content = trim(line)
+	if content == "" or content == "---" then
+		return nil, nil
+	end
+
+	local key, value = content:match("^[-#]%s*([%w_%.]+):%s*(.*)$")
+	if key then
+		return key, value
+	end
+
+	return content:match("^([%w_%.]+):%s*(.*)$")
+end
+
 -- Structure to represent a parsed chat:
 -- {
 --   headers = { key-value pairs },
@@ -49,13 +96,13 @@ M.parse_chat = function(lines, header_end, config)
 	-- Parse headers
 	for i = 1, header_end do
 		local line = lines[i]
-		local key, value = line:match("^[-#] (%w+): (.*)")
+		local key, value = parse_header_key_value(line)
 		if key ~= nil then
 			if key == "tags" then
 				-- Parse tags into individual items
 				local tags = {}
-				for tag in value:gmatch("%S+") do
-					local trimmed_tag = tag:match("^%s*(.-)%s*$")
+				for tag in value:gmatch("[^,%s]+") do
+					local trimmed_tag = trim(tag)
 					if trimmed_tag and trimmed_tag ~= "" then
 						table.insert(tags, trimmed_tag)
 					end
@@ -64,16 +111,19 @@ M.parse_chat = function(lines, header_end, config)
 			else
 				result.headers[key] = value
 			end
-		end
 
-		-- Parse configuration override parameters
-		local config_key, config_value = line:match("^%- ([%w_]+): (.*)")
-		if config_key ~= nil and config_key ~= "file" and config_key ~= "model" and config_key ~= "provider" and config_key ~= "role" then
-			-- Try to convert to number if possible
-			if tonumber(config_value) ~= nil then
-				config_value = tonumber(config_value)
+			-- Parse configuration override parameters
+			if key ~= "file" and key ~= "model" and key ~= "provider" and key ~= "role" and key ~= "topic" and key ~= "tags" then
+				local config_value = value
+				if tonumber(config_value) ~= nil then
+					config_value = tonumber(config_value)
+				elseif config_value == "true" then
+					config_value = true
+				elseif config_value == "false" then
+					config_value = false
+				end
+				result.headers["config_" .. key] = config_value
 			end
-			result.headers["config_" .. config_key] = config_value
 		end
 	end
 

--- a/lua/parley/config.lua
+++ b/lua/parley/config.lua
@@ -294,7 +294,7 @@ local config = {
 	-- shortcut for opening oil.nvim file explorer
 	global_shortcut_oil = { modes = { "n" }, shortcut = "<leader>fo" },
 	-- default search term when using :ParleyChatFinder
-	chat_finder_pattern = "^# topic: ",
+	chat_finder_pattern = "",
 	chat_finder_mappings = {
 		delete = { modes = { "n", "i", "v", "x" }, shortcut = "<C-d>" },
 		toggle_all = { modes = { "n", "i", "v", "x" }, shortcut = "<C-a>" },

--- a/lua/parley/defaults.lua
+++ b/lua/parley/defaults.lua
@@ -35,23 +35,23 @@ M.code_system_prompt = "You are an AI working as a code editor.\n\n"
 	.. "START AND END YOUR ANSWER WITH:\n\n```"
 
 M.chat_template = [[
-# topic: ?
-
-- file: {{filename}}
+---
+topic: ?
+file: {{filename}}
 {{optional_headers}}
 Write your queries after {{user_prefix}}. Use `{{respond_shortcut}}` or :{{cmd_prefix}}ChatRespond to generate a response.
 Response generation can be terminated by using `{{stop_shortcut}}` or :{{cmd_prefix}}ChatStop command.
 Chats are saved automatically. To delete this chat, use `{{delete_shortcut}}` or :{{cmd_prefix}}ChatDelete.
 Be cautious of very long chats. Start a fresh chat by using `{{new_shortcut}}` or :{{cmd_prefix}}ChatNew.
-
 ---
 
 {{user_prefix}}
 ]]
 
 M.short_chat_template = [[
-# topic: ?
-- file: {{filename}}
+---
+topic: ?
+file: {{filename}}
 ---
 
 {{user_prefix}}

--- a/lua/parley/file_tracker.lua
+++ b/lua/parley/file_tracker.lua
@@ -7,6 +7,10 @@
 
 local M = {}
 
+local function is_test_mode()
+    return vim.g and vim.g.parley_test_mode == true
+end
+
 -- Structure to store file access information
 -- Keys are file paths, values are tables with:
 -- { 
@@ -28,6 +32,11 @@ end
 
 -- Load file access data from disk
 function M.load_data()
+    if is_test_mode() then
+        M._file_access = {}
+        return false
+    end
+
     ensure_dir_exists(access_data_file)
     
     -- Check if the file exists
@@ -50,6 +59,10 @@ end
 
 -- Save file access data to disk
 function M.save_data()
+    if is_test_mode() then
+        return true
+    end
+
     ensure_dir_exists(access_data_file)
     
     local ok, json_str = pcall(vim.fn.json_encode, M._file_access)
@@ -64,7 +77,7 @@ end
 -- Track file access
 function M.track_file_access(file_path)
     -- Load data if it's the first time
-    if next(M._file_access) == nil then
+    if not is_test_mode() and next(M._file_access) == nil then
         M.load_data()
     end
     
@@ -80,14 +93,14 @@ function M.track_file_access(file_path)
         M._file_access[file_path].access_count = (M._file_access[file_path].access_count or 0) + 1
     end
     
-    -- Save data to disk
+    -- Save data to disk (skipped in test mode)
     M.save_data()
 end
 
 -- Get last access time for a file
 function M.get_last_access_time(file_path)
     -- Load data if it's the first time
-    if next(M._file_access) == nil then
+    if not is_test_mode() and next(M._file_access) == nil then
         M.load_data()
     end
     
@@ -108,7 +121,7 @@ end
 -- Get access count for a file
 function M.get_access_count(file_path)
     -- Load data if it's the first time
-    if next(M._file_access) == nil then
+    if not is_test_mode() and next(M._file_access) == nil then
         M.load_data()
     end
     
@@ -155,7 +168,9 @@ end
 
 -- Initialize the tracker
 function M.init()
-    M.load_data()
+    if not is_test_mode() then
+        M.load_data()
+    end
     
     -- Run cleanup on startup to remove stale entries
     M.cleanup()

--- a/lua/parley/init.lua
+++ b/lua/parley/init.lua
@@ -69,6 +69,51 @@ local function stop_and_close_timer(timer)
 	end)
 end
 
+local function find_chat_header_end(lines)
+	return M.chat_parser.find_header_end(lines)
+end
+
+local function parse_chat_headers(lines)
+	local header_end = find_chat_header_end(lines)
+	if not header_end then
+		return nil, nil
+	end
+	local cfg = M.config or {}
+	local parse_config = {
+		chat_user_prefix = cfg.chat_user_prefix or "💬:",
+		chat_local_prefix = cfg.chat_local_prefix or "🔒:",
+		chat_assistant_prefix = cfg.chat_assistant_prefix or { "🤖:" },
+		chat_memory = cfg.chat_memory or {
+			enable = true,
+			summary_prefix = "📝:",
+			reasoning_prefix = "🧠:",
+		},
+	}
+	local parsed = M.chat_parser.parse_chat(lines, header_end, parse_config)
+	return parsed.headers, header_end
+end
+
+local function set_chat_topic_line(buf, lines, topic)
+	local header_end = find_chat_header_end(lines)
+	if not header_end then
+		vim.api.nvim_buf_set_lines(buf, 0, 1, false, { "# topic: " .. topic })
+		return
+	end
+
+	if lines[1] and lines[1]:gsub("^%s*(.-)%s*$", "%1") == "---" then
+		for i = 2, header_end - 1 do
+			if lines[i]:match("^%s*topic:%s*") then
+				vim.api.nvim_buf_set_lines(buf, i - 1, i, false, { "topic: " .. topic })
+				return
+			end
+		end
+		vim.api.nvim_buf_set_lines(buf, 1, 1, false, { "topic: " .. topic })
+		return
+	end
+
+	vim.api.nvim_buf_set_lines(buf, 0, 1, false, { "# topic: " .. topic })
+end
+
 -- Interview mode helper functions
 M.format_timestamp = function()
 	if not M._state.interview_start_time then
@@ -1199,27 +1244,26 @@ M.cmd.ExportMarkdown = function(params)
 		return
 	end
 
+	local headers, header_end = parse_chat_headers(lines)
+	if not header_end then
+		M.logger.error("Cannot export: invalid chat header format")
+		print("Error: Cannot export - invalid chat header format")
+		return
+	end
+
 	-- Extract Jekyll front matter data from Parley header
 	local title = "Untitled"
 	local post_date = os.date("%Y-%m-%d")
 	local tags = "unclassified"
 	local markdown_filename = nil
 
-	-- Extract title from first line (# topic: Title)
-	if lines[1] and lines[1]:match("^# topic: (.+)") then
-		title = lines[1]:match("^# topic: (.+)")
-	elseif lines[1] and lines[1]:match("^# (.+)") then
-		title = lines[1]:match("^# (.+)")
+	-- Extract title from parsed headers
+	if headers and headers.topic and headers.topic ~= "" then
+		title = headers.topic
 	end
 
 	-- Extract date from transcript header filename first, then fallback to current file
-	local transcript_filename = nil
-	for _, line in ipairs(lines) do
-		if line:match("^%- file:%s*(.+)") then
-			transcript_filename = line:match("^%- file:%s*(.+)")
-			break
-		end
-	end
+	local transcript_filename = headers and headers.file or nil
 
 	-- Try to extract date from transcript header filename first
 	if transcript_filename then
@@ -1239,11 +1283,14 @@ M.cmd.ExportMarkdown = function(params)
 		end
 	end
 
-	-- Extract tags from header lines (- tags: tag1, tag2, tag3)
-	for _, line in ipairs(lines) do
-		if line:match("^%- tags:%s*(.+)") then
-			tags = line:match("^%- tags:%s*(.+)")
-			break
+	-- Extract tags from parsed headers
+	if headers and headers.tags then
+		if type(headers.tags) == "table" then
+			if #headers.tags > 0 then
+				tags = table.concat(headers.tags, ", ")
+			end
+		elseif type(headers.tags) == "string" and headers.tags ~= "" then
+			tags = headers.tags
 		end
 	end
 
@@ -1267,10 +1314,11 @@ comments: true
 ]]
 
 	-- Process content: replace 💬: with ## and remove Parley header
-	local content = table.concat(lines, "\n")
-
-	-- Remove Parley header (everything from start until first ---)
-	content = content:gsub("^.-\n%-%-%-\n", "")
+	local body_lines = {}
+	for i = header_end + 1, #lines do
+		table.insert(body_lines, lines[i])
+	end
+	local content = table.concat(body_lines, "\n")
 
 	-- Replace 💬: with ## (the main transformation for Jekyll)
 	content = content:gsub("💬:", "#### 💬:")
@@ -1352,7 +1400,7 @@ M.prep_md = function(buf)
 end
 
 --- Checks if a file should be considered a chat transcript, it enforces that a file needs to be in chat_dir
---- and have header portion. Also first line needs to start with # (for the topic)
+--- and have a valid header portion.
 ---@param buf number # buffer number
 ---@param file_name string # file name
 ---@return string | nil # reason for not being a chat or nil if it is a chat
@@ -1375,18 +1423,16 @@ M.not_chat = function(buf, file_name)
 		return "file too short"
 	end
 
-	if not lines[1]:match("^# ") then
+	local headers, header_end = parse_chat_headers(lines)
+	if not header_end then
+		return "missing header separator"
+	end
+
+	if not headers or not headers.topic or headers.topic == "" then
 		return "missing topic header"
 	end
 
-	local header_found = nil
-	for i = 1, 10 do
-		if i < #lines and lines[i]:match("^- file: ") then
-			header_found = true
-			break
-		end
-	end
-	if not header_found then
+	if not headers.file or headers.file == "" then
 		return "missing file header"
 	end
 
@@ -1590,14 +1636,9 @@ M.get_chat_topic = function(file_path)
 		end
 	end
 
-	local lines = vim.fn.readfile(file_path, "", 5) -- Read first 5 lines
-	local topic = nil
-	for _, line in ipairs(lines) do
-		topic = line:match("^# topic: (.+)")
-		if topic then
-			break
-		end
-	end
+	local lines = vim.fn.readfile(file_path, "", 20)
+	local headers = parse_chat_headers(lines)
+	local topic = headers and headers.topic or nil
 
 	M._chat_topic_cache[file_path] = {
 		mtime = stat_mtime or { sec = 0, nsec = 0 },
@@ -2226,22 +2267,22 @@ M.new_chat = function(system_prompt, agent, initial_question)
 		model = agent.model
 		provider = agent.provider
 		if type(model) == "table" then
-			model = "- model: " .. vim.json.encode(model) .. "\n"
+			model = "model: " .. vim.json.encode(model) .. "\n"
 		else
-			model = "- model: " .. model .. "\n"
+			model = "model: " .. model .. "\n"
 		end
 
-		provider = "- provider: " .. provider:gsub("\n", "\\n") .. "\n"
+		provider = "provider: " .. provider:gsub("\n", "\\n") .. "\n"
 	end
 
 	-- display system prompt as single line with escaped newlines
 	if system_prompt then
-		system_prompt = "- role: " .. system_prompt:gsub("\n", "\\n") .. "\n"
+		system_prompt = "role: " .. system_prompt:gsub("\n", "\\n") .. "\n"
 	else
 		-- Use the selected system prompt from state
 		local selected_system_prompt = M._state.system_prompt or "default"
 		if M.system_prompts[selected_system_prompt] then
-			system_prompt = "- role: " .. M.system_prompts[selected_system_prompt].system_prompt:gsub("\n", "\\n") .. "\n"
+			system_prompt = "role: " .. M.system_prompts[selected_system_prompt].system_prompt:gsub("\n", "\\n") .. "\n"
 		else
 			system_prompt = ""
 		end
@@ -3101,13 +3142,7 @@ M.chat_respond = function(params, callback, override_free_cursor, force)
 	end
 
 	-- Find header section end
-	local header_end = nil
-	for i, line in ipairs(lines) do
-		if line:sub(1, 3) == "---" then
-			header_end = i
-			break
-		end
-	end
+	local header_end = find_chat_header_end(lines)
 
 	if header_end == nil then
 		M.logger.error("Error while parsing headers: --- not found. Check your chat template.")
@@ -3350,7 +3385,8 @@ M.chat_respond = function(params, callback, override_free_cursor, force)
 
 							-- replace topic in current buffer
 							M.helpers.undojoin(buf)
-							vim.api.nvim_buf_set_lines(buf, 0, 1, false, { "# topic: " .. topic })
+							local all_lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+							set_chat_topic_line(buf, all_lines, topic)
 						end)
 					)
 				end
@@ -3424,13 +3460,7 @@ M.chat_respond_all = function()
 	local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
 
 	-- Find header section end
-	local header_end = nil
-	for i, line in ipairs(lines) do
-		if line:sub(1, 3) == "---" then
-			header_end = i
-			break
-		end
-	end
+	local header_end = find_chat_header_end(lines)
 
 	if header_end == nil then
 		M.logger.error("Error while parsing headers: --- not found. Check your chat template.")
@@ -4037,16 +4067,8 @@ M.cmd.ChatFinder = function(options)
 			local tags = {}
 
 			-- Parse the file headers to get topic and tags
-			local header_end = 0
-			for idx, line in ipairs(lines) do
-				if line == "---" then
-					header_end = idx
-					break
-				end
-			end
-
-			-- If we found headers, parse them properly
-			if header_end > 0 then
+			local header_end = find_chat_header_end(lines)
+			if header_end then
 				local parsed_chat = M.parse_chat(lines, header_end)
 				if parsed_chat.headers.topic then
 					topic = parsed_chat.headers.topic

--- a/specs/chat/format.md
+++ b/specs/chat/format.md
@@ -4,21 +4,22 @@
 The chat transcript is a Markdown-compatible file with specific conventions for marking turns, metadata, and special content.
 
 ## File Header Section
-Every chat file MUST contain a header section before the first `---` separator.
+Every chat file MUST contain a header section before the transcript body.
+Preferred format is Markdown front matter (`---` opening + `---` closing). Legacy header style remains supported for existing files.
 
 ### Required Fields
-- `# topic: <topic>`: The first line of the file.
-- `- file: <filename>`: Within the first 10 lines.
+- `topic: <topic>`
+- `file: <filename>`
 
 ### Optional Configuration Overrides
 The header MAY contain YAML-like keys to override global configurations for the specific chat:
-- `- model: <string|json>`: Model parameters.
-- `- provider: <provider_name>`: LLM provider.
-- `- role: <system_prompt>`: System prompt (newlines escaped as `\n`).
-- `- tags: <space_separated_tags>`: Tags for organization.
-- `- max_full_exchanges: <number>`: Memory threshold override.
-- `- raw_mode.show_raw_response: <boolean>`: Display raw JSON response.
-- `- raw_mode.parse_raw_request: <boolean>`: Parse user JSON as request.
+- `model: <string|json>`: Model parameters.
+- `provider: <provider_name>`: LLM provider.
+- `role: <system_prompt>`: System prompt (newlines escaped as `\n`).
+- `tags: <space_or_comma_separated_tags>`: Tags for organization.
+- `max_full_exchanges: <number>`: Memory threshold override.
+- `raw_mode.show_raw_response: <boolean>`: Display raw JSON response.
+- `raw_mode.parse_raw_request: <boolean>`: Parse user JSON as request.
 
 ## Conversation Prefixes
 The plugin uses specific markers to distinguish between roles and special content.

--- a/specs/chat/parsing.md
+++ b/specs/chat/parsing.md
@@ -5,8 +5,10 @@ Parley parses chat buffers to identify conversation turns (questions and answers
 
 ## Buffer Segmentation
 A chat buffer is divided into two primary sections:
-1. **Header Section**: All lines before the first `---`.
-2. **Transcript Section**: All lines after the first `---`.
+1. **Header Section**:
+   - Front matter format: lines between opening `---` and closing `---`.
+   - Legacy format: lines before the first `---`.
+2. **Transcript Section**: All lines after the header closing separator.
 
 ## Identifying Conversation Turns
 - **Question (User)**: Begins with `chat_user_prefix` (default `💬:`). Ends at the next assistant prefix or end of file.
@@ -24,5 +26,5 @@ A chat buffer is divided into two primary sections:
 The plugin performs a series of checks to validate a chat buffer:
 1. Resolved path MUST start with `chat_dir`.
 2. Filename MUST follow the `YYYY-MM-DD` timestamp pattern.
-3. First line MUST start with `# topic:`.
-4. Header MUST contain `- file: <filename>`.
+3. Header MUST contain `topic`.
+4. Header MUST contain `file`.

--- a/specs/index.md
+++ b/specs/index.md
@@ -4,7 +4,7 @@
 This index provides a central directory for all specifications of the `parley.nvim` plugin.
 
 ## 1. Core Chat System
-- [Chat Format](chat/format.md): Transcript prefixes and header metadata.
+- [Chat Format](chat/format.md): Transcript prefixes and front matter header metadata.
 - [Chat Lifecycle](chat/lifecycle.md): Creation, response, resubmission, and deletion.
 - [Chat Memory](chat/memory.md): History management, summarization, and preservation.
 - [Chat Parsing](chat/parsing.md): Buffer segmentation and turn identification.

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -4,3 +4,6 @@
 - Avoid escaped-quote initialization inside Makefile shell recipes (e.g. `all_tests=\"\"`), which can become a literal token (`""`) and be treated as a filename.
 - Prefer newline-producing helper commands plus plain `for` iteration over manually concatenating quoted strings in Make recipes.
 - Always run the new Make target against at least one changed input path to catch recipe-level quoting bugs early.
+
+## 2026-03-08
+- When spec docs are changed, always run `make test-changed` before closing the task and report the result explicitly.

--- a/tests/integration/new_chat_spec.lua
+++ b/tests/integration/new_chat_spec.lua
@@ -66,28 +66,35 @@ describe("ChatNew", function()
             "file should contain a --- separator line")
     end)
 
-    it("created file contains the topic header line", function()
+    it("created file starts with front matter and contains topic line", function()
         parley.cmd.ChatNew({})
         local files = vim.fn.glob(tmp_dir .. "/*.md", false, true)
         assert.is_true(#files >= 1)
         local lines = vim.fn.readfile(files[#files])
-        assert.is_truthy(lines[1]:match("^# topic:"), 
-            "first line should be '# topic: ...', got: " .. tostring(lines[1]))
+        assert.equals("---", lines[1], "first line should be front matter opener")
+        local has_topic = false
+        for i = 1, math.min(#lines, 10) do
+            if lines[i]:match("^topic:") then
+                has_topic = true
+                break
+            end
+        end
+        assert.is_true(has_topic, "front matter should contain 'topic:' line")
     end)
 
-    it("created file contains a - file: header line", function()
+    it("created file contains a file: front matter line", function()
         parley.cmd.ChatNew({})
         local files = vim.fn.glob(tmp_dir .. "/*.md", false, true)
         assert.is_true(#files >= 1)
         local lines = vim.fn.readfile(files[#files])
         local has_file_header = false
         for _, line in ipairs(lines) do
-            if line:match("^%- file:") then
+            if line:match("^file:") then
                 has_file_header = true
                 break
             end
         end
-        assert.is_true(has_file_header, "file should contain a '- file:' header line")
+        assert.is_true(has_file_header, "file should contain a 'file:' front matter line")
     end)
 
     it("the new chat buffer passes not_chat validation", function()

--- a/tests/integration/not_chat_spec.lua
+++ b/tests/integration/not_chat_spec.lua
@@ -19,10 +19,11 @@ parley.setup({
 local function make_chat_buf(filename)
     local path = tmp_dir .. "/" .. filename
     local lines = {
-        "# topic: Test",
-        "- file: " .. filename,
-        "- model: test-model",
-        "- provider: openai",
+        "---",
+        "topic: Test",
+        "file: " .. filename,
+        "model: test-model",
+        "provider: openai",
         "---",
         "",
         "💬: Hello",
@@ -70,10 +71,11 @@ describe("not_chat: invalid files", function()
     it("returns a reason for a file in chat_dir without timestamp format", function()
         local path = tmp_dir .. "/no-timestamp.md"
         local lines = {
-            "# topic: Test",
-            "- file: no-timestamp.md",
-            "- model: test",
-            "- provider: openai",
+            "---",
+            "topic: Test",
+            "file: no-timestamp.md",
+            "model: test",
+            "provider: openai",
             "---",
             "",
             "💬: hi",
@@ -88,7 +90,7 @@ describe("not_chat: invalid files", function()
 
     it("returns a reason for a file that is too short (< 5 lines)", function()
         local path = tmp_dir .. "/2026-02-28.short.md"
-        local lines = { "# topic: Short", "---" }
+        local lines = { "---", "topic: Short", "---" }
         vim.fn.writefile(lines, path)
         local buf = vim.api.nvim_create_buf(false, true)
         vim.api.nvim_buf_set_name(buf, path)
@@ -100,10 +102,11 @@ describe("not_chat: invalid files", function()
     it("returns a reason for a file missing the topic header", function()
         local path = tmp_dir .. "/2026-02-28.no-topic.md"
         local lines = {
+            "---",
             "not a topic line",
-            "- file: 2026-02-28.no-topic.md",
-            "- model: test",
-            "- provider: openai",
+            "file: 2026-02-28.no-topic.md",
+            "model: test",
+            "provider: openai",
             "---",
             "",
             "💬: hi",
@@ -119,10 +122,11 @@ describe("not_chat: invalid files", function()
     it("returns a reason for a file missing the file header", function()
         local path = tmp_dir .. "/2026-02-28.no-file-header.md"
         local lines = {
-            "# topic: Test",
+            "---",
+            "topic: Test",
             "no file header here",
-            "- model: test",
-            "- provider: openai",
+            "model: test",
+            "provider: openai",
             "---",
             "",
             "💬: hi",

--- a/tests/minimal_init.vim
+++ b/tests/minimal_init.vim
@@ -7,7 +7,16 @@ set nocompatible
 set rtp+=.
 
 " Add plenary (installed via lazy.nvim)
-set rtp+=~/.local/share/nvim/lazy/plenary.nvim
+if exists('$NVIM_TEST_PLENARY') && !empty($NVIM_TEST_PLENARY)
+  execute 'set rtp+=' . fnameescape($NVIM_TEST_PLENARY)
+else
+  set rtp+=~/.local/share/nvim/lazy/plenary.nvim
+endif
 
 " Load plenary plugin so PlenaryBusted* commands are registered
 runtime plugin/plenary.vim
+
+" Hermetic test runtime: avoid swap/temp writes outside workspace
+set noswapfile
+set directory=.test-tmp//
+let g:parley_test_mode = v:true

--- a/tests/unit/parse_chat_spec.lua
+++ b/tests/unit/parse_chat_spec.lua
@@ -85,6 +85,26 @@ describe("parse_chat: headers", function()
         local result = parse_chat(lines, header_end)
         assert.equals(0, #result.exchanges)
     end)
+
+    it("parses front matter style headers", function()
+        local lines = {
+            "---",
+            "topic: Front Matter Topic",
+            "file: 2026-02-28.frontmatter.md",
+            "provider: openai",
+            "tags: lua, neovim",
+            "---",
+            "",
+            "💬: Hello",
+        }
+        local header_end = chat_parser.find_header_end(lines)
+        local result = parse_chat(lines, header_end)
+        assert.equals("Front Matter Topic", result.headers["topic"])
+        assert.equals("2026-02-28.frontmatter.md", result.headers["file"])
+        assert.equals("openai", result.headers["provider"])
+        assert.equals("lua", result.headers["tags"][1])
+        assert.equals("neovim", result.headers["tags"][2])
+    end)
 end)
 
 describe("parse_chat: single exchange", function()


### PR DESCRIPTION
## Summary
- Migrate chat file headers from legacy format (`# topic:` / `- file:`) to standard Markdown front matter (`---` delimited YAML), with backward compatibility for existing files
- Add `find_header_end()` and `parse_header_key_value()` to chat_parser, centralizing header detection across all call sites
- Run tests in hermetic HOME/XDG environment via Makefile to prevent side effects on host system

## Test plan
- [x] All 29 test suites pass with 0 failures
- [x] Unit tests cover front matter header parsing
- [x] Integration tests updated for new format (new_chat, not_chat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)