### PR TITLE
#127: infer a prose anchor for unquoted drill-in comments

### DIFF
--- a/atlas/chat/drill_in.md
+++ b/atlas/chat/drill_in.md
@@ -42,6 +42,11 @@ Accept and reject for `~X~` and the full §5 table are wired via `<M-a>` / `<M-r
      normalized). Its block quote is **inferred** from the surrounding reply
      prose (#127) so the flattened comment keeps an anchor — see Anchor
      inference below.
+   - **Referenced-span brackets** (#127, `config.mark_reference_span`, default
+     on): the referenced span is enclosed in `[]` *in place* so the reader can
+     see what each gathered comment points at — `T` → `[T]`; an inferred span is
+     bracketed where it already sits (the snippet is **not** re-inserted). The
+     enclosed spans are highlighted `ParleyReference` (see Anchor inference).
 
 4. **Resolve** — `<M-a>` accepts the marker at cursor and `<M-r>` rejects it, per the §5 table. Bulk-resolve was dropped in #124 M2 — operators resolve markers one at a time, or ask an agent to walk the chains (agentic resolution, §6 of the canonical target).
 
@@ -110,6 +115,22 @@ pure, the prefixes are passed in as `opts.boundaries`; `chat_respond` assembles
 them from config (`💬: 🤖: 🧠: 📝: 🔧: 📎: 🌿:`) and threads them through
 `gather_and_strip`. Note `---` is a *body* section separator, **not** a turn
 boundary, so it never stops the scan.
+
+**Referenced-span brackets + highlight.** `generate_snippet` also returns the
+**byte range** of the prose it drew from. With `opts.bracket` (set by
+`chat_respond` from `config.mark_reference_span`, default on) `gather_and_strip`
+encloses that span in `[]` in place — inline spans absorb the trailing gap +
+marker into the closing `]`; standalone spans are bracketed in the previous
+paragraph with the marker removed separately. Explicit `<Q>` becomes `[Q]`. The
+snippet itself is **never re-inserted** (it's already in the reply — we only
+delimit it). The highlighter colors these spans `ParleyReference` (default
+underline; `config.highlight.reference` overrides) via a per-line matcher that
+skips markdown links `](`, checkboxes, footnote refs, and 1-char content — a
+*heuristic*, since plain `[]` can't be told apart from incidental brackets with
+certainty. Set `config.mark_reference_span = false` to strip markers without the
+brackets. This is the one persistent visual cue for "what this comment points
+at" — `ParleyReviewQuoted` (reverse+bold on `🤖<…>`) only marks the scope while
+the *live* marker exists; the brackets survive the flatten + file reload.
 
 A small-LLM summarizer fallback (for long/messy spans) is deferred (YAGNI): a
 verbatim quote is a strictly better meaning-anchor than a paraphrase, and the

--- a/atlas/chat/drill_in.md
+++ b/atlas/chat/drill_in.md
@@ -112,9 +112,9 @@ agent turn — otherwise a standalone marker at a reply's start would anchor the
 agent's comment to the `💬:` user question or a `🧠:`/`📎:` block. The scan stops
 at any line beginning with a configured turn prefix. To keep `generate_snippet`
 pure, the prefixes are passed in as `opts.boundaries`; `chat_respond` assembles
-them from config (`💬: 🤖: 🧠: 📝: 🔧: 📎: 🌿:`) and threads them through
-`gather_and_strip`. Note `---` is a *body* section separator, **not** a turn
-boundary, so it never stops the scan.
+them from config (`💬: 🤖: 🧠: 📝: 🔧: 📎: 🌿:`, plus `chat_local_prefix` when
+set) and threads them through `gather_and_strip`. Note `---` is a *body* section
+separator, **not** a turn boundary, so it never stops the scan.
 
 **Referenced-span brackets + highlight.** `generate_snippet` also returns the
 **byte range** of the prose it drew from. With `opts.bracket` (set by

--- a/atlas/chat/drill_in.md
+++ b/atlas/chat/drill_in.md
@@ -38,7 +38,10 @@ Accept and reject for `~X~` and the full §5 table are wired via `<M-a>` / `<M-r
 
    Inline collapse rule for stripped markers:
    - Marker with `<T>` body → inline replaced by plain `T`.
-   - Marker without `<T>` body → marker removed entirely (whitespace not normalized).
+   - Marker without `<T>` body → marker removed entirely (whitespace not
+     normalized). Its block quote is **inferred** from the surrounding reply
+     prose (#127) so the flattened comment keeps an anchor — see Anchor
+     inference below.
 
 4. **Resolve** — `<M-a>` accepts the marker at cursor and `<M-r>` rejects it, per the §5 table. Bulk-resolve was dropped in #124 M2 — operators resolve markers one at a time, or ask an agent to walk the chains (agentic resolution, §6 of the canonical target).
 
@@ -70,7 +73,47 @@ U2
 
 Continuation lines inside chain sections (multi-line `U1`/`A1`) stay inside the blockquote with `> ` (no per-line `User:`/`Agent:` prefix).
 
-For a no-quote marker `🤖[Q]`, only `Q` is emitted (no leading `>` line). For a no-quote chain `🤖[U1]{A1}[U2]`, the chain lines are emitted without the leading `> T-…` block. Between adjacent gathered blocks, one blank line.
+For a no-quote marker `🤖[Q]`, an anchor `Q̂` is inferred from surrounding prose
+(#127) and emitted as the `> Q̂` line above `Q`. When no anchor can be recovered
+(degradation cases below), only `Q` is emitted (the pre-#127 behavior). Same for
+a no-quote chain `🤖[U1]{A1}[U2]` — an inferred `> Q̂` line, else none. Between
+adjacent gathered blocks, one blank line.
+
+## Anchor inference (#127)
+
+An unquoted marker carries no anchor, so flattening it into the next turn would
+strip the comment of *what it's about*. `drill_in.generate_snippet` recovers a
+**verbatim anchor** from the reply prose around the marker — so an unquoted
+comment is treated as a quoted comment whose `<T>` we infer, routing through the
+same block pipeline. It is a *meaning* anchor (the text the model re-reads),
+deliberately not a position token; a reference-token scheme was considered and
+rejected (see #127 Spec — refs cost a counter + conceal + edit-sync for only
+look-alike disambiguation).
+
+Rules (pure function of text + the marker's byte span + optional turn
+boundaries):
+
+- **inline** (prose precedes the marker, or a bare marker sits mid-paragraph
+  with no blank separation): the preceding ~10–20 words ending at the marker,
+  snapped back to a sentence boundary (extends across boundaries if the current
+  sentence is <10 words; caps at 20 with a leading `…`).
+- **standalone** (the marker is its own blank-separated paragraph): the first
+  sentence of the previous prose block (capped ~20 words).
+- **degrades to empty** (→ no `>` line) when nothing is recoverable: inline with
+  no preceding prose, or standalone at a turn start.
+
+**Turn boundaries.** The backward scan must never cross out of the marker's own
+agent turn — otherwise a standalone marker at a reply's start would anchor the
+agent's comment to the `💬:` user question or a `🧠:`/`📎:` block. The scan stops
+at any line beginning with a configured turn prefix. To keep `generate_snippet`
+pure, the prefixes are passed in as `opts.boundaries`; `chat_respond` assembles
+them from config (`💬: 🤖: 🧠: 📝: 🔧: 📎: 🌿:`) and threads them through
+`gather_and_strip`. Note `---` is a *body* section separator, **not** a turn
+boundary, so it never stops the scan.
+
+A small-LLM summarizer fallback (for long/messy spans) is deferred (YAGNI): a
+verbatim quote is a strictly better meaning-anchor than a paraphrase, and the
+fallback would live behind the same `generate_snippet` seam if ever needed.
 
 ## Cross-tool consistency
 
@@ -78,8 +121,8 @@ Both parley and ariadne (`/fix` skill) parse this marker family identically. The
 
 ## Key files
 
-- `lua/parley/drill_in.lua` — pure-function module (`parse`, `gather_and_strip`, `resolve`, `accept_at`, `reject_at`, `format_block`, `format_blocks`, `wrap`, `append_blocks`).
-- `lua/parley/chat_respond.lua` — pre-processing hook before message build (gates on resubmit detection).
+- `lua/parley/drill_in.lua` — pure-function module (`parse`, `gather_and_strip`, `generate_snippet`, `resolve`, `accept_at`, `reject_at`, `format_block`, `format_blocks`, `wrap`, `append_blocks`).
+- `lua/parley/chat_respond.lua` — pre-processing hook before message build (gates on resubmit detection); assembles the turn-prefix `boundaries` from config and threads them into `gather_and_strip` (#127).
 - `lua/parley/init.lua` — `<M-q>` (insert), `<M-a>` (accept), `<M-r>` (reject) wiring inside `prep_chat` / `setup_markdown_keymaps`.
 - `lua/parley/skills/review/init.lua` — shared section parser (`_parse_marker_sections`).
 - `lua/parley/buffer_edit.lua` — `replace_all_lines` helper used to write the rewritten buffer in one shot.

--- a/lua/parley/chat_respond.lua
+++ b/lua/parley/chat_respond.lua
@@ -993,13 +993,33 @@ M.respond = function(params, callback, override_free_cursor, force, live_model, 
     local drill_in = require("parley.drill_in")
     local branch_handled = false
 
+    -- Turn-prefix boundaries for unquoted-marker anchor inference (#127): the
+    -- backward prose scan must not cross out of the marker's own agent turn
+    -- (into the 💬: question, a 🧠:/📎: block, or a neighboring exchange). The
+    -- config→prefix coupling lives here in the glue layer; drill_in stays pure.
+    local di_opts = { boundaries = (function()
+        local cfg = _parley.config
+        local function first(p) return type(p) == "table" and p[1] or p end
+        local out = {}
+        local function add(p) if p and p ~= "" then table.insert(out, p) end end
+        add(cfg.chat_user_prefix or "💬:")
+        add(first(cfg.chat_assistant_prefix) or "🤖:")
+        add((cfg.chat_memory and cfg.chat_memory.reasoning_prefix) or "🧠:")
+        add((cfg.chat_memory and cfg.chat_memory.summary_prefix) or "📝:")
+        add(cfg.chat_tool_use_prefix or "🔧:")
+        add(cfg.chat_tool_result_prefix or "📎:")
+        add(cfg.chat_branch_prefix or "🌿:")
+        add(cfg.chat_local_prefix)
+        return out
+    end)() }
+
     if params.range ~= 2 and exchange_idx and component then
         local exch = parsed_chat.exchanges[exchange_idx]
         local exch_start = exch.question.line_start
         local exch_end = (exch.answer and exch.answer.line_end) or exch.question.line_end
         local exch_lines = {}
         for i = exch_start, exch_end do table.insert(exch_lines, lines[i]) end
-        local blocks, stripped_text = drill_in.gather_and_strip(table.concat(exch_lines, "\n"))
+        local blocks, stripped_text = drill_in.gather_and_strip(table.concat(exch_lines, "\n"), di_opts)
         if #blocks > 0 then
             local stripped_lines = vim.split(stripped_text, "\n", { plain = true })
             local user_prefix = _parley.config.chat_user_prefix or "💬:"
@@ -1051,7 +1071,7 @@ M.respond = function(params, callback, override_free_cursor, force, live_model, 
         end
     end
     if not branch_handled and not is_resubmit then
-        local di_blocks, stripped_text = drill_in.gather_and_strip(table.concat(lines, "\n"))
+        local di_blocks, stripped_text = drill_in.gather_and_strip(table.concat(lines, "\n"), di_opts)
         if #di_blocks > 0 then
             local stripped_lines = vim.split(stripped_text, "\n", { plain = true })
             local new_lines = drill_in.append_blocks(stripped_lines, di_blocks)

--- a/lua/parley/chat_respond.lua
+++ b/lua/parley/chat_respond.lua
@@ -997,7 +997,12 @@ M.respond = function(params, callback, override_free_cursor, force, live_model, 
     -- backward prose scan must not cross out of the marker's own agent turn
     -- (into the 💬: question, a 🧠:/📎: block, or a neighboring exchange). The
     -- config→prefix mapping is a tested pure helper; drill_in's core stays pure.
-    local di_opts = { boundaries = drill_in.chat_boundaries(_parley.config) }
+    -- `bracket` encloses each referenced span in `[]` in place so the reader can
+    -- see what the gathered comment points at (highlighted via ParleyReference).
+    local di_opts = {
+        boundaries = drill_in.chat_boundaries(_parley.config),
+        bracket = _parley.config.mark_reference_span ~= false,
+    }
 
     if params.range ~= 2 and exchange_idx and component then
         local exch = parsed_chat.exchanges[exchange_idx]

--- a/lua/parley/chat_respond.lua
+++ b/lua/parley/chat_respond.lua
@@ -996,22 +996,8 @@ M.respond = function(params, callback, override_free_cursor, force, live_model, 
     -- Turn-prefix boundaries for unquoted-marker anchor inference (#127): the
     -- backward prose scan must not cross out of the marker's own agent turn
     -- (into the 💬: question, a 🧠:/📎: block, or a neighboring exchange). The
-    -- config→prefix coupling lives here in the glue layer; drill_in stays pure.
-    local di_opts = { boundaries = (function()
-        local cfg = _parley.config
-        local function first(p) return type(p) == "table" and p[1] or p end
-        local out = {}
-        local function add(p) if p and p ~= "" then table.insert(out, p) end end
-        add(cfg.chat_user_prefix or "💬:")
-        add(first(cfg.chat_assistant_prefix) or "🤖:")
-        add((cfg.chat_memory and cfg.chat_memory.reasoning_prefix) or "🧠:")
-        add((cfg.chat_memory and cfg.chat_memory.summary_prefix) or "📝:")
-        add(cfg.chat_tool_use_prefix or "🔧:")
-        add(cfg.chat_tool_result_prefix or "📎:")
-        add(cfg.chat_branch_prefix or "🌿:")
-        add(cfg.chat_local_prefix)
-        return out
-    end)() }
+    -- config→prefix mapping is a tested pure helper; drill_in's core stays pure.
+    local di_opts = { boundaries = drill_in.chat_boundaries(_parley.config) }
 
     if params.range ~= 2 and exchange_idx and component then
         local exch = parsed_chat.exchanges[exchange_idx]

--- a/lua/parley/config.lua
+++ b/lua/parley/config.lua
@@ -190,7 +190,7 @@ local config = {
 		{
 			provider = "anthropic",
 			name = "ToolOpus",
-			model = { model = "claude-Opus-4-7", temperature = 0.8 },
+			model = { model = "claude-opus-4-7", temperature = 0.8 },
 			system_prompt = require("parley.defaults").chat_system_prompt,
 			tools = { "read_file", "ls", "find", "grep", "chat_history_search", "edit_file", "write_file" },
 			-- Optional: defaults applied at setup time when absent
@@ -502,6 +502,12 @@ local config = {
 	-- how wide should the preview be, number between 0.0 and 1.0
 	style_chat_finder_preview_ratio = 0.5,
 
+	-- When drill-in gathers a 🤖 comment into the next turn (#127), enclose the
+	-- referenced span in `[]` in place so you can see what it points at, and
+	-- highlight those spans (ParleyReference). Set to false to strip markers
+	-- without leaving the brackets.
+	mark_reference_span = true,
+
 	-- highlight styling (set to nil to use defaults that match your colorscheme)
 	-- these settings override the default highlight links if provided
 	highlight = {
@@ -512,6 +518,7 @@ local config = {
 		annotation = nil, -- highlight for annotations (default: links to DiffAdd)
 		approximate_match = nil, -- highlight for typo-tolerance edit positions in picker matches (default: links to IncSearch)
 		chat_reference = nil, -- highlight for 🌿: chat branch/parent links (default: links to Special)
+		reference = nil, -- highlight for [referenced span] markers left by drill-in (#127) (default: underline)
 	},
 
 	-- lualine integration options

--- a/lua/parley/drill_in.lua
+++ b/lua/parley/drill_in.lua
@@ -156,6 +156,19 @@ end
 local function is_blank(line) return line:match("^%s*$") ~= nil end
 local function word_count(s) local n = 0; for _ in s:gmatch("%S+") do n = n + 1 end; return n end
 
+-- Topmost line of the contiguous content block ending at line `start` (scan up
+-- while the line above is neither blank nor a turn boundary). Shared by the
+-- inline and previous-block scans.
+local function paragraph_top(idx, start, boundaries)
+    local top = start
+    while top - 1 >= 1
+        and not is_blank(idx[top - 1].line)
+        and not is_boundary_line(idx[top - 1].line, boundaries) do
+        top = top - 1
+    end
+    return top
+end
+
 local function collapse_ws(s)
     return (s:gsub("%s+", " "):gsub("^%s+", ""):gsub("%s+$", ""))
 end
@@ -231,6 +244,12 @@ end
 
 --- Infer a verbatim anchor snippet for an unquoted marker from surrounding
 --- reply prose. Pure.
+---
+--- Tuned for single-line markers (the common `🤖[comment]` case): classification
+--- reasons line-locally off `byte_start`/`byte_end`, so a multi-line marker
+--- (`🤖[a\nb]`) whose `byte_end` lands on a later line may mis-pick inline vs
+--- standalone. It still degrades safely (a reasonable or empty anchor, never a
+--- crash) since both branches fall back to the previous prose block.
 --- @param text string           joined reply text
 --- @param marker table          a parsed marker (M.parse) — uses byte_start/byte_end
 --- @param opts table|nil        { boundaries = string[] } turn-prefix hard stops
@@ -269,12 +288,7 @@ function M.generate_snippet(text, marker, opts)
         local i = L - 1
         while i >= 1 and is_blank(idx[i].line) do i = i - 1 end
         if i < 1 or is_boundary_line(idx[i].line, boundaries) then return "" end
-        local top = i
-        while top - 1 >= 1
-            and not is_blank(idx[top - 1].line)
-            and not is_boundary_line(idx[top - 1].line, boundaries) do
-            top = top - 1
-        end
+        local top = paragraph_top(idx, i, boundaries)
         local parts = {}
         for k = top, i do table.insert(parts, idx[k].line) end
         return first_sentence_snippet(table.concat(parts, " "))
@@ -282,12 +296,7 @@ function M.generate_snippet(text, marker, opts)
 
     -- Prose preceding the marker within its own paragraph (stop at blank/boundary).
     local function inline_before()
-        local top = L
-        while top - 1 >= 1
-            and not is_blank(idx[top - 1].line)
-            and not is_boundary_line(idx[top - 1].line, boundaries) do
-            top = top - 1
-        end
+        local top = paragraph_top(idx, L, boundaries)
         local parts = {}
         for k = top, L - 1 do table.insert(parts, idx[k].line) end
         table.insert(parts, before_on_line)
@@ -312,6 +321,29 @@ function M.generate_snippet(text, marker, opts)
     local snip = tail_snippet(inline_before())
     if snip ~= "" then return snip end
     return prev_block_first_sentence()
+end
+
+--- Assemble the turn-prefix boundary list for snippet inference from a parley
+--- config table (#127). Pure (config in → string[] out) so the chat-structure
+--- knowledge has a single tested home instead of an inline closure in the
+--- chat_respond glue. These prefixes hard-stop the backward anchor scan so it
+--- never crosses out of the marker's own agent turn.
+--- @param cfg table  parley config (reads chat_*_prefix fields)
+--- @return string[]  ordered, de-nil'd prefix list
+function M.chat_boundaries(cfg)
+    cfg = cfg or {}
+    local function first(p) return type(p) == "table" and p[1] or p end
+    local out = {}
+    local function add(p) if p and p ~= "" then table.insert(out, p) end end
+    add(cfg.chat_user_prefix or "💬:")
+    add(first(cfg.chat_assistant_prefix) or "🤖:")
+    add((cfg.chat_memory and cfg.chat_memory.reasoning_prefix) or "🧠:")
+    add((cfg.chat_memory and cfg.chat_memory.summary_prefix) or "📝:")
+    add(cfg.chat_tool_use_prefix or "🔧:")
+    add(cfg.chat_tool_result_prefix or "📎:")
+    add(cfg.chat_branch_prefix or "🌿:")
+    add(cfg.chat_local_prefix)
+    return out
 end
 
 --- Gather ready markers and strip each from the inline text.

--- a/lua/parley/drill_in.lua
+++ b/lua/parley/drill_in.lua
@@ -142,15 +142,19 @@ local function index_lines(text)
     return out
 end
 
--- Does `line` begin a non-prose turn region (a configured prefix)? Such lines
--- are hard stops for the backward scan — never cross into another turn or a
--- 🧠:/📎: block, and never use the prefix line itself as anchor prose.
-local function is_boundary_line(line, boundaries)
-    if not boundaries then return false end
+-- Length of the turn-prefix `line` begins with, else 0. Single source for both
+-- boundary detection and prefix stripping (a configured prefix marks a non-prose
+-- turn region — a hard stop for the backward scan, never used as anchor prose).
+local function boundary_prefix_len(line, boundaries)
+    if not boundaries then return 0 end
     for _, p in ipairs(boundaries) do
-        if p ~= "" and line:sub(1, #p) == p then return true end
+        if p ~= "" and line:sub(1, #p) == p then return #p end
     end
-    return false
+    return 0
+end
+
+local function is_boundary_line(line, boundaries)
+    return boundary_prefix_len(line, boundaries) > 0
 end
 
 local function is_blank(line) return line:match("^%s*$") ~= nil end
@@ -277,24 +281,14 @@ function M.generate_snippet(text, marker, opts)
 
     -- If the marker sits on a boundary (prefix) line, drop the prefix from the
     -- before-text so the prefix never leaks into classification.
-    if boundaries then
-        for _, p in ipairs(boundaries) do
-            if p ~= "" and before_on_line:sub(1, #p) == p then
-                before_on_line = before_on_line:sub(#p + 1)
-                break
-            end
-        end
-    end
+    before_on_line = before_on_line:sub(boundary_prefix_len(before_on_line, boundaries) + 1)
 
     -- Inline source region [lo, hi]: the paragraph prose before the marker.
     local function inline_region()
         local top = paragraph_top(idx, L, boundaries)
-        local lo = idx[top].off
-        if boundaries and is_boundary_line(idx[top].line, boundaries) then
-            for _, p in ipairs(boundaries) do
-                if p ~= "" and idx[top].line:sub(1, #p) == p then lo = lo + #p; break end
-            end
-        end
+        -- Skip a leading turn-prefix on the region's first line (rare: marker on
+        -- a boundary line) so the prefix never leaks into the anchor.
+        local lo = idx[top].off + boundary_prefix_len(idx[top].line, boundaries)
         return lo, marker.byte_start - 1
     end
 

--- a/lua/parley/drill_in.lua
+++ b/lua/parley/drill_in.lua
@@ -13,11 +13,16 @@
 --      next user turn. See `M.gather_and_strip` and `M.format_block`. Marker
 --      shapes:
 --        * `🤖<Q>[U]`          → block `> Q` / `U`            ; inline → `Q`
---        * `🤖[U]`             → block `U`                   ; inline removed
+--        * `🤖[U]`             → block `> Q̂` / `U`            ; inline removed
 --        * `🤖<Q>[U1]{A1}[U2]` → block `> Q` / `> User: U1` /
 --                                `> Agent: A1` / `U2`        ; inline → `Q`
---        * `🤖[U1]{A1}[U2]`    → block `> User: U1` / `> Agent: A1` / `U2`;
---                                inline removed
+--        * `🤖[U1]{A1}[U2]`    → block `> Q̂` / `> User: U1` /
+--                                `> Agent: A1` / `U2`         ; inline removed
+--      For the unquoted forms, the block quote `Q̂` is *inferred* from the reply
+--      prose around the marker (#127) — an unquoted comment is a quoted comment
+--      whose anchor we recover, so it routes through the same block pipeline.
+--      See `M.generate_snippet`. When no anchor can be recovered the block has
+--      no `>` line (degrades to the pre-#127 behavior).
 --      Markers ending in `{}` (pending agent turns) and `~D~` markers
 --      (proposals, not questions) stay inline.
 --
@@ -114,26 +119,231 @@ local function splice(text, replacements)
     return result
 end
 
+-- ─── Snippet inference (#127) ───────────────────────────────────────────
+-- An unquoted ready marker `🤖[U]` carries no anchor: stripping it would drop
+-- the comment into the next turn with no pointer back. `generate_snippet`
+-- recovers a verbatim anchor from the reply prose *around* the marker, so the
+-- unquoted form routes through the same quoted pipeline as `🤖<Q>[U]` — we just
+-- infer the Q the operator didn't type. Pure: a function of text + the marker's
+-- byte range (+ optional turn boundaries). The anchor is a meaning-anchor, not
+-- a position token; precision is intentionally forgiving (see #127 Spec).
+
+local SNIPPET_MIN_WORDS = 10
+local SNIPPET_MAX_WORDS = 20
+
+-- Index `text` into lines, each tagged with its 1-based byte offset (`off`).
+local function index_lines(text)
+    local out = {}
+    local off = 1
+    for _, line in ipairs(split_lines(text)) do
+        table.insert(out, { line = line, off = off })
+        off = off + #line + 1 -- +1 for the stripped "\n"
+    end
+    return out
+end
+
+-- Does `line` begin a non-prose turn region (a configured prefix)? Such lines
+-- are hard stops for the backward scan — never cross into another turn or a
+-- 🧠:/📎: block, and never use the prefix line itself as anchor prose.
+local function is_boundary_line(line, boundaries)
+    if not boundaries then return false end
+    for _, p in ipairs(boundaries) do
+        if p ~= "" and line:sub(1, #p) == p then return true end
+    end
+    return false
+end
+
+local function is_blank(line) return line:match("^%s*$") ~= nil end
+local function word_count(s) local n = 0; for _ in s:gmatch("%S+") do n = n + 1 end; return n end
+
+local function collapse_ws(s)
+    return (s:gsub("%s+", " "):gsub("^%s+", ""):gsub("%s+$", ""))
+end
+
+-- Strip any 🤖-markers embedded in candidate prose — a neighboring marker's raw
+-- bytes can fall inside a snippet window; they are not prose. Reuses M.parse.
+local function strip_markers(s)
+    local markers = M.parse(s)
+    local repls = {}
+    for _, m in ipairs(markers) do
+        table.insert(repls, { byte_start = m.byte_start, byte_end = m.byte_end, replacement = "" })
+    end
+    return splice(s, repls)
+end
+
+-- Split prose into sentences at `.!?` followed by whitespace/end (punctuation
+-- kept with its sentence). Forgiving: mis-snaps on abbreviations/decimals are
+-- accepted per the meaning-anchor philosophy.
+local function split_sentences(s)
+    local sents, cur = {}, ""
+    for i = 1, #s do
+        local c = s:sub(i, i)
+        cur = cur .. c
+        if c:match("[%.%!%?]") then
+            local nxt = s:sub(i + 1, i + 1)
+            if nxt == "" or nxt:match("%s") then
+                table.insert(sents, cur)
+                cur = ""
+            end
+        end
+    end
+    if cur:match("%S") then table.insert(sents, cur) end
+    return sents
+end
+
+-- Keep only the last MAX words; prefix "… " when truncated.
+local function cap_tail(words)
+    if #words <= SNIPPET_MAX_WORDS then return table.concat(words, " ") end
+    local kept = {}
+    for i = #words - SNIPPET_MAX_WORDS + 1, #words do table.insert(kept, words[i]) end
+    return "… " .. table.concat(kept, " ")
+end
+
+-- Inline anchor: the prose immediately before the marker, snapped back to a
+-- sentence boundary, ≥MIN words (extending across boundaries) and ≤MAX words.
+local function tail_snippet(before)
+    before = collapse_ws(strip_markers(before))
+    if before == "" then return "" end
+    local sents = split_sentences(before)
+    local acc, count = {}, 0
+    for i = #sents, 1, -1 do
+        table.insert(acc, 1, sents[i])
+        count = count + word_count(sents[i])
+        if count >= SNIPPET_MIN_WORDS then break end
+    end
+    local words = {}
+    for w in collapse_ws(table.concat(acc, " ")):gmatch("%S+") do table.insert(words, w) end
+    return cap_tail(words)
+end
+
+-- Standalone anchor: the first sentence of a previous prose block, ≤MAX words.
+local function first_sentence_snippet(block)
+    block = collapse_ws(strip_markers(block))
+    if block == "" then return "" end
+    local first = split_sentences(block)[1] or block
+    local words = {}
+    for w in first:gmatch("%S+") do table.insert(words, w) end
+    if #words <= SNIPPET_MAX_WORDS then return first end
+    local kept = {}
+    for i = 1, SNIPPET_MAX_WORDS do table.insert(kept, words[i]) end
+    return table.concat(kept, " ") .. " …"
+end
+
+--- Infer a verbatim anchor snippet for an unquoted marker from surrounding
+--- reply prose. Pure.
+--- @param text string           joined reply text
+--- @param marker table          a parsed marker (M.parse) — uses byte_start/byte_end
+--- @param opts table|nil        { boundaries = string[] } turn-prefix hard stops
+--- @return string               anchor snippet, or "" when none can be recovered
+function M.generate_snippet(text, marker, opts)
+    opts = opts or {}
+    local boundaries = opts.boundaries
+    local idx = index_lines(text)
+
+    -- Locate the marker's line + its column span within that line.
+    local L, before_on_line, after_on_line
+    for i, e in ipairs(idx) do
+        local line_end = e.off + #e.line -- byte just past the line's content
+        if marker.byte_start >= e.off and marker.byte_start <= line_end then
+            L = i
+            before_on_line = e.line:sub(1, marker.byte_start - e.off)
+            after_on_line = e.line:sub(marker.byte_end - e.off + 2)
+            break
+        end
+    end
+    if not L then return "" end
+
+    -- If the marker sits on a boundary (prefix) line, drop the prefix from the
+    -- before-text so the prefix never leaks into the anchor.
+    if boundaries then
+        for _, p in ipairs(boundaries) do
+            if p ~= "" and before_on_line:sub(1, #p) == p then
+                before_on_line = before_on_line:sub(#p + 1)
+                break
+            end
+        end
+    end
+
+    -- Previous prose block (scan up past blanks; stop at a boundary/top).
+    local function prev_block_first_sentence()
+        local i = L - 1
+        while i >= 1 and is_blank(idx[i].line) do i = i - 1 end
+        if i < 1 or is_boundary_line(idx[i].line, boundaries) then return "" end
+        local top = i
+        while top - 1 >= 1
+            and not is_blank(idx[top - 1].line)
+            and not is_boundary_line(idx[top - 1].line, boundaries) do
+            top = top - 1
+        end
+        local parts = {}
+        for k = top, i do table.insert(parts, idx[k].line) end
+        return first_sentence_snippet(table.concat(parts, " "))
+    end
+
+    -- Prose preceding the marker within its own paragraph (stop at blank/boundary).
+    local function inline_before()
+        local top = L
+        while top - 1 >= 1
+            and not is_blank(idx[top - 1].line)
+            and not is_boundary_line(idx[top - 1].line, boundaries) do
+            top = top - 1
+        end
+        local parts = {}
+        for k = top, L - 1 do table.insert(parts, idx[k].line) end
+        table.insert(parts, before_on_line)
+        return table.concat(parts, " ")
+    end
+
+    local has_before = before_on_line:match("%S") ~= nil
+    local marker_only = (not has_before) and (after_on_line:match("%S") == nil)
+
+    if marker_only then
+        -- Standalone iff blank/boundary-separated above AND below.
+        local above_sep = (L == 1) or is_blank(idx[L - 1].line) or is_boundary_line(idx[L - 1].line, boundaries)
+        local below_sep = (L == #idx) or is_blank(idx[L + 1].line) or is_boundary_line(idx[L + 1].line, boundaries)
+        if above_sep and below_sep then
+            return prev_block_first_sentence()
+        end
+        -- Bare marker mid-paragraph → inline from preceding lines.
+    end
+
+    -- Inline (or bare-mid-paragraph): preceding words; fall back to the
+    -- previous block when there is nothing before the marker.
+    local snip = tail_snippet(inline_before())
+    if snip ~= "" then return snip end
+    return prev_block_first_sentence()
+end
+
 --- Gather ready markers and strip each from the inline text.
 --- - Marker with `<Q>` body → inline replaced by Q.
---- - Marker without `<Q>` body → inline removed entirely.
+--- - Marker without `<Q>` body → inline removed entirely; its block quote is
+---   inferred from surrounding prose (#127) when one can be recovered.
 --- Pending markers (last section non-empty `{}`) and annotation-only markers
 --- (no ready `[]` last section) are left untouched.
 --- @param text string
+--- @param opts table|nil  { boundaries = string[] } passed to generate_snippet
 --- @return table[] blocks  list of { quoted = string|nil, sections = list } in document order
 --- @return string new_text
-function M.gather_and_strip(text)
+function M.gather_and_strip(text, opts)
     local markers = M.parse(text)
     local blocks = {}
     local replacements = {}
     for _, m in ipairs(markers) do
         if m.ready then
-            local quoted_text = m.quoted and m.quoted.text or nil
-            table.insert(blocks, { quoted = quoted_text, sections = m.sections })
+            -- An explicit <Q> body restores inline to Q and anchors the block.
+            -- An unquoted marker is removed inline (the snippet is *already* in
+            -- the reply — do not re-insert it) and its block quote is inferred.
+            local explicit = m.quoted and m.quoted.text or nil
+            local block_quote = explicit
+            if not block_quote then
+                local snip = M.generate_snippet(text, m, opts)
+                if snip ~= "" then block_quote = snip end
+            end
+            table.insert(blocks, { quoted = block_quote, sections = m.sections })
             table.insert(replacements, {
                 byte_start = m.byte_start,
                 byte_end = m.byte_end,
-                replacement = quoted_text or "",
+                replacement = explicit or "",
             })
         end
     end

--- a/lua/parley/drill_in.lua
+++ b/lua/parley/drill_in.lua
@@ -154,7 +154,6 @@ local function is_boundary_line(line, boundaries)
 end
 
 local function is_blank(line) return line:match("^%s*$") ~= nil end
-local function word_count(s) local n = 0; for _ in s:gmatch("%S+") do n = n + 1 end; return n end
 
 -- Topmost line of the contiguous content block ending at line `start` (scan up
 -- while the line above is neither blank nor a turn boundary). Shared by the
@@ -184,66 +183,68 @@ local function strip_markers(s)
     return splice(s, repls)
 end
 
--- Split prose into sentences at `.!?` followed by whitespace/end (punctuation
--- kept with its sentence). Forgiving: mis-snaps on abbreviations/decimals are
--- accepted per the meaning-anchor philosophy.
-local function split_sentences(s)
-    local sents, cur = {}, ""
-    for i = 1, #s do
-        local c = s:sub(i, i)
-        cur = cur .. c
-        if c:match("[%.%!%?]") then
-            local nxt = s:sub(i + 1, i + 1)
-            if nxt == "" or nxt:match("%s") then
-                table.insert(sents, cur)
-                cur = ""
-            end
+-- Tokenize byte range [lo, hi] of `text` into words tagged with absolute byte
+-- offsets {s, e}. Works directly on the original text so the selected span maps
+-- straight back to byte positions (needed to enclose the span — #127 brackets).
+local function tokenize(text, lo, hi)
+    local toks = {}
+    local i = lo
+    while i <= hi do
+        while i <= hi and text:sub(i, i):match("%s") do i = i + 1 end
+        if i > hi then break end
+        local s = i
+        while i <= hi and not text:sub(i, i):match("%s") do i = i + 1 end
+        toks[#toks + 1] = { s = s, e = i - 1 }
+    end
+    return toks
+end
+
+-- `.!?` are ASCII (single byte), so the last byte of a token suffices.
+local function ends_sentence(text, tok) return text:sub(tok.e, tok.e):match("[%.%!%?]") ~= nil end
+
+-- Inline span: the smallest sentence-aligned suffix of [lo,hi] with ≥MIN words,
+-- capped to the last MAX. Returns span_start, span_end (absolute), truncated.
+local function select_tail(text, lo, hi)
+    local toks = tokenize(text, lo, hi)
+    local n = #toks
+    if n == 0 then return nil end
+    local chosen = 1 -- token 1 always begins a sentence; whole region is the floor
+    for k = 1, n do
+        if (k == 1 or ends_sentence(text, toks[k - 1])) and (n - k + 1) >= SNIPPET_MIN_WORDS then
+            chosen = k -- latest sentence start still ≥MIN words = smallest qualifying span
         end
     end
-    if cur:match("%S") then table.insert(sents, cur) end
-    return sents
-end
-
--- Keep only the last MAX words; prefix "… " when truncated.
-local function cap_tail(words)
-    if #words <= SNIPPET_MAX_WORDS then return table.concat(words, " ") end
-    local kept = {}
-    for i = #words - SNIPPET_MAX_WORDS + 1, #words do table.insert(kept, words[i]) end
-    return "… " .. table.concat(kept, " ")
-end
-
--- Inline anchor: the prose immediately before the marker, snapped back to a
--- sentence boundary, ≥MIN words (extending across boundaries) and ≤MAX words.
-local function tail_snippet(before)
-    before = collapse_ws(strip_markers(before))
-    if before == "" then return "" end
-    local sents = split_sentences(before)
-    local acc, count = {}, 0
-    for i = #sents, 1, -1 do
-        table.insert(acc, 1, sents[i])
-        count = count + word_count(sents[i])
-        if count >= SNIPPET_MIN_WORDS then break end
+    local truncated = false
+    if (n - chosen + 1) > SNIPPET_MAX_WORDS then
+        chosen = n - SNIPPET_MAX_WORDS + 1
+        truncated = true
     end
-    local words = {}
-    for w in collapse_ws(table.concat(acc, " ")):gmatch("%S+") do table.insert(words, w) end
-    return cap_tail(words)
+    return toks[chosen].s, toks[n].e, truncated
 end
 
--- Standalone anchor: the first sentence of a previous prose block, ≤MAX words.
-local function first_sentence_snippet(block)
-    block = collapse_ws(strip_markers(block))
-    if block == "" then return "" end
-    local first = split_sentences(block)[1] or block
-    local words = {}
-    for w in first:gmatch("%S+") do table.insert(words, w) end
-    if #words <= SNIPPET_MAX_WORDS then return first end
-    local kept = {}
-    for i = 1, SNIPPET_MAX_WORDS do table.insert(kept, words[i]) end
-    return table.concat(kept, " ") .. " …"
+-- Standalone span: the first sentence of [lo,hi], capped at MAX words.
+local function select_head(text, lo, hi)
+    local toks = tokenize(text, lo, hi)
+    local n = #toks
+    if n == 0 then return nil end
+    local f = n
+    for k = 1, n do if ends_sentence(text, toks[k]) then f = k; break end end
+    local truncated = false
+    if f > SNIPPET_MAX_WORDS then f = SNIPPET_MAX_WORDS; truncated = true end
+    return toks[1].s, toks[f].e, truncated
+end
+
+-- Display text for a span: verbatim slice, markers stripped + whitespace
+-- collapsed, with a leading "… " (tail) or trailing " …" (head) when capped.
+local function span_text(text, lo, hi, truncated, head)
+    local s = collapse_ws(strip_markers(text:sub(lo, hi)))
+    if not truncated then return s end
+    return head and (s .. " …") or ("… " .. s)
 end
 
 --- Infer a verbatim anchor snippet for an unquoted marker from surrounding
---- reply prose. Pure.
+--- reply prose. Pure. Also returns the byte range of the prose it drew from so
+--- a caller can enclose the referenced span in place (#127 brackets).
 ---
 --- Tuned for single-line markers (the common `🤖[comment]` case): classification
 --- reasons line-locally off `byte_start`/`byte_end`, so a multi-line marker
@@ -254,6 +255,8 @@ end
 --- @param marker table          a parsed marker (M.parse) — uses byte_start/byte_end
 --- @param opts table|nil        { boundaries = string[] } turn-prefix hard stops
 --- @return string               anchor snippet, or "" when none can be recovered
+--- @return integer|nil          span_start (absolute byte, inclusive) or nil
+--- @return integer|nil          span_end   (absolute byte, inclusive) or nil
 function M.generate_snippet(text, marker, opts)
     opts = opts or {}
     local boundaries = opts.boundaries
@@ -273,7 +276,7 @@ function M.generate_snippet(text, marker, opts)
     if not L then return "" end
 
     -- If the marker sits on a boundary (prefix) line, drop the prefix from the
-    -- before-text so the prefix never leaks into the anchor.
+    -- before-text so the prefix never leaks into classification.
     if boundaries then
         for _, p in ipairs(boundaries) do
             if p ~= "" and before_on_line:sub(1, #p) == p then
@@ -283,24 +286,41 @@ function M.generate_snippet(text, marker, opts)
         end
     end
 
-    -- Previous prose block (scan up past blanks; stop at a boundary/top).
-    local function prev_block_first_sentence()
-        local i = L - 1
-        while i >= 1 and is_blank(idx[i].line) do i = i - 1 end
-        if i < 1 or is_boundary_line(idx[i].line, boundaries) then return "" end
-        local top = paragraph_top(idx, i, boundaries)
-        local parts = {}
-        for k = top, i do table.insert(parts, idx[k].line) end
-        return first_sentence_snippet(table.concat(parts, " "))
+    -- Inline source region [lo, hi]: the paragraph prose before the marker.
+    local function inline_region()
+        local top = paragraph_top(idx, L, boundaries)
+        local lo = idx[top].off
+        if boundaries and is_boundary_line(idx[top].line, boundaries) then
+            for _, p in ipairs(boundaries) do
+                if p ~= "" and idx[top].line:sub(1, #p) == p then lo = lo + #p; break end
+            end
+        end
+        return lo, marker.byte_start - 1
     end
 
-    -- Prose preceding the marker within its own paragraph (stop at blank/boundary).
-    local function inline_before()
-        local top = paragraph_top(idx, L, boundaries)
-        local parts = {}
-        for k = top, L - 1 do table.insert(parts, idx[k].line) end
-        table.insert(parts, before_on_line)
-        return table.concat(parts, " ")
+    -- Standalone source region [lo, hi]: the previous prose block (nil if none).
+    local function prev_block_region()
+        local i = L - 1
+        while i >= 1 and is_blank(idx[i].line) do i = i - 1 end
+        if i < 1 or is_boundary_line(idx[i].line, boundaries) then return nil end
+        local top = paragraph_top(idx, i, boundaries)
+        return idx[top].off, idx[i].off + #idx[i].line - 1
+    end
+
+    local function from_inline()
+        local lo, hi = inline_region()
+        if hi < lo then return "" end
+        local s, e, trunc = select_tail(text, lo, hi)
+        if not s then return "" end
+        return span_text(text, s, e, trunc, false), s, e
+    end
+
+    local function from_prev_block()
+        local lo, hi = prev_block_region()
+        if not lo then return "" end
+        local s, e, trunc = select_head(text, lo, hi)
+        if not s then return "" end
+        return span_text(text, s, e, trunc, true), s, e
     end
 
     local has_before = before_on_line:match("%S") ~= nil
@@ -311,16 +331,16 @@ function M.generate_snippet(text, marker, opts)
         local above_sep = (L == 1) or is_blank(idx[L - 1].line) or is_boundary_line(idx[L - 1].line, boundaries)
         local below_sep = (L == #idx) or is_blank(idx[L + 1].line) or is_boundary_line(idx[L + 1].line, boundaries)
         if above_sep and below_sep then
-            return prev_block_first_sentence()
+            return from_prev_block()
         end
         -- Bare marker mid-paragraph → inline from preceding lines.
     end
 
     -- Inline (or bare-mid-paragraph): preceding words; fall back to the
     -- previous block when there is nothing before the marker.
-    local snip = tail_snippet(inline_before())
-    if snip ~= "" then return snip end
-    return prev_block_first_sentence()
+    local t, s, e = from_inline()
+    if t ~= "" then return t, s, e end
+    return from_prev_block()
 end
 
 --- Assemble the turn-prefix boundary list for snippet inference from a parley
@@ -352,34 +372,58 @@ end
 ---   inferred from surrounding prose (#127) when one can be recovered.
 --- Pending markers (last section non-empty `{}`) and annotation-only markers
 --- (no ready `[]` last section) are left untouched.
+---
+--- With `opts.bracket`, the referenced span is enclosed in `[]` in place so a
+--- human can see what each gathered comment points at (#127): an explicit `Q`
+--- becomes `[Q]`; an inferred span is bracketed where it sits in the reply (the
+--- snippet is *not* re-inserted — it's already there, we only delimit it).
 --- @param text string
---- @param opts table|nil  { boundaries = string[] } passed to generate_snippet
+--- @param opts table|nil  { boundaries = string[], bracket = boolean }
 --- @return table[] blocks  list of { quoted = string|nil, sections = list } in document order
 --- @return string new_text
 function M.gather_and_strip(text, opts)
+    opts = opts or {}
+    local bracket = opts.bracket
     local markers = M.parse(text)
     local blocks = {}
-    local replacements = {}
+    local edits = {}
+    local function edit(bs, be, repl) table.insert(edits, { byte_start = bs, byte_end = be, replacement = repl }) end
     for _, m in ipairs(markers) do
         if m.ready then
-            -- An explicit <Q> body restores inline to Q and anchors the block.
-            -- An unquoted marker is removed inline (the snippet is *already* in
-            -- the reply — do not re-insert it) and its block quote is inferred.
             local explicit = m.quoted and m.quoted.text or nil
-            local block_quote = explicit
-            if not block_quote then
-                local snip = M.generate_snippet(text, m, opts)
-                if snip ~= "" then block_quote = snip end
+            if explicit then
+                -- Explicit <Q>: restore Q inline (optionally bracketed) — the
+                -- whole marker collapses to the anchor text.
+                edit(m.byte_start, m.byte_end, bracket and ("[" .. explicit .. "]") or explicit)
+                table.insert(blocks, { quoted = explicit, sections = m.sections })
+            else
+                -- Unquoted: infer the anchor + its span, remove the marker, and
+                -- (optionally) bracket the span where it already sits.
+                local snip, ss, se = M.generate_snippet(text, m, opts)
+                if bracket and ss then
+                    edit(ss, ss - 1, "[") -- zero-width insert before the span
+                    local gap = (se < m.byte_start) and text:sub(se + 1, m.byte_start - 1) or "x"
+                    if se < m.byte_start and gap:match("^%s*$") then
+                        -- Inline: span abuts the marker — absorb the gap + marker into "]".
+                        edit(se + 1, m.byte_end, "]")
+                    else
+                        -- Standalone: span sits elsewhere — close it, remove the marker.
+                        edit(se + 1, se, "]") -- zero-width insert after the span
+                        edit(m.byte_start, m.byte_end, "")
+                    end
+                else
+                    edit(m.byte_start, m.byte_end, "") -- no span / no bracketing: just remove
+                end
+                table.insert(blocks, { quoted = (snip ~= "" and snip or nil), sections = m.sections })
             end
-            table.insert(blocks, { quoted = block_quote, sections = m.sections })
-            table.insert(replacements, {
-                byte_start = m.byte_start,
-                byte_end = m.byte_end,
-                replacement = explicit or "",
-            })
         end
     end
-    return blocks, splice(text, replacements)
+    -- splice() applies right-to-left on original offsets, so order ascending.
+    table.sort(edits, function(a, b)
+        if a.byte_start ~= b.byte_start then return a.byte_start < b.byte_start end
+        return a.byte_end < b.byte_end
+    end)
+    return blocks, splice(text, edits)
 end
 
 --- Resolve a marker to its final inline text per the review-convention §5

--- a/lua/parley/highlighter.lua
+++ b/lua/parley/highlighter.lua
@@ -461,6 +461,28 @@ local function compute_markdown_highlights(buf, start_line, end_line)
             end
             search_start = end_pos
         end
+
+        -- #127: enclose-reference spans `[…]` left in the reply by drill-in
+        -- (what each gathered comment points at). Heuristic — plain `[]` can't
+        -- be told apart from incidental brackets with certainty, so we skip
+        -- markdown links `](`, checkboxes, footnote refs, and 1-char content.
+        -- Disable wholesale via config.mark_reference_span = false.
+        if _parley.config.mark_reference_span ~= false then
+            for s, content, e in line:gmatch("()%[([^%[%]]+)%]()") do
+                local skip = line:sub(e, e) == "("                 -- markdown link
+                    or content == " " or content == "x" or content == "X" -- checkbox
+                    or content:sub(1, 1) == "^"                    -- footnote ref
+                    or #content < 2
+                if not skip then
+                    result[row] = result[row] or {}
+                    table.insert(result[row], {
+                        hl_group = "ParleyReference",
+                        col_start = s - 1, -- 0-indexed `[`
+                        col_end = e - 1,   -- exclusive end (through `]`)
+                    })
+                end
+            end
+        end
     end
 
     -- Draft-block backgrounds (=== label === / === end ===). Full-buffer
@@ -659,6 +681,16 @@ M.setup_highlights = function()
             underline = true,
             link = "Special",
         })
+    end
+
+    -- Referenced-span markers `[…]` left in a reply by drill-in (#127): the
+    -- text a gathered comment points at. Underline reads as "this span is
+    -- marked" without the weight of a full background. Override via
+    -- config.highlight.reference.
+    if user_highlights.reference then
+        vim.api.nvim_set_hl(0, "ParleyReference", user_highlights.reference)
+    else
+        vim.api.nvim_set_hl(0, "ParleyReference", { underline = true })
     end
 
     -- Tags - Highlighted tags in @@tag@@ format

--- a/lua/parley/highlighter.lua
+++ b/lua/parley/highlighter.lua
@@ -411,6 +411,27 @@ end
 
 M._scan_draft_blocks = scan_draft_blocks
 
+-- Is the bracketed run `[content]` at byte range [s, e) a drill-in
+-- referenced-span marker (#127), versus an incidental bracket? Pure predicate
+-- — plain `[]` is ambiguous, so this is a heuristic. `line` is the whole line,
+-- `s` = byte of `[`, `e` = byte just past `]`. Rejects:
+--   * markdown links `](`           — `[text](url)`
+--   * footnote refs                 — `[^1]`
+--   * 1-char content                — `[ ]`, `[x]`, `[1]`
+--   * a *live* 🤖 marker's section   — `[U]` chained after 🤖 / `>` / `~` / a
+--                                     prior `]`/`}` close (already highlighted
+--                                     ParleyReviewUser; don't double-mark it).
+-- A flattened reference span's `[` follows ordinary prose, so it passes.
+function M.is_reference_span(line, s, content, e)
+    if line:sub(e, e) == "(" then return false end
+    if content:sub(1, 1) == "^" then return false end
+    if #content < 2 then return false end
+    local prev = line:sub(s - 1, s - 1)
+    if prev == "]" or prev == "}" or prev == ">" or prev == "~" then return false end
+    if s > 4 and line:sub(s - 4, s - 1) == "🤖" then return false end
+    return true
+end
+
 -- Compute desired markdown highlights for a 1-indexed line range.
 -- Returns a table keyed by 0-indexed row: { [row] = { {hl_group, col_start, col_end}, ... } }
 local function compute_markdown_highlights(buf, start_line, end_line)
@@ -462,18 +483,12 @@ local function compute_markdown_highlights(buf, start_line, end_line)
             search_start = end_pos
         end
 
-        -- #127: enclose-reference spans `[…]` left in the reply by drill-in
-        -- (what each gathered comment points at). Heuristic — plain `[]` can't
-        -- be told apart from incidental brackets with certainty, so we skip
-        -- markdown links `](`, checkboxes, footnote refs, and 1-char content.
-        -- Disable wholesale via config.mark_reference_span = false.
+        -- #127: highlight drill-in referenced-span markers `[…]` left in the
+        -- reply (what each gathered comment points at) via the pure
+        -- M.is_reference_span heuristic. Disable via mark_reference_span = false.
         if _parley.config.mark_reference_span ~= false then
             for s, content, e in line:gmatch("()%[([^%[%]]+)%]()") do
-                local skip = line:sub(e, e) == "("                 -- markdown link
-                    or content == " " or content == "x" or content == "X" -- checkbox
-                    or content:sub(1, 1) == "^"                    -- footnote ref
-                    or #content < 2
-                if not skip then
+                if M.is_reference_span(line, s, content, e) then
                     result[row] = result[row] or {}
                     table.insert(result[row], {
                         hl_group = "ParleyReference",

--- a/tests/integration/chat_respond_spec.lua
+++ b/tests/integration/chat_respond_spec.lua
@@ -1062,10 +1062,11 @@ describe("chat_respond: drill-in pre-processing", function()
         local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
         local joined = table.concat(lines, "\n")
 
-        -- Marker stripped to plain term
+        -- Marker stripped; quoted term remains inline, enclosed in [] so the
+        -- reader can see the referenced span (#127 mark_reference_span).
         assert.is_nil(joined:find("🤖<", 1, true), "drill-in marker should be stripped from buffer")
-        assert.truthy(joined:find("tell me about RedShift", 1, true),
-            "stripped term should remain inline; got:\n" .. joined)
+        assert.truthy(joined:find("tell me about [RedShift]", 1, true),
+            "stripped term should remain inline, bracketed; got:\n" .. joined)
         -- Quote block appended at the end
         assert.truthy(joined:find("> RedShift\nwhat is this?", 1, true),
             "quote block should be appended; got:\n" .. joined)
@@ -1134,11 +1135,11 @@ describe("chat_respond: drill-in pre-processing", function()
         pcall(function() parley.chat_respond({ range = 0 }) end)
         local after = table.concat(vim.api.nvim_buf_get_lines(buf, 0, -1, false), "\n")
 
-        -- Marker stripped to plain T in the original question
+        -- Marker stripped; quoted term remains inline, enclosed in [] (#127)
         assert.is_nil(after:find("🤖<Term>", 1, true),
             "drill-in marker should be stripped after branch; got:\n" .. after)
-        assert.truthy(after:find("explain Term", 1, true),
-            "stripped term should remain inline; got:\n" .. after)
+        assert.truthy(after:find("explain [Term]", 1, true),
+            "stripped term should remain inline, bracketed; got:\n" .. after)
         -- Original answer preserved (we did NOT resubmit / overwrite it)
         assert.truthy(after:find("prior answer about Term.", 1, true),
             "original answer should be preserved; got:\n" .. after)

--- a/tests/unit/drill_in_spec.lua
+++ b/tests/unit/drill_in_spec.lua
@@ -457,6 +457,75 @@ describe("drill_in.chat_boundaries (#127)", function()
     end)
 end)
 
+-- #127: generate_snippet reports the byte range of the prose it drew from, so a
+-- caller can enclose the span in place.
+describe("drill_in.generate_snippet span range (#127)", function()
+    it("returns the inline span's absolute byte range", function()
+        local text = "preamble words here 🤖[just ask] tail"
+        local m = drill_in.parse(text)[1]
+        local snip, s, e = drill_in.generate_snippet(text, m)
+        assert.equals("preamble words here", snip)
+        assert.equals(1, s)                       -- "preamble" starts at byte 1
+        assert.equals(19, e)                      -- "here" ends at byte 19
+        assert.equals("preamble words here", text:sub(s, e))
+    end)
+
+    it("returns the standalone span's byte range (prev paragraph first sentence)", function()
+        local text = "Para one here. More of it.\n\n🤖[c]\n\nx"
+        local m = drill_in.parse(text)[1]
+        local snip, s, e = drill_in.generate_snippet(text, m)
+        assert.equals("Para one here.", snip)
+        assert.equals("Para one here.", text:sub(s, e)) -- range maps to the verbatim sentence
+    end)
+
+    it("returns nil range when no anchor is recoverable", function()
+        local text = "🤖[c]\n\nbody"
+        local m = drill_in.parse(text)[1]
+        local snip, s, e = drill_in.generate_snippet(text, m)
+        assert.equals("", snip)
+        assert.is_nil(s)
+        assert.is_nil(e)
+    end)
+end)
+
+-- #127: opts.bracket encloses the referenced span in [] in place.
+describe("drill_in.gather_and_strip bracket=true (#127)", function()
+    it("brackets an explicit <Q> inline as [Q]", function()
+        local _, new_text = drill_in.gather_and_strip(
+            "this is 🤖<RedShift>[what?] cool", { bracket = true }
+        )
+        assert.equals("this is [RedShift] cool", new_text)
+    end)
+
+    it("brackets an inferred inline span, absorbing the marker into the close", function()
+        local blocks, new_text = drill_in.gather_and_strip(
+            "preamble words here 🤖[just ask] tail", { bracket = true }
+        )
+        assert.equals("[preamble words here] tail", new_text)
+        assert.equals("preamble words here", blocks[1].quoted) -- next-turn quote stays unbracketed
+    end)
+
+    it("brackets a standalone inferred span and removes the marker", function()
+        local _, new_text = drill_in.gather_and_strip(
+            "Para one here. More of it.\n\n🤖[expand]\n\nnext", { bracket = true }
+        )
+        -- The prev-paragraph first sentence is enclosed; the marker line empties.
+        assert.equals("[Para one here.] More of it.\n\n\n\nnext", new_text)
+    end)
+
+    it("default (no bracket) leaves the inline replacement bare", function()
+        local _, new_text = drill_in.gather_and_strip("this is 🤖<RedShift>[what?] cool")
+        assert.equals("this is RedShift cool", new_text) -- regression: unchanged
+    end)
+
+    it("brackets multiple markers (explicit + inferred) in one pass", function()
+        local _, new_text = drill_in.gather_and_strip(
+            "alpha beta 🤖[c1] gamma delta 🤖<Term>[c2] epsilon", { bracket = true }
+        )
+        assert.equals("[alpha beta] gamma delta [Term] epsilon", new_text)
+    end)
+end)
+
 -- ─── §5 resolution table (#124 M2) ─────────────────────────────────────
 -- Pure resolve(marker, mode) implementing the spec §5 table:
 --   ref=nil, chain=[H]                → "" (both)

--- a/tests/unit/drill_in_spec.lua
+++ b/tests/unit/drill_in_spec.lua
@@ -437,6 +437,26 @@ describe("drill_in.gather_and_strip + inferred anchors (#127)", function()
     end)
 end)
 
+describe("drill_in.chat_boundaries (#127)", function()
+    it("maps the default config prefixes, de-nil'd and ordered", function()
+        assert.same(
+            { "💬:", "🤖:", "🧠:", "📝:", "🔧:", "📎:", "🌿:" },
+            drill_in.chat_boundaries({})
+        )
+    end)
+
+    it("uses the first element when chat_assistant_prefix is a table", function()
+        local b = drill_in.chat_boundaries({ chat_assistant_prefix = { "🤖:", "[{{agent}}]" } })
+        assert.equals("🤖:", b[2])
+    end)
+
+    it("honors overrides and appends chat_local_prefix when set", function()
+        local b = drill_in.chat_boundaries({ chat_user_prefix = "U>", chat_local_prefix = "L>" })
+        assert.equals("U>", b[1])
+        assert.equals("L>", b[#b]) -- local prefix appended last
+    end)
+end)
+
 -- ─── §5 resolution table (#124 M2) ─────────────────────────────────────
 -- Pure resolve(marker, mode) implementing the spec §5 table:
 --   ref=nil, chain=[H]                → "" (both)

--- a/tests/unit/drill_in_spec.lua
+++ b/tests/unit/drill_in_spec.lua
@@ -221,14 +221,17 @@ describe("drill_in.gather_and_strip", function()
         assert.equals("this is RedShift cool", new_text)
     end)
 
-    it("strips 🤖[U] (no quote) and gathers the bare turn", function()
+    it("strips 🤖[U] (no quote) and infers an anchor from preceding prose (#127)", function()
         local blocks, new_text = drill_in.gather_and_strip(
             "preamble 🤖[just ask] tail"
         )
         assert.equals(1, #blocks)
-        assert.is_nil(blocks[1].quoted)
+        -- #127: the unquoted marker now carries an inferred anchor (the
+        -- preceding prose), not nil. Only one word precedes it here.
+        assert.equals("preamble", blocks[1].quoted)
         assert.equals("just ask", blocks[1].sections[1].text)
-        -- Marker removed entirely (single space remains where it sat).
+        -- Inline replacement is still empty — the snippet is NOT re-inserted
+        -- (it's already present in the reply); only the marker is removed.
         assert.equals("preamble  tail", new_text)
     end)
 
@@ -242,12 +245,13 @@ describe("drill_in.gather_and_strip", function()
         assert.equals("x term y", new_text)
     end)
 
-    it("strips ready chain without <>", function()
+    it("strips ready chain without <> (anchor inferred from preceding prose, #127)", function()
         local blocks, new_text = drill_in.gather_and_strip(
             "x 🤖[Q1]{A1}[Q2] y"
         )
         assert.equals(1, #blocks)
-        assert.is_nil(blocks[1].quoted)
+        -- #127: unquoted chain gets an inferred anchor ("x" precedes it).
+        assert.equals("x", blocks[1].quoted)
         assert.equals(3, #blocks[1].sections)
         assert.equals("x  y", new_text)
     end)
@@ -303,6 +307,133 @@ describe("drill_in.gather_and_strip", function()
         local blocks, new_text = drill_in.gather_and_strip(input)
         assert.equals(0, #blocks)
         assert.equals(input, new_text)
+    end)
+end)
+
+-- ─── #127: inferred snippet anchors for unquoted markers ───────────────
+describe("drill_in.generate_snippet (#127)", function()
+    -- Return the only marker in `text` (helper).
+    local function marker_in(text, n)
+        local ms = drill_in.parse(text)
+        return ms[n or 1]
+    end
+
+    -- ── inline: prose precedes the marker on its line ──────────────────
+    it("inline: grabs the preceding sentence when ≥10 words are present", function()
+        local text = "Germany had been rearming in secret all through the nineteen twenties already 🤖[source?] here"
+        assert.equals(
+            "Germany had been rearming in secret all through the nineteen twenties already",
+            drill_in.generate_snippet(text, marker_in(text))
+        )
+    end)
+
+    it("inline: a <10-word current sentence extends back across the boundary", function()
+        local text = "This matters a lot. It really does 🤖[why?] now."
+        -- "It really does" (3) < 10 → prepend "This matters a lot." (4) → 7 words.
+        assert.equals(
+            "This matters a lot. It really does",
+            drill_in.generate_snippet(text, marker_in(text))
+        )
+    end)
+
+    it("inline: caps at 20 words, keeping the words nearest the marker with a … prefix", function()
+        local words = {}
+        for i = 1, 25 do table.insert(words, "w" .. i) end
+        local text = table.concat(words, " ") .. " 🤖[q] end"
+        local last20 = {}
+        for i = 6, 25 do table.insert(last20, words[i]) end
+        local expect = "… " .. table.concat(last20, " ")
+        assert.equals(expect, drill_in.generate_snippet(text, marker_in(text)))
+    end)
+
+    it("inline: strips a neighboring marker's raw bytes out of the window", function()
+        local text = "context here 🤖<x>[c0] more words after 🤖[c1] end"
+        -- The 🤖[c1] window includes the raw 🤖<x>[c0]; it must not leak in.
+        assert.equals(
+            "context here more words after",
+            drill_in.generate_snippet(text, marker_in(text, 2))
+        )
+    end)
+
+    -- ── standalone: marker is its own blank-separated paragraph ─────────
+    it("standalone: anchors to the previous paragraph's first sentence", function()
+        local text = "Para one sentence here. More of it.\n\n🤖[comment]\n\nPara two."
+        assert.equals(
+            "Para one sentence here.",
+            drill_in.generate_snippet(text, marker_in(text))
+        )
+    end)
+
+    it("standalone: degrades to empty when there is no previous prose block", function()
+        local text = "🤖[comment]\n\nSome paragraph follows."
+        assert.equals("", drill_in.generate_snippet(text, marker_in(text)))
+    end)
+
+    -- ── degradation + classification edges ─────────────────────────────
+    it("inline at reply start (prose only after the marker) degrades to empty", function()
+        local text = "🤖[note] this is the very first line"
+        assert.equals("", drill_in.generate_snippet(text, marker_in(text)))
+    end)
+
+    it("bare marker mid-paragraph (no blank separation) is treated as inline", function()
+        local text = "first line of the paragraph here\n🤖[comment]\nsecond line continues"
+        assert.equals(
+            "first line of the paragraph here",
+            drill_in.generate_snippet(text, marker_in(text))
+        )
+    end)
+
+    -- ── turn boundaries: never pull an anchor across a speaker prefix ───
+    it("standalone: stops at a turn prefix instead of crossing into the user turn", function()
+        local text = "💬: tell me about tanks\n\n🤖:[Agent]\n\n🤖[expand here]\n\nTanks mattered a lot."
+        -- 🤖:[Agent] header is the marker's own turn start — the user's
+        -- question above it must NOT become the agent comment's anchor.
+        assert.equals(
+            "",
+            drill_in.generate_snippet(text, marker_in(text), { boundaries = { "💬:", "🤖:" } })
+        )
+    end)
+
+    it("standalone: anchors to the prior paragraph within the same turn, not across the header", function()
+        local text = "🤖:[Agent]\n\nFirst paragraph of the answer here.\n\n🤖[expand]\n\nsecond"
+        assert.equals(
+            "First paragraph of the answer here.",
+            drill_in.generate_snippet(text, marker_in(text), { boundaries = { "💬:", "🤖:" } })
+        )
+    end)
+
+    it("forgiving: mis-snaps on an abbreviation period (documented limitation)", function()
+        local text = "Dr. Smith presented the findings clearly.\n\n🤖[c]\n\nx"
+        -- "Dr." reads as a sentence end; accepted per the meaning-anchor
+        -- philosophy (a verbatim near-anchor still routes attention).
+        assert.equals("Dr.", drill_in.generate_snippet(text, marker_in(text)))
+    end)
+end)
+
+-- #127: gather_and_strip end-to-end — quoted unchanged, mixed order, inference.
+describe("drill_in.gather_and_strip + inferred anchors (#127)", function()
+    it("explicit <Q> is unchanged — no inference for quoted markers (regression)", function()
+        local blocks = drill_in.gather_and_strip("lots of prose before 🤖<Q>[ask] and after")
+        assert.equals(1, #blocks)
+        assert.equals("Q", blocks[1].quoted)
+    end)
+
+    it("mixes quoted + unquoted markers in document order, each anchored", function()
+        local blocks, new_text = drill_in.gather_and_strip(
+            "alpha beta 🤖[c1] gamma delta 🤖<Term>[c2] epsilon"
+        )
+        assert.equals(2, #blocks)
+        assert.equals("alpha beta", blocks[1].quoted) -- inferred
+        assert.equals("Term", blocks[2].quoted)        -- explicit
+        -- Inferred snippet is NOT re-inserted; explicit quote IS restored.
+        assert.equals("alpha beta  gamma delta Term epsilon", new_text)
+    end)
+
+    it("threads boundaries through to suppress a cross-turn anchor", function()
+        local text = "💬: a question\n\n🤖:[Agent]\n\n🤖[expand]\n\nbody"
+        local blocks = drill_in.gather_and_strip(text, { boundaries = { "💬:", "🤖:" } })
+        assert.equals(1, #blocks)
+        assert.is_nil(blocks[1].quoted) -- no anchor recoverable within the turn
     end)
 end)
 

--- a/tests/unit/highlighter_spec.lua
+++ b/tests/unit/highlighter_spec.lua
@@ -1,0 +1,50 @@
+-- Unit tests for lua/parley/highlighter.lua pure predicates.
+
+local highlighter = require("parley.highlighter")
+
+-- Run M.is_reference_span over the FIRST `[...]` run in `line` (the matcher
+-- iterates the same gmatch), mirroring how compute_markdown_highlights calls it.
+local function first_span_is_reference(line)
+    for s, content, e in line:gmatch("()%[([^%[%]]+)%]()") do
+        return highlighter.is_reference_span(line, s, content, e)
+    end
+    return nil -- no bracket run at all
+end
+
+describe("highlighter.is_reference_span (#127)", function()
+    it("accepts a flattened reference span after ordinary prose", function()
+        assert.is_true(first_span_is_reference("the [train on Soviet soil] dodged it"))
+        assert.is_true(first_span_is_reference("They [rearmed in secret] really"))
+        assert.is_true(first_span_is_reference("see [RedShift] cool")) -- single-word explicit quote
+    end)
+
+    it("rejects a markdown link", function()
+        assert.is_false(first_span_is_reference("see the [docs](http://x) here"))
+    end)
+
+    it("rejects a footnote reference", function()
+        assert.is_false(first_span_is_reference("a claim [^1] needs backing"))
+    end)
+
+    it("rejects 1-char content (checkboxes / citations)", function()
+        assert.is_false(first_span_is_reference("- [ ] todo"))
+        assert.is_false(first_span_is_reference("- [x] done"))
+        assert.is_false(first_span_is_reference("ref [1] there"))
+    end)
+
+    it("rejects a live 🤖 marker's bare [U] section (preceded by 🤖)", function()
+        assert.is_false(first_span_is_reference("🤖[my comment in progress]"))
+    end)
+
+    it("rejects a live marker's [U] chained after a section close or quote", function()
+        -- first `[...]` follows `>` (close of <Q>)
+        assert.is_false(first_span_is_reference("🤖<scope>[the question]"))
+        -- first `[...]` follows `}` (close of {A})
+        assert.is_false(first_span_is_reference("🤖{ans}[then ask]"))
+    end)
+
+    it("accepts an explicit-quote span [Q] once flattened (preceded by prose)", function()
+        -- After flatten the marker is gone; `[Q]` follows a space, not 🤖.
+        assert.is_true(first_span_is_reference("this is [RedShift] cool"))
+    end)
+end)

--- a/workshop/issues/000127-drill-in-snippet-anchor.md
+++ b/workshop/issues/000127-drill-in-snippet-anchor.md
@@ -1,11 +1,12 @@
 ---
 id: 000127
-status: working
+status: done
 deps: []
 github_issue:
 created: 2026-06-10
 updated: 2026-06-10
 estimate_hours: 2.5
+actual_hours: 0.34
 ---
 
 # Smart-snippet anchoring for unquoted drill-in comments
@@ -110,24 +111,60 @@ it's a drop-in swap, not a rewrite.
 
 ## Plan
 
-- [ ] Add pure `M.generate_snippet(text, marker)` to `drill_in.lua` — inline +
-      standalone classification, word/sentence-boundary snapping, degradation.
-- [ ] Wire it into `M.gather_and_strip` per the decouple snippet (block-quote
-      vs inline-replacement); explicit-quote path untouched.
-- [ ] Tests in `drill_in_spec.lua`: inline mid-sentence; inline short-sentence
-      extends back; inline cap-at-20; standalone → prev-paragraph first sentence;
-      standalone no-prev-prose degrades; marker at reply start degrades; bare
-      marker mid-paragraph treated as inline; explicit-quote regression; mixed
-      quoted+unquoted markers in document order.
-- [ ] Run the suite; verify end-to-end in a scratch chat (`<C-g>g` on an
-      unquoted comment shows the recovered `> snippet` in the new turn).
+- [x] Add pure `M.generate_snippet(text, marker, opts)` to `drill_in.lua` —
+      inline + standalone classification, word/sentence-boundary snapping,
+      neighboring-marker stripping, `opts.boundaries` turn-prefix stops,
+      degradation.
+- [x] Wire it into `M.gather_and_strip` per the decouple snippet (block-quote
+      vs inline-replacement); explicit-quote path untouched. `chat_respond`
+      assembles config boundaries and threads `di_opts` into both call sites.
+- [x] Tests in `drill_in_spec.lua`: all enumerated cases + turn-boundary
+      cross-protection (both directions) + neighboring-marker strip +
+      abbreviation-pin. 14 new + 2 updated; 90/90 in the file.
+- [x] Ran the suite; demonstrated end-to-end on a realistic multi-paragraph
+      reply (inline + standalone markers → correct `> snippet` blocks, header
+      boundary respected).
 
 ## Log
 
 ### 2026-06-10
+- 2026-06-10: closed — drill_in_spec 90/90 (14 new+2 updated); generate_snippet inline+standalone+boundary+degradation covered; integration chat_respond_spec 20/20; e2e demo recovered correct > anchors for inline & standalone markers, header boundary respected; 8 unrelated pre-existing failures confirmed identical with edits stashed; review verdict: SHIP
 
 Design converged in-session (parley brainstorm). Started as a `[^-N]` reference
 scheme; talked it down to pure-snippet (no refs) once it was clear meaning-based
 anchoring makes verbatim recurrence a non-issue and dissolves the counter /
 conceal / edit-sync costs. Lineage: #123 (quoted body) → #124 (review
 convention) → #125 (bounded multiline) → #127 (infer the quote when absent).
+
+**Plan-quality judge (INFO, non-blocking) — resolved the standalone scan
+boundary.** Both `gather_and_strip` call sites pass wide text (whole buffer /
+full exchange), so a naive backward scan could pull a standalone marker's anchor
+across a speaker boundary (the agent's comment anchored to the *user's* words,
+or to a 🧠:/📎: block). Decision (ARCH-PURE preserved): `generate_snippet` takes
+an optional `opts.boundaries` = list of turn-prefix strings; the backward scan
+never crosses a line starting with one. The config→prefix coupling lives in the
+`chat_respond` glue (the IO layer), which assembles `{💬: 🤖: 🧠: 📝: 🔧: 📎:
+🌿:}` from config and threads it through. Confirmed from a real chat that `---`
+is a *body* section separator (not a turn boundary) — so only the emoji-colon
+prefixes bound the scan, never `---`. Judge's two advisory notes also handled:
+neighboring raw markers are stripped from a candidate snippet (reuse `M.parse`);
+abbreviation/decimal mis-snap on `.!?` accepted per the forgiving-anchor
+philosophy (pinned by a test).
+
+**Implemented.** `generate_snippet` + helpers (`index_lines`, `is_boundary_line`,
+`split_sentences`, `tail_snippet`, `first_sentence_snippet`, `strip_markers`)
+landed in `drill_in.lua`; `gather_and_strip` gained the explicit-vs-inferred
+decouple + optional `opts`; `chat_respond` builds the boundary list from config
+and threads it into both call sites. Atlas (`atlas/chat/drill_in.md`) updated
+with an "Anchor inference (#127)" section + key-files note.
+
+**Verification.** `drill_in_spec.lua` 90/90 green (76 baseline + 14 new, 2
+updated). Full `tests/unit` sweep: the only failures are 8 pre-existing,
+unrelated, env-dependent ones (note_finder ×4, super_repo ×1, chat_slug_resolve
+×3) — confirmed identical with my edits stashed. `chat_respond.lua` loads clean;
+integration `chat_respond_spec.lua` 20/20 green (uses only quoted markers, so the
+unquoted-path change touches none). End-to-end demo on a realistic reply:
+inline marker → `> Germany rebuilt its army…The Treaty of Rapallo let them`
+(cross-line collect + sentence extension); standalone marker → `> Blitzkrieg was
+less a new invention than a synthesis of old doctrine.` (prev-paragraph first
+sentence), correctly stopping before the `🤖:[Claude]` header.

--- a/workshop/issues/000127-drill-in-snippet-anchor.md
+++ b/workshop/issues/000127-drill-in-snippet-anchor.md
@@ -6,7 +6,7 @@ github_issue:
 created: 2026-06-10
 updated: 2026-06-10
 estimate_hours: 2.5
-actual_hours: 0.34
+actual_hours: 1.51
 ---
 
 # Smart-snippet anchoring for unquoted drill-in comments
@@ -124,10 +124,31 @@ it's a drop-in swap, not a rewrite.
 - [x] Ran the suite; demonstrated end-to-end on a realistic multi-paragraph
       reply (inline + standalone markers → correct `> snippet` blocks, header
       boundary respected).
+- [x] **Referenced-span enclosing (added per operator request).** Refactor
+      `generate_snippet` to offset-based selection returning the span byte range
+      (behavior-preserving for the snippet text). `gather_and_strip` gains
+      `opts.bracket`: explicit `<Q>` → `[Q]`; inferred span bracketed in place
+      (inline absorbs gap+marker into `]`; standalone inserts `]` + removes
+      marker). `chat_respond` enables it via `config.mark_reference_span`
+      (default on). `ParleyReference` highlight (underline; `highlight.reference`
+      override) + a conservative per-line matcher (skips `](` links, checkboxes,
+      `[^..]`, 1-char). Tests: span-range + bracket cases (101/101 unit, 20/20
+      integration). Brackets persist across reload; the experiment is one flag.
 
 ## Log
 
 ### 2026-06-10
+- 2026-06-10: FIX-THEN-SHIP follow-ups before merge. Important: extracted pure
+  `highlighter.is_reference_span` + `highlighter_spec.lua` (7 tests:
+  link/footnote/checkbox/1-char skips) and added a live-🤖-marker-section skip
+  (a marker's `[U]` chained after 🤖/`>`/`}` no longer double-marks while you
+  compose). Minors: DRY'd boundary-prefix logic into `boundary_prefix_len` (3
+  sites→1); dropped redundant checkbox checks; atlas notes `chat_local_prefix`.
+  Incidental `claude-Opus-4-7`→`claude-opus-4-7` id-casing fix swept in — kept
+  (correct). Forward notes (cosmetic/untested): nested bracket when a neighbor
+  marker sits in the span window; multi-line unquoted marker. drill_in 101/101,
+  highlighter 7/7, integration 20/20.
+- 2026-06-10: closed — referenced-span [] enclosing both forms; generate_snippet offset-refactor returns span range (behavior-preserving); drill_in 101/101, integration 20/20; matcher selectivity verified ([train on Soviet soil]/[RedShift] color, [docs](),[ ],[1] skip); operator verified the live effect and approved; gated by config.mark_reference_span; review verdict: FIX-THEN-SHIP
 - 2026-06-10: closed — drill_in_spec 90/90 (14 new+2 updated); generate_snippet inline+standalone+boundary+degradation covered; integration chat_respond_spec 20/20; e2e demo recovered correct > anchors for inline & standalone markers, header boundary respected; 8 unrelated pre-existing failures confirmed identical with edits stashed; review verdict: SHIP
 
 Design converged in-session (parley brainstorm). Started as a `[^-N]` reference
@@ -168,3 +189,23 @@ inline marker → `> Germany rebuilt its army…The Treaty of Rapallo let them`
 (cross-line collect + sentence extension); standalone marker → `> Blitzkrieg was
 less a new invention than a synthesis of old doctrine.` (prev-paragraph first
 sentence), correctly stopping before the `🤖:[Claude]` header.
+
+**Referenced-span enclosing (reopened — operator wants a persistent visual cue
+of the referenced segment).** Folded into #127 rather than a follow-up.
+- Chose literal `[]` per operator preference. It's the one cue that *persists*
+  across the flatten + a file reload (extmark-only color would not — parley's
+  inline-branch conceal re-derives extmarks from on-disk `[🌿:..]()` text each
+  render; after flatten there's no marker to re-derive from, so the cue must be
+  in the text). `ParleyReviewQuoted` (reverse+bold on `🤖<…>`) already marks the
+  scope but only while the *live* marker exists.
+- Needed the span's byte range → refactored `generate_snippet` to offset-based
+  token selection (`tokenize`/`select_tail`/`select_head`/`span_text`),
+  reproducing every prior snippet text (93→101 tests stay green) and returning
+  `(text, span_start, span_end)`. Removed now-dead `split_sentences`/`word_count`.
+- Coloring caveat (told operator): plain `[]` can't be told apart from
+  markdown links / incidental brackets / single-word explicit quotes
+  (`[RedShift]` looks like any bracketed word). The matcher is a heuristic
+  (skip `](`, checkboxes, `[^..]`, 1-char); residual false positives on genuine
+  multi-char agent `[brackets]`). Gated by `config.mark_reference_span` so the
+  whole experiment is one flag — operator will evaluate the rendered effect and
+  decide whether to keep it / switch to a distinguishable delimiter.

--- a/workshop/lessons.md
+++ b/workshop/lessons.md
@@ -1,5 +1,9 @@
 # Lessons
 
+## 2026-06-10
+- A config→data mapping written as an inline IIFE/closure in glue code is invisible to tests — a dropped or typo'd key silently degrades behavior. Extract it to a small *pure* named helper (`f(cfg) -> data`) and unit-test the mapping. (#127: the `chat_boundaries` prefix list started as an inline closure in `chat_respond`; the boundary review flagged the untested surface.)
+- Pure-but-IO-adjacent helpers belong in the *pure* module taking the config table as a param, not requiring config — keeps the core testable while quarantining the field-name knowledge in one place.
+
 ## 2026-05-30
 - **A "line-bounded" parser's line bound is often a load-bearing blast-radius cap, not just a limitation.** `parse_markers` was line-bounded only because it fed `parse_marker_sections` one line at a time — `find_matching_bracket` itself already scanned across `\n` (drill_in relied on that). So "make it multi-line" was really "stop slicing per-line + add a bound back in." Before removing a bound that looks accidental, ask what it was silently protecting: here, an unmatched `🤖{` could only ruin one line; unbounded it would swallow to EOF. The fix kept the protection as an explicit per-section newline budget (#125).
 - **Extend a shared parser via an optional opts arg that defaults to the historical behavior — then existing callers are provably untouched.** `find_matching_bracket(text, start, open, close, opts)` with `opts.budget`/`opts.is_excluded`; `opts or {}` → `budget == nil` → unbounded, exactly as before. Only the new caller (`parse_markers`) opts in. This sidesteps the lesson-#7 trap (2-arg call sites silently losing a new return) because there's no new *return* and no signature change at the call sites — highlighter and drill_in still pass 3 args. Grep-confirm the call sites anyway.


### PR DESCRIPTION
- #127: address FIX-THEN-SHIP review — test the reference matcher, close it + minors
- #127: enclose the referenced span in [] as a persistent visual cue
- #127: close + address boundary-review findings
- #127: infer a prose anchor for unquoted drill-in comments