### PR TITLE
#128: restructure ## Plan into M1-M5 milestone rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Most-used defaults:
 ## What Parley Supports
 
 - Providers: OpenAI, Anthropic, Google AI, Ollama, OpenAI-compatible endpoints, and CLIProxyAPI.
-  - **Optional**: parley can manage a local `cliproxyapi` for you — set `cliproxy = { manage = true }` in `setup{}` and it renders the config from Lua and lazily starts/reuses/health-checks the proxy. `:ParleyProxy status|start|stop|restart|login <provider>`. Off by default; see [atlas/providers/cliproxy-managed.md](atlas/providers/cliproxy-managed.md).
+  - parley can **manage a local `cliproxyapi`** for you — it renders the config from Lua and lazily starts/reuses/health-checks the proxy. `:ParleyProxy status|start|stop|restart|login <provider>`. **On by default but dormant** — only acts when a cliproxyapi-provider agent runs, and reuses an existing proxy if one is up; a fresh machine needs `brew install cliproxyapi` + a one-time `:ParleyProxy login`. Set `cliproxy = { manage = false }` to opt out. See [atlas/providers/cliproxy-managed.md](atlas/providers/cliproxy-managed.md).
 - File context with `@@path/to/file` and directory patterns.
 - Web search toggle for supported providers.
 - Outline navigation, highlighting.

--- a/README.md
+++ b/README.md
@@ -138,7 +138,8 @@ Most-used defaults:
 
 ## What Parley Supports
 
-- Providers: OpenAI, Anthropic, Google AI, Ollama, OpenAI-compatible endpoints, and `CLI Proxy API``:w
+- Providers: OpenAI, Anthropic, Google AI, Ollama, OpenAI-compatible endpoints, and CLIProxyAPI.
+  - **Optional**: parley can manage a local `cliproxyapi` for you — set `cliproxy = { manage = true }` in `setup{}` and it renders the config from Lua and lazily starts/reuses/health-checks the proxy. `:ParleyProxy status|start|stop|restart|login <provider>`. Off by default; see [atlas/providers/cliproxy-managed.md](atlas/providers/cliproxy-managed.md).
 - File context with `@@path/to/file` and directory patterns.
 - Web search toggle for supported providers.
 - Outline navigation, highlighting.

--- a/atlas/index.md
+++ b/atlas/index.md
@@ -17,6 +17,7 @@ This index provides a central directory for all atlas entries of the `parley.nvi
 - [Provider Architecture](providers/architecture.md): Transport layer, payload construction, and streaming.
 - [OpenAI Provider](providers/openai.md): Implementation for OpenAI-compatible backends.
 - [CLIProxyAPI Provider](providers/cliproxyapi.md): OpenAI-compatible local proxy provider for multi-vendor models.
+- [Managed cliproxyapi](providers/cliproxy-managed.md): Opt-in lifecycle + config management for a local cliproxyapi (render from Lua, lazy start/reuse, `:ParleyProxy`).
 - [Anthropic Provider](providers/anthropic.md): Implementation for Claude models.
 - [Google AI Provider](providers/googleai.md): Implementation for Gemini models.
 - [Agents](providers/agents.md): Agent configuration and selection mechanisms.

--- a/atlas/providers/cliproxy-managed.md
+++ b/atlas/providers/cliproxy-managed.md
@@ -71,6 +71,23 @@ silently skips the request (neither the query nor the abort fires). This is the
 same gate all secret-backed providers use; just be aware managed mode doesn't
 remove the secret requirement (the secret is the client↔proxy token).
 
+## Auth-failure → guided login (M3)
+
+When a cliproxy chat fails because the upstream credential is missing/invalid,
+cliproxyapi returns `"unknown provider for model <X>"` (it resolves models only
+from *loaded* auth clients — `util.GetProviderName` reads the dynamic registry,
+so an unloaded auth makes the model unresolvable; the static catalog isn't
+consulted). The dispatcher's cliproxy response path calls
+`cliproxy.check_auth_failure`, which:
+1. `cliproxy_config.detect_auth_failure` extracts `<X>` from that error.
+2. `cliproxy_config.resolve_login_provider` finds the **channel** whose
+   `oauth-model-alias` list contains `<X>` and maps it → a login provider — over
+   cliproxyapi's fixed channel set (claude/codex/gemini-cli/vertex/aistudio/kimi/
+   antigravity). This is **config-driven, not a name heuristic**: the channel
+   key in the rendered `oauth-model-alias` *is* the provider (the default keys by
+   the canonical `claude` channel for exactly this reason).
+3. prompts (`vim.ui.select`) `:ParleyProxy login <provider>`.
+
 ## auto_download (M2)
 
 `cliproxy = { manage = true, auto_download = true }` removes the

--- a/atlas/providers/cliproxy-managed.md
+++ b/atlas/providers/cliproxy-managed.md
@@ -47,6 +47,13 @@ teardown (`chat_respond` collapses the empty answer + stops the spinner;
 so the request fails fast instead of hanging. **`:ParleyProxy stop` is transient**
 — every dispatch re-`ensure_running`s, so a dead/stopped proxy revives on next use.
 
+`stop` reaps **across sessions**: it kills this session's spawned PIDs *and* a
+leftover cliproxy on the managed port spawned by an earlier nvim (parley's
+proxies are detached + survive nvim exit, so `_spawned` alone can't reach them).
+It **identity-probes the port first** (the same `/v1/models` classifier as
+`health_probe`), so a *foreign* process holding the port is never killed — only
+a process that actually answers as cliproxy. `restart` = `stop` + ensure.
+
 ## Auth & secrets
 
 - The **client token** (`api_keys.cliproxyapi`) is resolved through the vault and

--- a/atlas/providers/cliproxy-managed.md
+++ b/atlas/providers/cliproxy-managed.md
@@ -3,8 +3,15 @@
 Parley can manage a local [cliproxyapi](https://github.com/router-for-me/CLIProxyAPI)
 instance — render its config, start it on demand, reuse it if it's already up —
 so users stop hand-maintaining `/opt/homebrew/etc/cliproxyapi.conf` and
-`brew services`. **Off by default**; activated by a `cliproxy = { manage = true }`
-block in `setup{}`. Issue #131.
+`brew services`. Issue #131.
+
+**On by default** (`config.lua` ships `cliproxy = { manage = true, … }`), but
+**dormant** — it only acts when a cliproxyapi-provider agent actually runs, and
+it **reuses** an already-running proxy (e.g. `brew services`) when one answers
+healthy. So the default is safe for users who don't use cliproxyapi (it never
+fires) and cooperative for those who run their own (it reuses it). Set
+`cliproxy = { manage = false }` to opt out. A new machine needs only
+`brew install cliproxyapi` + a one-time `:ParleyProxy login <provider>`.
 
 ## Pieces
 

--- a/atlas/providers/cliproxy-managed.md
+++ b/atlas/providers/cliproxy-managed.md
@@ -1,0 +1,55 @@
+# Managed cliproxyapi (opt-in)
+
+Parley can manage a local [cliproxyapi](https://github.com/router-for-me/CLIProxyAPI)
+instance — render its config, start it on demand, reuse it if it's already up —
+so users stop hand-maintaining `/opt/homebrew/etc/cliproxyapi.conf` and
+`brew services`. **Off by default**; activated by a `cliproxy = { manage = true }`
+block in `setup{}`. Issue #131.
+
+## Pieces
+
+- **`cliproxy_config.lua`** (pure): `parse_endpoint` (host:port from the provider
+  endpoint — the single source of truth, no separate port knob), `render` (merge
+  raw `config` passthrough + wiring fields + the resolved client secret), `encode`
+  (JSON-as-YAML — valid YAML 1.2, no emitter needed). Unit-tested, no mocks.
+- **`cliproxy.lua`** (IO): `discover_binary` (`cliproxy.binary_path` → `cliproxyapi`/
+  `cli-proxy-api` on PATH), `health_probe` (`GET /v1/models` with the bearer →
+  `healthy`/`needs_login`/`client_key_mismatch`/`foreign`/`down`), `spawn`
+  (detached, PID-tracked), `ensure_running` (reuse-if-healthy → else
+  discover/spawn/poll, bounded — never hangs), and `status`/`start`/`stop`/
+  `restart`/`login_argv`. Tested against a process-level fake.
+
+## Flow
+
+`setup{ cliproxy.manage = true }` → on the first dispatch to a cliproxy-provider
+agent, the adapter's **`pre_query`** hook (the same seam copilot uses) calls
+`ensure_running`:
+
+1. parse host:port from `providers.cliproxyapi.endpoint`; render the config from
+   Lua + the vault-resolved secret; write it `0600` to
+   `stdpath('data')/parley/cliproxy/config.yaml` (a derived artifact — the
+   committed Lua is the source of truth).
+2. probe `/v1/models`. `healthy`/`needs_login` → proceed (reuse). `foreign`/
+   `client_key_mismatch` → abort. `down` → discover the binary, spawn it
+   detached, poll until healthy (≤5s) or abort.
+
+On any failure, `ensure_running` drives **`on_error`** → the dispatcher's
+**abort channel** (`D.query`'s trailing `on_abort`) → each caller's qid-free
+teardown (`chat_respond` collapses the empty answer + stops the spinner;
+`skill_runner` clears its in-flight guard; `memory_prefs` advances its batch),
+so the request fails fast instead of hanging. **`:ParleyProxy stop` is transient**
+— every dispatch re-`ensure_running`s, so a dead/stopped proxy revives on next use.
+
+## Auth & secrets
+
+- The **client token** (`api_keys.cliproxyapi`) is resolved through the vault and
+  written into the rendered `api-keys`; the committed Lua holds no secret.
+- **OAuth subscription tokens** live in `auth-dir` (default `~/.cli-proxy-api`),
+  written by `:ParleyProxy login <provider>` → `cliproxyapi -<provider>-login`
+  (per-provider flags: claude, codex, codex-device, google, kimi, xai,
+  antigravity). The one unavoidable manual, per-machine step.
+
+## Deferred (M2)
+
+`auto_download` — fetch a pinned release tarball + checksum-verify + extract,
+falling through `discover_binary`. Not in M1 (bring-your-own binary).

--- a/atlas/providers/cliproxy-managed.md
+++ b/atlas/providers/cliproxy-managed.md
@@ -64,7 +64,15 @@ silently skips the request (neither the query nor the abort fires). This is the
 same gate all secret-backed providers use; just be aware managed mode doesn't
 remove the secret requirement (the secret is the client↔proxy token).
 
-## Deferred (M2)
+## auto_download (M2)
 
-`auto_download` — fetch a pinned release tarball + checksum-verify + extract,
-falling through `discover_binary`. Not in M1 (bring-your-own binary).
+`cliproxy = { manage = true, auto_download = true }` removes the
+`brew install` step: when `discover_binary` finds nothing, `ensure_running`
+fetches the **pinned** release (`cliproxy.lua` `PINNED_VERSION`, overridable via
+`cliproxy.download_version`) for the host platform — `cliproxy_config.platform`
++ `asset_name` build the asset name, `download()` curls the tarball +
+`checksums.txt`, **sha256-verifies (refuses to install on mismatch)**, and
+extracts `cli-proxy-api` into `stdpath('data')/parley/cliproxy/bin/`. That dir
+sits between `binary_path` and PATH in `discover_binary`'s chain.
+`:ParleyProxy update` re-fetches. The download is synchronous + one-time (cached
+after first fetch). Windows (`.zip`) is not auto-downloaded — install manually.

--- a/atlas/providers/cliproxy-managed.md
+++ b/atlas/providers/cliproxy-managed.md
@@ -49,6 +49,14 @@ so the request fails fast instead of hanging. **`:ParleyProxy stop` is transient
   (per-provider flags: claude, codex, codex-device, google, kimi, xai,
   antigravity). The one unavoidable manual, per-machine step.
 
+## Required even when managed
+
+`api_keys.cliproxyapi` must be set even with `manage = true` — the dispatcher's
+`vault.run_with_secret` gate runs *before* `pre_query`, so a missing secret
+silently skips the request (neither the query nor the abort fires). This is the
+same gate all secret-backed providers use; just be aware managed mode doesn't
+remove the secret requirement (the secret is the client↔proxy token).
+
 ## Deferred (M2)
 
 `auto_download` — fetch a pinned release tarball + checksum-verify + extract,

--- a/atlas/traceability.yaml
+++ b/atlas/traceability.yaml
@@ -279,6 +279,7 @@ atlas:
       - tests/integration/cliproxy_command_spec.lua
       - tests/integration/cliproxy_caller_teardown_spec.lua
       - tests/integration/cliproxy_download_spec.lua
+      - tests/integration/cliproxy_auth_login_spec.lua
 
   providers/anthropic:
     code:

--- a/atlas/traceability.yaml
+++ b/atlas/traceability.yaml
@@ -260,6 +260,22 @@ atlas:
       - tests/unit/provider_params_spec.lua
       - tests/unit/pure_functions_spec.lua
 
+  providers/cliproxy-managed:
+    code:
+      - lua/parley/cliproxy_config.lua
+      - lua/parley/cliproxy.lua
+      - lua/parley/providers.lua
+      - lua/parley/dispatcher.lua
+      - lua/parley/chat_respond.lua
+      - lua/parley/skill_runner.lua
+      - lua/parley/memory_prefs.lua
+    tests:
+      - tests/unit/cliproxy_config_spec.lua
+      - tests/unit/providers_pre_query_spec.lua
+      - tests/unit/dispatcher_query_spec.lua
+      - tests/integration/cliproxy_lifecycle_spec.lua
+      - tests/integration/cliproxy_dispatch_spec.lua
+
   providers/anthropic:
     code:
       - lua/parley/providers.lua

--- a/atlas/traceability.yaml
+++ b/atlas/traceability.yaml
@@ -269,12 +269,14 @@ atlas:
       - lua/parley/chat_respond.lua
       - lua/parley/skill_runner.lua
       - lua/parley/memory_prefs.lua
+      - lua/parley/init.lua
     tests:
       - tests/unit/cliproxy_config_spec.lua
       - tests/unit/providers_pre_query_spec.lua
       - tests/unit/dispatcher_query_spec.lua
       - tests/integration/cliproxy_lifecycle_spec.lua
       - tests/integration/cliproxy_dispatch_spec.lua
+      - tests/integration/cliproxy_command_spec.lua
 
   providers/anthropic:
     code:

--- a/atlas/traceability.yaml
+++ b/atlas/traceability.yaml
@@ -277,6 +277,7 @@ atlas:
       - tests/integration/cliproxy_lifecycle_spec.lua
       - tests/integration/cliproxy_dispatch_spec.lua
       - tests/integration/cliproxy_command_spec.lua
+      - tests/integration/cliproxy_caller_teardown_spec.lua
 
   providers/anthropic:
     code:

--- a/atlas/traceability.yaml
+++ b/atlas/traceability.yaml
@@ -278,6 +278,7 @@ atlas:
       - tests/integration/cliproxy_dispatch_spec.lua
       - tests/integration/cliproxy_command_spec.lua
       - tests/integration/cliproxy_caller_teardown_spec.lua
+      - tests/integration/cliproxy_download_spec.lua
 
   providers/anthropic:
     code:

--- a/lua/parley/chat_respond.lua
+++ b/lua/parley/chat_respond.lua
@@ -811,6 +811,17 @@ M.generate_topic = function(messages, provider, model, callback, spinner)
     local topic_buf = vim.api.nvim_create_buf(false, true)
     local topic_handler = _parley.dispatcher.create_handler(topic_buf, nil, 0, false, "", false)
 
+    -- Abort teardown (#131): stop the topic spinner + drop the scratch buffer
+    -- if the managed cliproxy can't start, so topic-gen fails quietly (no hang).
+    local function on_abort(msg)
+        stop_and_close_timer(spinner_timer)
+        spinner_timer = nil
+        if vim.api.nvim_buf_is_valid(topic_buf) then
+            vim.api.nvim_buf_delete(topic_buf, { force = true })
+        end
+        vim.notify(msg or "parley: topic generation aborted", vim.log.levels.WARN)
+    end
+
     _parley.dispatcher.query(
         nil,
         provider,
@@ -826,7 +837,10 @@ M.generate_topic = function(messages, provider, model, callback, spinner)
             if topic ~= "" then
                 callback(topic)
             end
-        end)
+        end),
+        nil,
+        nil,
+        on_abort
     )
 end
 
@@ -1479,6 +1493,39 @@ M.respond = function(params, callback, override_free_cursor, force, live_model, 
             base_handler(qid, chunk)
         end
 
+        -- Shared empty-answer collapse (#131): used by on_exit (tool-use-only /
+        -- empty response) AND on_abort, so a failed managed-cliproxy start tears
+        -- down the same inserted stream placeholder instead of leaving it.
+        local function collapse_empty_answer()
+            if not stream_block_idx then
+                return
+            end
+            local sblk = model.exchanges[target_idx].blocks[stream_block_idx]
+            if sblk and sblk.size == 1 then
+                local spos = model:block_start(target_idx, stream_block_idx)
+                local sline = vim.api.nvim_buf_get_lines(buf, spos, spos + 1, false)[1] or ""
+                if not sline:match("%S") then
+                    -- Just a blank — remove it + its margin, set size 0 (the
+                    -- empty-block rule cancels the margin).
+                    local del_start = math.max(spos - 1, 0)
+                    local del_count = spos - del_start + 1
+                    buffer_edit.delete_lines_after(buf, del_start, del_count)
+                    model:set_block_size(target_idx, stream_block_idx, 0)
+                end
+            end
+        end
+
+        -- Abort teardown (#131): the dispatcher invokes this (qid-free) when the
+        -- managed cliproxy can't be started, so the request fails fast — spinner
+        -- stopped, empty answer block collapsed, error surfaced — never hangs.
+        local function on_abort(msg)
+            vim.schedule(function()
+                clear_progress_indicator(nil)
+                collapse_empty_answer()
+                vim.notify(msg or "parley: request aborted", vim.log.levels.WARN)
+            end)
+        end
+
         -- call the model and write response
         _parley.dispatcher.query(
             buf,
@@ -1492,25 +1539,9 @@ M.respond = function(params, callback, override_free_cursor, force, live_model, 
                 end
                 request_clear_progress_indicator(qt)
 
-                -- If the stream_placeholder has no real content (Claude
-                -- responded with only tool_use, no text), collapse it to
-                -- size 0 so it doesn't produce extra blank lines.
-                if stream_block_idx then
-                    local sblk = model.exchanges[target_idx].blocks[stream_block_idx]
-                    if sblk and sblk.size == 1 then
-                        local spos = model:block_start(target_idx, stream_block_idx)
-                        local sline = vim.api.nvim_buf_get_lines(buf, spos, spos + 1, false)[1] or ""
-                        if not sline:match("%S") then
-                            -- It's just a blank — remove it + its margin
-                            -- from the buffer, then set size 0 in the model
-                            -- (empty-block rule cancels the margin).
-                            local del_start = math.max(spos - 1, 0)  -- margin line
-                            local del_count = spos - del_start + 1   -- margin + blank
-                            buffer_edit.delete_lines_after(buf, del_start, del_count)
-                            model:set_block_size(target_idx, stream_block_idx, 0)
-                        end
-                    end
-                end
+                -- Collapse the empty stream placeholder (tool-use-only or empty
+                -- response). Shared with the #131 abort path.
+                collapse_empty_answer()
 
                 -- Tool loop hook: if the streamed response contained
                 -- tool_use blocks, write 🔧:/📎: into the buffer and
@@ -1722,7 +1753,8 @@ M.respond = function(params, callback, override_free_cursor, force, live_model, 
                     spinner_message = message
                     render_spinner_line()
                 end
-            end)
+            end),
+            on_abort
         )
     end)
 end

--- a/lua/parley/chat_respond.lua
+++ b/lua/parley/chat_respond.lua
@@ -762,24 +762,29 @@ M.generate_topic = function(messages, provider, model, callback, spinner)
     -- generation — the topic model doesn't care about tool blocks.
     local msgs = {}
     for _, m in ipairs(messages) do
-        local content = m.content
-        if type(content) == "table" then
-            -- Content-block list: concatenate text-typed block bodies.
-            -- Non-text blocks (tool_use, tool_result) contribute nothing
-            -- useful to a topic string, so we drop them.
-            local parts = {}
-            for _, block in ipairs(content) do
-                if block.type == "text" and type(block.text) == "string" then
-                    table.insert(parts, block.text)
+        -- Drop the persona system prompt for topic generation: it's a utility
+        -- call, and the default system prompt mandates a `🧠:` thinking block —
+        -- which an obedient model emits, and which then becomes the "topic".
+        if m.role ~= "system" then
+            local content = m.content
+            if type(content) == "table" then
+                -- Content-block list: concatenate text-typed block bodies.
+                -- Non-text blocks (tool_use, tool_result) contribute nothing
+                -- useful to a topic string, so we drop them.
+                local parts = {}
+                for _, block in ipairs(content) do
+                    if block.type == "text" and type(block.text) == "string" then
+                        table.insert(parts, block.text)
+                    end
                 end
+                content = table.concat(parts, " ")
+            elseif type(content) ~= "string" then
+                content = ""
             end
-            content = table.concat(parts, " ")
-        elseif type(content) ~= "string" then
-            content = ""
-        end
-        content = content:gsub("^%s*(.-)%s*$", "%1")
-        if content ~= "" then
-            table.insert(msgs, { role = m.role, content = content })
+            content = content:gsub("^%s*(.-)%s*$", "%1")
+            if content ~= "" then
+                table.insert(msgs, { role = m.role, content = content })
+            end
         end
     end
     table.insert(msgs, { role = "user", content = _parley.config.chat_topic_gen_prompt })

--- a/lua/parley/chat_respond.lua
+++ b/lua/parley/chat_respond.lua
@@ -755,6 +755,22 @@ end
 -- @param callback  function called with (topic_string) on completion
 -- @param spinner   table|nil optional {buf, find_line} — buf is the buffer to animate,
 --                  find_line() returns 0-indexed line number of the topic line (or nil to skip)
+--- Pure: drop the first `lead` messages from a built messages array, returning
+--- just the current-file conversation turns. `lead` = (# system-prompt messages)
+--- + (# ancestor messages). The system prompt is 1 message normally, but 2 for
+--- a synthetic system prompt (leading user turn + assistant ack) — so dropping
+--- by COUNT is robust to both encodings. Exposed for tests.
+---@param messages table[]
+---@param lead integer
+---@return table[]
+function M._conversation_after_lead(messages, lead)
+    local out = {}
+    for i = (lead or 0) + 1, #messages do
+        out[#out + 1] = vim.deepcopy(messages[i])
+    end
+    return out
+end
+
 M.generate_topic = function(messages, provider, model, callback, spinner)
     -- Build a clean copy: strip whitespace, drop empty messages and cache_control.
     -- Messages carrying content-block arrays (Anthropic tool-use shape, M2
@@ -1618,15 +1634,13 @@ M.respond = function(params, callback, override_free_cursor, force, live_model, 
 
                 -- if topic is ?, then generate it
                 if headers.topic == "?" then
-                    -- For topic generation, use only current file's messages (skip ancestors)
-                    -- messages layout: [system_prompt, ...ancestors, ...current_file_msgs]
-                    local topic_msgs = {}
-                    for i, m in ipairs(messages) do
-                        -- skip ancestor messages (indices 2 through ancestor_msg_count + 1)
-                        if i == 1 or i > ancestor_msg_count + 1 then
-                            table.insert(topic_msgs, vim.deepcopy(m))
-                        end
-                    end
+                    -- Topic gen: drop the leading system-prompt messages (1, or 2
+                    -- for a synthetic system prompt) AND ancestors — keep only the
+                    -- current-file conversation. Carrying the system prompt makes
+                    -- the model obey its 🧠:/persona mandate and open with a
+                    -- thinking block, which would otherwise become the "topic".
+                    local sys_lead = #require("parley.system_prompt_msgs").build(agent_info)
+                    local topic_msgs = M._conversation_after_lead(messages, sys_lead + ancestor_msg_count)
                     table.insert(topic_msgs, { role = "assistant", content = qt.response })
 
                     M.generate_topic(topic_msgs, agent_info.provider, agent_info.model, function(topic)

--- a/lua/parley/cliproxy.lua
+++ b/lua/parley/cliproxy.lua
@@ -131,4 +131,277 @@ function M.health_probe(host, port, secret, cb)
     end)
 end
 
+--------------------------------------------------------------------------------
+-- Rendered config (derived artifact)
+--------------------------------------------------------------------------------
+
+-- A derived, machine-local artifact under stdpath('data') — NOT in the user's
+-- dotfiles repo. The committed Lua setup{} is the source of truth.
+local function config_path()
+    local dir = vim.fn.stdpath("data") .. "/parley/cliproxy"
+    vim.fn.mkdir(dir, "p")
+    return dir .. "/config.yaml"
+end
+
+M._config_path = config_path -- exposed for tests
+
+-- Render the merged config from Lua + the resolved secret, write it 0600.
+-- Returns (path, host, port) or (nil, err).
+local function write_rendered_config()
+    local host, port = cc.parse_endpoint(endpoint())
+    if not host then
+        return nil, "cannot parse host:port from endpoint: " .. tostring(endpoint())
+    end
+    local c = cfg() or {}
+    local secret = require("parley.vault").get_secret(
+        require("parley.providers").get_secret_name("cliproxyapi"))
+    local rendered, overrides = cc.render({
+        host = host,
+        port = port,
+        auth_dir = c.auth_dir,
+        secret = secret,
+        config = c.config,
+    })
+    if #overrides > 0 then
+        logger.warning("cliproxy: managed host/port override raw config key(s): "
+            .. table.concat(overrides, ", "))
+    end
+    local path = config_path()
+    local f, ferr = io.open(path, "w")
+    if not f then
+        return nil, "cannot write config: " .. tostring(ferr)
+    end
+    f:write(cc.encode(rendered))
+    f:close()
+    local fs_chmod = uv.fs_chmod or vim.loop.fs_chmod
+    fs_chmod(path, tonumber("600", 8))
+    return path, host, port, secret
+end
+
+--------------------------------------------------------------------------------
+-- Spawn (detached, PID-tracked)
+--------------------------------------------------------------------------------
+
+--- Spawn the proxy detached so it outlives nvim and is shared across instances.
+--- Records the pid so stop() is scoped to a parley-spawned daemon only.
+---@param binary string
+---@param config_file string
+---@return number|nil pid, any handle_or_err
+function M.spawn(binary, config_file)
+    local handle, pid
+    handle, pid = uv.spawn(binary, {
+        args = { "-config", config_file },
+        detached = true,
+    }, function(code, _signal)
+        local rec = _spawned[pid]
+        if rec then
+            rec.exited = true
+            rec.code = code
+        end
+    end)
+    if not handle then
+        return nil, tostring(pid) -- pid carries the error message on failure
+    end
+    uv.unref(handle)
+    _spawned[pid] = { handle = handle, exited = false }
+    return pid, handle
+end
+
+--- pids of proxies parley spawned (for scoped stop()).
+---@return number[]
+function M.spawned_pids()
+    local pids = {}
+    for pid in pairs(_spawned) do
+        table.insert(pids, pid)
+    end
+    return pids
+end
+
+--- Test helper: forget all tracked spawns (does not kill them).
+function M._reset_spawned()
+    _spawned = {}
+end
+
+--------------------------------------------------------------------------------
+-- ensure_running — reuse-if-healthy, else spawn + poll; never hang
+--------------------------------------------------------------------------------
+
+local POLL_INTERVAL_MS = 250
+local POLL_BUDGET_MS = 5000
+
+local function poll_until_healthy(host, port, secret, pid, callback, on_error)
+    local deadline = uv.now() + POLL_BUDGET_MS
+    local function tick()
+        local rec = _spawned[pid]
+        if rec and rec.exited then
+            return on_error("cliproxy: process exited (code " .. tostring(rec.code)
+                .. ") right after spawn — check the binary/config")
+        end
+        M.health_probe(host, port, secret, function(state)
+            if state == "healthy" or state == "needs_login" then
+                return callback()
+            end
+            if uv.now() >= deadline then
+                return on_error("cliproxy: proxy did not become healthy within "
+                    .. (POLL_BUDGET_MS / 1000) .. "s — try :ParleyProxy status")
+            end
+            vim.defer_fn(tick, POLL_INTERVAL_MS)
+        end)
+    end
+    tick()
+end
+
+--- Ensure a healthy managed proxy is reachable, then call `callback`. On any
+--- failure call `on_error(msg)` so the dispatch path fails fast (never hangs).
+--- No-op pass-through when the feature isn't opted in.
+---@param callback fun()
+---@param on_error fun(msg: string)|nil
+function M.ensure_running(callback, on_error)
+    on_error = on_error or function() end
+    if not M.is_managed() then
+        return callback()
+    end
+
+    local path, host, port, secret = write_rendered_config()
+    if not path then
+        return on_error("cliproxy: " .. tostring(host)) -- host carries the err
+    end
+
+    M.health_probe(host, port, secret, function(state)
+        if state == "healthy" or state == "needs_login" then
+            return callback() -- reuse the already-running (brew service / other nvim)
+        end
+        if state == "client_key_mismatch" then
+            return on_error("cliproxy: client api-key mismatch — the rendered api-keys "
+                .. "do not match the bearer parley sends (check api_keys.cliproxyapi)")
+        end
+        if state == "foreign" then
+            return on_error("cliproxy: port " .. port .. " is held by a non-cliproxy process")
+        end
+        -- down → spawn our own
+        local bin = M.discover_binary()
+        if not bin then
+            return on_error("cliproxy: no cliproxy binary found — `brew install cliproxyapi`, "
+                .. "set cliproxy.binary_path, or enable auto_download (M2)")
+        end
+        local pid, err = M.spawn(bin, path)
+        if not pid then
+            return on_error("cliproxy: failed to spawn " .. bin .. ": " .. tostring(err))
+        end
+        poll_until_healthy(host, port, secret, pid, callback, on_error)
+    end)
+end
+
+--------------------------------------------------------------------------------
+-- Commands: status / start / stop / restart / login
+--------------------------------------------------------------------------------
+
+M.start = M.ensure_running
+
+--- Stop only proxies parley spawned (a reused/foreign daemon is left alone).
+---@return number killed
+function M.stop()
+    local killed = 0
+    for pid in pairs(_spawned) do
+        pcall(uv.kill, pid, "sigterm")
+        killed = killed + 1
+    end
+    _spawned = {}
+    return killed
+end
+
+--- Restart: stop our own daemon, then ensure-running (re-renders config).
+function M.restart(callback, on_error)
+    M.stop()
+    M.ensure_running(callback or function() end, on_error)
+end
+
+-- Does the on-disk rendered config differ from a fresh render of the current
+-- Lua config? Compares decoded tables (NOT encoded strings — key order is
+-- unstable across renders).
+local function config_drift()
+    local f = io.open(config_path(), "r")
+    if not f then
+        return false -- nothing rendered yet
+    end
+    local content = f:read("*a")
+    f:close()
+    local ok, on_disk = pcall(vim.json.decode, content)
+    if not ok then
+        return true
+    end
+    local host, port = cc.parse_endpoint(endpoint())
+    if not host then
+        return false
+    end
+    local c = cfg() or {}
+    local secret = require("parley.vault").get_secret(
+        require("parley.providers").get_secret_name("cliproxyapi"))
+    local fresh = cc.render({ host = host, port = port, auth_dir = c.auth_dir, secret = secret, config = c.config })
+    return not vim.deep_equal(on_disk, fresh)
+end
+
+--- Gather a status snapshot. Async (health is probed); calls cb(info).
+---@param cb fun(info: table)
+function M.status(cb)
+    local bin = M.discover_binary()
+    local c = cfg() or {}
+    local host, port = cc.parse_endpoint(endpoint())
+    local source = "none"
+    if bin then
+        source = (c.binary_path == bin) and "binary_path" or "PATH"
+    end
+    local info = {
+        managed = M.is_managed(),
+        binary = bin,
+        binary_source = source,
+        host = host,
+        port = port,
+        auth_dir = c.auth_dir,
+        config_path = config_path(),
+        spawned_by_parley = #M.spawned_pids() > 0,
+        config_drift = config_drift(),
+    }
+    if not host then
+        info.health = "unknown"
+        return cb(info)
+    end
+    local secret = require("parley.vault").get_secret(
+        require("parley.providers").get_secret_name("cliproxyapi"))
+    M.health_probe(host, port, secret, function(state)
+        info.health = state
+        cb(info)
+    end)
+end
+
+-- Per-provider login flags (NOT a `login` subcommand — confirmed Task 2.0).
+local LOGIN_FLAGS = {
+    claude = "-claude-login",
+    codex = "-codex-login",
+    ["codex-device"] = "-codex-device-login",
+    google = "-login",
+    kimi = "-kimi-login",
+    xai = "-xai-login",
+    antigravity = "-antigravity-login",
+}
+
+--- Build the argv for an interactive OAuth login for `provider`.
+--- Passes -config so login writes into parley's configured auth-dir.
+---@param provider string
+---@return string[]|nil argv, string|nil err
+function M.login_argv(provider)
+    local bin = M.discover_binary()
+    if not bin then
+        return nil, "no cliproxy binary found — `brew install cliproxyapi` or set cliproxy.binary_path"
+    end
+    local flag = LOGIN_FLAGS[provider]
+    if not flag then
+        local valid = vim.tbl_keys(LOGIN_FLAGS)
+        table.sort(valid)
+        return nil, "unknown login provider '" .. tostring(provider)
+            .. "' — valid: " .. table.concat(valid, ", ")
+    end
+    return { bin, "-config", config_path(), flag }
+end
+
 return M

--- a/lua/parley/cliproxy.lua
+++ b/lua/parley/cliproxy.lua
@@ -313,16 +313,58 @@ end
 
 M.start = M.ensure_running
 
---- Stop only proxies parley spawned (a reused/foreign daemon is left alone).
+-- PIDs listening on `port` (best-effort via lsof; empty if lsof is absent).
+local function pids_on_port(port)
+    if vim.fn.executable("lsof") ~= 1 then
+        return {}
+    end
+    local res = vim.system({ "lsof", "-nP", "-iTCP:" .. port, "-sTCP:LISTEN", "-t" }, { text = true }):wait()
+    local pids = {}
+    for s in (res.stdout or ""):gmatch("%d+") do
+        pids[#pids + 1] = tonumber(s)
+    end
+    return pids
+end
+
+-- Synchronously decide whether host:port is held by a cliproxy — same
+-- /v1/models identity as health_probe (reusing classify) — so stop() never
+-- reaps a foreign process that merely happens to hold the port. A 401
+-- (client_key_mismatch) still means a cliproxy is there, so it counts.
+local function port_holds_cliproxy(host, port, secret)
+    local args = { "curl", "-s", "-w", "\n%{http_code}", "--max-time", "2" }
+    if type(secret) == "string" and secret ~= "" then
+        table.insert(args, "-H")
+        table.insert(args, "Authorization: Bearer " .. secret)
+    end
+    table.insert(args, ("http://%s:%s/v1/models"):format(host, port))
+    local res = vim.system(args, { text = true }):wait()
+    local state = classify(res.code, res.stdout)
+    return state == "healthy" or state == "needs_login" or state == "client_key_mismatch"
+end
+
+--- Stop the managed proxy. Kills proxies this session spawned AND reaps a
+--- leftover cliproxy on the managed port from ANY session (the detached-proxy
+--- rough edge: a proxy spawned in an earlier nvim that `_spawned` can't reach).
+--- It identity-probes the port first, so a **foreign** process holding the port
+--- is left untouched.
 ---@return number killed
 function M.stop()
-    local killed = 0
+    local killed = {}
     for pid in pairs(_spawned) do
         pcall(uv.kill, pid, "sigterm")
-        killed = killed + 1
+        killed[pid] = true
     end
     _spawned = {}
-    return killed
+    local opts = render_opts()
+    if opts.host and opts.port and port_holds_cliproxy(opts.host, opts.port, opts.secret) then
+        for _, pid in ipairs(pids_on_port(opts.port)) do
+            if not killed[pid] then
+                pcall(uv.kill, pid, "sigterm")
+                killed[pid] = true
+            end
+        end
+    end
+    return vim.tbl_count(killed)
 end
 
 --- Restart: stop our own daemon, then ensure-running (re-renders config).

--- a/lua/parley/cliproxy.lua
+++ b/lua/parley/cliproxy.lua
@@ -64,6 +64,10 @@ function M.discover_binary()
             return c.binary_path
         end
     end
+    local managed = M.managed_binary() -- M2 auto-downloaded binary
+    if managed then
+        return managed
+    end
     for _, name in ipairs({ "cliproxyapi", "cli-proxy-api" }) do
         local p = vim.fn.exepath(name)
         if p ~= nil and p ~= "" then
@@ -283,9 +287,17 @@ function M.ensure_running(callback, on_error)
         end
         -- down → spawn our own
         local bin = M.discover_binary()
+        if not bin and (cfg() or {}).auto_download then
+            vim.notify("cliproxy: downloading binary (one-time)…", vim.log.levels.INFO)
+            local dlbin, derr = M.download()
+            if not dlbin then
+                return on_error("cliproxy: auto_download failed — " .. tostring(derr))
+            end
+            bin = dlbin
+        end
         if not bin then
             return on_error("cliproxy: no cliproxy binary found — `brew install cliproxyapi`, "
-                .. "set cliproxy.binary_path, or enable auto_download (M2)")
+                .. "set cliproxy.binary_path, or enable auto_download")
         end
         local pid, err = M.spawn(bin, path)
         if not pid then
@@ -410,6 +422,97 @@ function M.login_argv(provider)
     -- before any dispatch has run (best-effort; ignore render errors here).
     pcall(write_rendered_config)
     return { bin, "-config", config_path(), flag }
+end
+
+--------------------------------------------------------------------------------
+-- M2: auto_download — fetch a pinned release, checksum-verify, extract
+--------------------------------------------------------------------------------
+
+local RELEASE_BASE = "https://github.com/router-for-me/CLIProxyAPI/releases/download"
+local PINNED_VERSION = "7.1.71" -- pinned, NOT "latest" — reproducible
+
+local function bin_dir()
+    local dir = vim.fn.stdpath("data") .. "/parley/cliproxy/bin"
+    vim.fn.mkdir(dir, "p")
+    return dir
+end
+
+--- Path to the auto-downloaded binary, if present + executable.
+---@return string|nil
+function M.managed_binary()
+    local p = bin_dir() .. "/cli-proxy-api"
+    if vim.fn.executable(p) == 1 then
+        return p
+    end
+    return nil
+end
+
+local function sha256_of(path)
+    local cmd = vim.fn.executable("sha256sum") == 1
+        and { "sha256sum", path }
+        or { "shasum", "-a", "256", path }
+    local res = vim.system(cmd, { text = true }):wait()
+    return (res.stdout or ""):match("^(%x+)")
+end
+
+--- Download + checksum-verify + extract the pinned release into the managed
+--- bin dir. Synchronous (one-time setup; used by auto_download / :ParleyProxy
+--- update). Refuses to install on a checksum mismatch.
+---@param opts table|nil # { version, base_url } — base_url overridable for tests
+---@return string|nil binary_path, string|nil err
+function M.download(opts)
+    opts = opts or {}
+    local c = cfg() or {}
+    local version = opts.version or c.download_version or PINNED_VERSION
+    local base = opts.base_url or RELEASE_BASE
+    local plat = cc.platform()
+    if not plat then
+        return nil, "no published cliproxy release for this platform"
+    end
+    if plat.os == "windows" then
+        return nil, "auto_download does not support Windows (.zip) — install cliproxyapi manually"
+    end
+    local asset = cc.asset_name(version, plat)
+    local tarball_url = ("%s/v%s/%s"):format(base, version, asset)
+    local sums_url = ("%s/v%s/checksums.txt"):format(base, version)
+
+    local tmp = vim.fn.tempname() .. ".tar.gz"
+    local dl = vim.system({ "curl", "-fsSL", "-o", tmp, tarball_url }, { text = true }):wait()
+    if dl.code ~= 0 then
+        return nil, "download failed (" .. tarball_url .. "): " .. tostring(dl.stderr)
+    end
+    local sums = vim.system({ "curl", "-fsSL", sums_url }, { text = true }):wait()
+    if sums.code ~= 0 then
+        os.remove(tmp)
+        return nil, "checksums fetch failed: " .. tostring(sums.stderr)
+    end
+    local expected = cc.parse_checksums(sums.stdout or "", asset)
+    if not expected then
+        os.remove(tmp)
+        return nil, asset .. " not listed in checksums.txt"
+    end
+    local actual = sha256_of(tmp)
+    if not actual or actual ~= expected then
+        os.remove(tmp)
+        return nil, "checksum mismatch for " .. asset .. " — refusing to install (expected "
+            .. expected .. ", got " .. tostring(actual) .. ")"
+    end
+    local dir = bin_dir()
+    local ex = vim.system({ "tar", "-xzf", tmp, "-C", dir, "cli-proxy-api" }, { text = true }):wait()
+    os.remove(tmp)
+    if ex.code ~= 0 then
+        return nil, "extract failed: " .. tostring(ex.stderr)
+    end
+    local bin = dir .. "/cli-proxy-api"
+    local fs_chmod = uv.fs_chmod or vim.loop.fs_chmod
+    fs_chmod(bin, tonumber("755", 8))
+    return bin
+end
+
+--- Re-fetch the pinned binary (for :ParleyProxy update).
+---@return string|nil binary_path, string|nil err
+function M.update()
+    return M.download()
 end
 
 return M

--- a/lua/parley/cliproxy.lua
+++ b/lua/parley/cliproxy.lua
@@ -145,23 +145,26 @@ end
 
 M._config_path = config_path -- exposed for tests
 
--- Render the merged config from Lua + the resolved secret, write it 0600.
--- Returns (path, host, port) or (nil, err).
-local function write_rendered_config()
+-- Single place that gathers the render inputs (host:port from the provider
+-- endpoint, auth_dir, vault-resolved client secret, raw config passthrough).
+-- Consumed by write_rendered_config, config_drift, and status (ARCH-DRY) — add
+-- a render field here and all three pick it up.
+local function render_opts()
     local host, port = cc.parse_endpoint(endpoint())
-    if not host then
-        return nil, "cannot parse host:port from endpoint: " .. tostring(endpoint())
-    end
     local c = cfg() or {}
     local secret = require("parley.vault").get_secret(
         require("parley.providers").get_secret_name("cliproxyapi"))
-    local rendered, overrides = cc.render({
-        host = host,
-        port = port,
-        auth_dir = c.auth_dir,
-        secret = secret,
-        config = c.config,
-    })
+    return { host = host, port = port, auth_dir = c.auth_dir, secret = secret, config = c.config }
+end
+
+-- Render the merged config from Lua + the resolved secret, write it 0600.
+-- Returns (path, host, port, secret) or (nil, err).
+local function write_rendered_config()
+    local opts = render_opts()
+    if not opts.host then
+        return nil, "cannot parse host:port from endpoint: " .. tostring(endpoint())
+    end
+    local rendered, overrides = cc.render(opts)
     if #overrides > 0 then
         logger.warning("cliproxy: managed host/port override raw config key(s): "
             .. table.concat(overrides, ", "))
@@ -175,7 +178,7 @@ local function write_rendered_config()
     f:close()
     local fs_chmod = uv.fs_chmod or vim.loop.fs_chmod
     fs_chmod(path, tonumber("600", 8))
-    return path, host, port, secret
+    return path, opts.host, opts.port, opts.secret
 end
 
 --------------------------------------------------------------------------------
@@ -330,15 +333,11 @@ local function config_drift()
     if not ok then
         return true
     end
-    local host, port = cc.parse_endpoint(endpoint())
-    if not host then
+    local opts = render_opts()
+    if not opts.host then
         return false
     end
-    local c = cfg() or {}
-    local secret = require("parley.vault").get_secret(
-        require("parley.providers").get_secret_name("cliproxyapi"))
-    local fresh = cc.render({ host = host, port = port, auth_dir = c.auth_dir, secret = secret, config = c.config })
-    return not vim.deep_equal(on_disk, fresh)
+    return not vim.deep_equal(on_disk, cc.render(opts))
 end
 
 --- Gather a status snapshot. Async (health is probed); calls cb(info).
@@ -346,7 +345,7 @@ end
 function M.status(cb)
     local bin = M.discover_binary()
     local c = cfg() or {}
-    local host, port = cc.parse_endpoint(endpoint())
+    local opts = render_opts()
     local source = "none"
     if bin then
         source = (c.binary_path == bin) and "binary_path" or "PATH"
@@ -355,20 +354,18 @@ function M.status(cb)
         managed = M.is_managed(),
         binary = bin,
         binary_source = source,
-        host = host,
-        port = port,
+        host = opts.host,
+        port = opts.port,
         auth_dir = c.auth_dir,
         config_path = config_path(),
         spawned_by_parley = #M.spawned_pids() > 0,
         config_drift = config_drift(),
     }
-    if not host then
+    if not opts.host then
         info.health = "unknown"
         return cb(info)
     end
-    local secret = require("parley.vault").get_secret(
-        require("parley.providers").get_secret_name("cliproxyapi"))
-    M.health_probe(host, port, secret, function(state)
+    M.health_probe(opts.host, opts.port, opts.secret, function(state)
         info.health = state
         cb(info)
     end)
@@ -385,8 +382,18 @@ local LOGIN_FLAGS = {
     antigravity = "-antigravity-login",
 }
 
+--- The valid login providers (single source — keys of LOGIN_FLAGS), sorted.
+--- The :ParleyProxy completer uses this so it can't drift from login_argv.
+---@return string[]
+function M.login_providers()
+    local list = vim.tbl_keys(LOGIN_FLAGS)
+    table.sort(list)
+    return list
+end
+
 --- Build the argv for an interactive OAuth login for `provider`.
---- Passes -config so login writes into parley's configured auth-dir.
+--- Renders the config first so login writes into parley's configured auth-dir
+--- (not the cliproxy default), then passes -config.
 ---@param provider string
 ---@return string[]|nil argv, string|nil err
 function M.login_argv(provider)
@@ -396,11 +403,12 @@ function M.login_argv(provider)
     end
     local flag = LOGIN_FLAGS[provider]
     if not flag then
-        local valid = vim.tbl_keys(LOGIN_FLAGS)
-        table.sort(valid)
         return nil, "unknown login provider '" .. tostring(provider)
-            .. "' — valid: " .. table.concat(valid, ", ")
+            .. "' — valid: " .. table.concat(M.login_providers(), ", ")
     end
+    -- Ensure the rendered config exists so a custom auth_dir is honored even
+    -- before any dispatch has run (best-effort; ignore render errors here).
+    pcall(write_rendered_config)
     return { bin, "-config", config_path(), flag }
 end
 

--- a/lua/parley/cliproxy.lua
+++ b/lua/parley/cliproxy.lua
@@ -430,6 +430,7 @@ end
 
 local RELEASE_BASE = "https://github.com/router-for-me/CLIProxyAPI/releases/download"
 local PINNED_VERSION = "7.1.71" -- pinned, NOT "latest" — reproducible
+local BIN_NAME = "cli-proxy-api" -- the executable inside the release tarball
 
 local function bin_dir()
     local dir = vim.fn.stdpath("data") .. "/parley/cliproxy/bin"
@@ -440,7 +441,7 @@ end
 --- Path to the auto-downloaded binary, if present + executable.
 ---@return string|nil
 function M.managed_binary()
-    local p = bin_dir() .. "/cli-proxy-api"
+    local p = bin_dir() .. "/" .. BIN_NAME
     if vim.fn.executable(p) == 1 then
         return p
     end
@@ -476,12 +477,17 @@ function M.download(opts)
     local tarball_url = ("%s/v%s/%s"):format(base, version, asset)
     local sums_url = ("%s/v%s/checksums.txt"):format(base, version)
 
+    -- Bounded: download() runs synchronously on the main loop (opt-in, one-time),
+    -- so a stalled fetch must not freeze the editor indefinitely.
     local tmp = vim.fn.tempname() .. ".tar.gz"
-    local dl = vim.system({ "curl", "-fsSL", "-o", tmp, tarball_url }, { text = true }):wait()
+    local dl = vim.system({ "curl", "-fsSL", "--connect-timeout", "10", "--max-time", "300",
+        "-o", tmp, tarball_url }, { text = true }):wait()
     if dl.code ~= 0 then
+        os.remove(tmp) -- curl -o may have left a partial file
         return nil, "download failed (" .. tarball_url .. "): " .. tostring(dl.stderr)
     end
-    local sums = vim.system({ "curl", "-fsSL", sums_url }, { text = true }):wait()
+    local sums = vim.system({ "curl", "-fsSL", "--connect-timeout", "10", "--max-time", "30",
+        sums_url }, { text = true }):wait()
     if sums.code ~= 0 then
         os.remove(tmp)
         return nil, "checksums fetch failed: " .. tostring(sums.stderr)
@@ -498,12 +504,12 @@ function M.download(opts)
             .. expected .. ", got " .. tostring(actual) .. ")"
     end
     local dir = bin_dir()
-    local ex = vim.system({ "tar", "-xzf", tmp, "-C", dir, "cli-proxy-api" }, { text = true }):wait()
+    local ex = vim.system({ "tar", "-xzf", tmp, "-C", dir, BIN_NAME }, { text = true }):wait()
     os.remove(tmp)
     if ex.code ~= 0 then
         return nil, "extract failed: " .. tostring(ex.stderr)
     end
-    local bin = dir .. "/cli-proxy-api"
+    local bin = dir .. "/" .. BIN_NAME
     local fs_chmod = uv.fs_chmod or vim.loop.fs_chmod
     fs_chmod(bin, tonumber("755", 8))
     return bin

--- a/lua/parley/cliproxy.lua
+++ b/lua/parley/cliproxy.lua
@@ -1,0 +1,134 @@
+--------------------------------------------------------------------------------
+-- IO lifecycle shell for the managed cliproxyapi instance (issue #131).
+--
+-- Thin IO seam (ARCH-PURE): binary discovery, detached spawn, identity-checked
+-- health probe, reuse-if-healthy, the :ParleyProxy commands. All pure config
+-- transforms live in parley/cliproxy_config.lua and are injected here.
+--
+-- Reached from the dispatcher via the cliproxyapi adapter's pre_query hook
+-- (ARCH-DRY: the same seam copilot uses to prep before a query).
+--------------------------------------------------------------------------------
+
+local uv = vim.uv or vim.loop
+local cc = require("parley.cliproxy_config")
+local logger = require("parley.logger")
+
+local M = {}
+
+-- pid -> uv process handle for proxies PARLEY spawned (so stop() is scoped to
+-- our own daemon and never touches a reused/foreign one).
+local _spawned = {}
+
+--------------------------------------------------------------------------------
+-- Config access
+--------------------------------------------------------------------------------
+
+-- The merged user config lives on the `parley` module (init.lua merges
+-- top-level setup{} keys into M.config), NOT on this module's M.
+local function cfg()
+    local ok, parley = pcall(require, "parley")
+    if ok and parley and type(parley.config) == "table" then
+        return parley.config.cliproxy
+    end
+    return nil
+end
+
+local function endpoint()
+    local ok, parley = pcall(require, "parley")
+    if ok and parley and parley.dispatcher and parley.dispatcher.providers
+        and parley.dispatcher.providers.cliproxyapi then
+        return parley.dispatcher.providers.cliproxyapi.endpoint
+    end
+    return nil
+end
+
+--- Is the managed-proxy feature opted into?
+---@return boolean
+function M.is_managed()
+    local c = cfg()
+    return c ~= nil and c.manage == true
+end
+
+--------------------------------------------------------------------------------
+-- Binary discovery
+--------------------------------------------------------------------------------
+
+--- Locate the cliproxy binary: explicit binary_path → PATH (brew name
+--- `cliproxyapi`, then release-tarball name `cli-proxy-api`). M2 inserts the
+--- managed download dir between binary_path and PATH.
+---@return string|nil
+function M.discover_binary()
+    local c = cfg() or {}
+    if type(c.binary_path) == "string" and c.binary_path ~= "" then
+        if vim.fn.executable(c.binary_path) == 1 then
+            return c.binary_path
+        end
+    end
+    for _, name in ipairs({ "cliproxyapi", "cli-proxy-api" }) do
+        local p = vim.fn.exepath(name)
+        if p ~= nil and p ~= "" then
+            return p
+        end
+    end
+    return nil
+end
+
+--------------------------------------------------------------------------------
+-- Health probe (identity-checked)
+--------------------------------------------------------------------------------
+
+-- Classify a curl result against cliproxy's /v1/models contract (route + body
+-- shapes confirmed in issue #131 Task 2.0):
+--   down                 connection refused / timeout (no usable response)
+--   client_key_mismatch  401 (rendered api-keys != the bearer we sent)
+--   healthy              200, {object:"list", data:[non-empty]}
+--   needs_login          200, {object:"list", data:[]}  (up, no upstream login)
+--   foreign              200 but not the list shape (someone else holds the port)
+local function classify(code, stdout)
+    if code ~= 0 then
+        return "down"
+    end
+    local out = stdout or ""
+    local body, http = out:match("^(.*)\n(%d+)%s*$")
+    http = tonumber(http)
+    if http == 401 then
+        return "client_key_mismatch"
+    end
+    if http ~= 200 then
+        return "foreign"
+    end
+    local ok, decoded = pcall(vim.json.decode, body or "")
+    if ok and type(decoded) == "table" and decoded.object == "list" then
+        if type(decoded.data) == "table" and #decoded.data > 0 then
+            return "healthy"
+        end
+        return "needs_login"
+    end
+    return "foreign"
+end
+
+M._classify = classify -- exposed for unit testing
+
+--- Probe http://host:port/v1/models with the client bearer and classify.
+--- Async; calls cb(state) on the main loop.
+---@param host string
+---@param port number
+---@param secret string|nil
+---@param cb fun(state: string)
+function M.health_probe(host, port, secret, cb)
+    local url = ("http://%s:%s/v1/models"):format(host, port)
+    local args = { "curl", "-s", "-w", "\n%{http_code}", "--max-time", "2" }
+    if type(secret) == "string" and secret ~= "" then
+        table.insert(args, "-H")
+        table.insert(args, "Authorization: Bearer " .. secret)
+    end
+    table.insert(args, url)
+    vim.system(args, { text = true }, function(obj)
+        local state = classify(obj.code, obj.stdout)
+        vim.schedule(function()
+            cb(state)
+        end)
+    end)
+end
+
+return M

--- a/lua/parley/cliproxy.lua
+++ b/lua/parley/cliproxy.lua
@@ -467,6 +467,55 @@ function M.login_argv(provider)
 end
 
 --------------------------------------------------------------------------------
+-- M3: auth-failure → guided login
+--------------------------------------------------------------------------------
+
+local _login_prompt_active = false
+
+function M._reset_login_prompt() -- test helper
+    _login_prompt_active = false
+end
+
+--- On a cliproxy response, detect a missing/invalid upstream credential and
+--- prompt-and-confirm the right `:ParleyProxy login`. The provider is resolved
+--- from parley's own `oauth-model-alias` (the channel the model sits under), not
+--- from the model name. No-op for non-cliproxy providers + normal responses.
+---@param provider string
+---@param raw_response string
+function M.check_auth_failure(provider, raw_response)
+    local ok, providers = pcall(require, "parley.providers")
+    if not ok or providers.resolve_name(provider) ~= "cliproxyapi" then
+        return
+    end
+    local failed_model = cc.detect_auth_failure(raw_response)
+    if not failed_model or _login_prompt_active then
+        return
+    end
+    local c = cfg() or {}
+    local alias = type(c.config) == "table" and c.config["oauth-model-alias"] or nil
+    local login = alias and cc.resolve_login_provider(failed_model, alias) or nil
+    _login_prompt_active = true
+    vim.schedule(function()
+        if not login then
+            _login_prompt_active = false
+            vim.notify(("cliproxy: \"%s\" — unknown provider / missing auth. Add it to "
+                .. "cliproxy.config['oauth-model-alias'], or :ParleyProxy login <provider>.")
+                :format(failed_model), vim.log.levels.WARN)
+            return
+        end
+        local prefix = (require("parley").config or {}).cmd_prefix or "Parley"
+        vim.ui.select({ "Log in (" .. login .. ")", "Not now" }, {
+            prompt = ("cliproxy: \"%s\" needs the %s login."):format(failed_model, login),
+        }, function(_, idx)
+            _login_prompt_active = false
+            if idx == 1 then
+                vim.cmd(prefix .. "Proxy login " .. login)
+            end
+        end)
+    end)
+end
+
+--------------------------------------------------------------------------------
 -- M2: auto_download — fetch a pinned release, checksum-verify, extract
 --------------------------------------------------------------------------------
 

--- a/lua/parley/cliproxy.lua
+++ b/lua/parley/cliproxy.lua
@@ -139,10 +139,25 @@ end
 -- Rendered config (derived artifact)
 --------------------------------------------------------------------------------
 
--- A derived, machine-local artifact under stdpath('data') — NOT in the user's
--- dotfiles repo. The committed Lua setup{} is the source of truth.
+-- Root for derived artifacts (rendered config + auto-downloaded binary), under
+-- stdpath('data') — NOT in the user's dotfiles repo. The committed Lua setup{}
+-- is the source of truth. Tests override this so a bare PlenaryBustedFile run
+-- (no XDG_DATA_HOME redirect) can NEVER write to the operator's real dir.
+local _data_dir_override = nil
+
+local function data_root()
+    return _data_dir_override or (vim.fn.stdpath("data") .. "/parley/cliproxy")
+end
+
+--- Test seam: redirect the derived-artifact root (config + bin) to `path`.
+--- Pass nil to restore the real stdpath location.
+---@param path string|nil
+function M._set_data_dir(path)
+    _data_dir_override = path
+end
+
 local function config_path()
-    local dir = vim.fn.stdpath("data") .. "/parley/cliproxy"
+    local dir = data_root()
     vim.fn.mkdir(dir, "p")
     return dir .. "/config.yaml"
 end
@@ -524,7 +539,7 @@ local PINNED_VERSION = "7.1.71" -- pinned, NOT "latest" — reproducible
 local BIN_NAME = "cli-proxy-api" -- the executable inside the release tarball
 
 local function bin_dir()
-    local dir = vim.fn.stdpath("data") .. "/parley/cliproxy/bin"
+    local dir = data_root() .. "/bin"
     vim.fn.mkdir(dir, "p")
     return dir
 end

--- a/lua/parley/cliproxy_config.lua
+++ b/lua/parley/cliproxy_config.lua
@@ -102,6 +102,9 @@ end
 
 --- Release asset filename for a version + platform, e.g.
 --- "CLIProxyAPI_7.1.71_darwin_aarch64.tar.gz" (".zip" on Windows).
+--- NB: FreeBSD is best-effort — some releases ship freebsd/aarch64 only as a
+--- `_no-plugin` variant, so this canonical name may 404 there (download() will
+--- surface the curl error). darwin/linux are the supported targets.
 ---@param version string # e.g. "7.1.71" (no leading v)
 ---@param plat table # { os, arch } from platform()
 ---@return string

--- a/lua/parley/cliproxy_config.lua
+++ b/lua/parley/cliproxy_config.lua
@@ -75,4 +75,54 @@ function M.encode(config_table)
     return vim.json.encode(config_table)
 end
 
+--------------------------------------------------------------------------------
+-- M2: release asset resolution (pure; consumed by cliproxy.download)
+--------------------------------------------------------------------------------
+
+--- Map an os_uname() result to cliproxy's release {os, arch} naming, or nil
+--- if this platform has no published release. `uname` is injectable for tests.
+---@param uname table|nil # defaults to vim.uv.os_uname()
+---@return table|nil # { os = "darwin|linux|freebsd|windows", arch = "aarch64|amd64" }
+function M.platform(uname)
+    uname = uname or (vim.uv or vim.loop).os_uname()
+    local os_map = { Darwin = "darwin", Linux = "linux", FreeBSD = "freebsd", Windows_NT = "windows" }
+    local os_name = os_map[uname.sysname]
+    local arch
+    local m = uname.machine
+    if m == "arm64" or m == "aarch64" then
+        arch = "aarch64"
+    elseif m == "x86_64" or m == "amd64" then
+        arch = "amd64"
+    end
+    if not os_name or not arch then
+        return nil
+    end
+    return { os = os_name, arch = arch }
+end
+
+--- Release asset filename for a version + platform, e.g.
+--- "CLIProxyAPI_7.1.71_darwin_aarch64.tar.gz" (".zip" on Windows).
+---@param version string # e.g. "7.1.71" (no leading v)
+---@param plat table # { os, arch } from platform()
+---@return string
+function M.asset_name(version, plat)
+    local ext = plat.os == "windows" and "zip" or "tar.gz"
+    return ("CLIProxyAPI_%s_%s_%s.%s"):format(version, plat.os, plat.arch, ext)
+end
+
+--- Pull the sha256 for `asset` out of a checksums.txt body
+--- ("<sha256>  <filename>" per line). Returns nil if absent.
+---@param text string
+---@param asset string
+---@return string|nil
+function M.parse_checksums(text, asset)
+    for line in (text or ""):gmatch("[^\n]+") do
+        local sha, name = line:match("^(%x+)%s+%*?(%S+)$")
+        if name == asset then
+            return sha
+        end
+    end
+    return nil
+end
+
 return M

--- a/lua/parley/cliproxy_config.lua
+++ b/lua/parley/cliproxy_config.lua
@@ -1,0 +1,78 @@
+--------------------------------------------------------------------------------
+-- Pure config core for the managed cliproxyapi instance (issue #131).
+--
+-- No IO: every function here is deterministic and unit-tested without mocks
+-- (ARCH-PURE). The IO shell — binary discovery, spawn, health probe, the
+-- :ParleyProxy commands — lives in parley/cliproxy.lua and injects these.
+--------------------------------------------------------------------------------
+
+local M = {}
+
+--- Parse host:port out of a provider endpoint URL.
+--- The provider endpoint is the single source of truth for host:port
+--- (spec §"host:port — single source of truth"); everything downstream
+--- derives from it, so there is deliberately no separate `cliproxy.port` knob.
+---
+--- NB: a port-less endpoint resolves to 80/443 — it will NOT silently fall
+--- back to cliproxy's 8317 default. The canonical endpoint carries `:8317`.
+---@param endpoint string
+---@return string|nil host, number|nil port
+function M.parse_endpoint(endpoint)
+    if type(endpoint) ~= "string" then
+        return nil, nil
+    end
+    local host, port = endpoint:match("^https?://([^:/]+):(%d+)")
+    if host and port then
+        return host, tonumber(port)
+    end
+    local scheme, h = endpoint:match("^(https?)://([^:/]+)")
+    if scheme and h then
+        return h, scheme == "https" and 443 or 80
+    end
+    return nil, nil
+end
+
+--- Merge the raw `config` passthrough with parley's wiring fields and the
+--- resolved client secret. Pure — the secret is passed in already resolved;
+--- this never touches the vault (ARCH-PURE). Unknown keys pass through
+--- untouched (ARCH-DRY: we do not re-model cliproxy's schema).
+---
+--- Returns the config table plus a list of any raw-config keys it clobbered,
+--- so the IO caller can warn (keeping the *decision* pure and the *act* of
+--- warning at the boundary).
+---@param opts table # { host, port, auth_dir?, secret?, config? }
+---@return table config_table, string[] overrides
+function M.render(opts)
+    local cfg = vim.deepcopy(opts.config or {})
+    local overrides = {}
+    if cfg.host ~= nil and cfg.host ~= opts.host then
+        table.insert(overrides, "host")
+    end
+    if cfg.port ~= nil and cfg.port ~= opts.port then
+        table.insert(overrides, "port")
+    end
+    cfg.host = opts.host
+    cfg.port = opts.port
+    if opts.auth_dir ~= nil then
+        cfg["auth-dir"] = opts.auth_dir
+    end
+    if opts.secret ~= nil and opts.secret ~= "" then
+        cfg["api-keys"] = { opts.secret } -- non-empty → encodes as a JSON array
+    else
+        -- Omit, never {} — vim.json.encode({}) emits `{}` (object), which
+        -- cliproxy would read as a malformed api-keys.
+        cfg["api-keys"] = nil
+    end
+    return cfg, overrides
+end
+
+--- Emit the config as a string cliproxy's --config can read. JSON is valid
+--- YAML 1.2, so we emit JSON and skip a YAML emitter (spec §Emission; the
+--- gating task in the plan validates a real cli-proxy-api accepts it).
+---@param config_table table
+---@return string
+function M.encode(config_table)
+    return vim.json.encode(config_table)
+end
+
+return M

--- a/lua/parley/cliproxy_config.lua
+++ b/lua/parley/cliproxy_config.lua
@@ -113,6 +113,60 @@ function M.asset_name(version, plat)
     return ("CLIProxyAPI_%s_%s_%s.%s"):format(version, plat.os, plat.arch, ext)
 end
 
+--------------------------------------------------------------------------------
+-- M3: auth-failure detection + login-provider resolution
+--------------------------------------------------------------------------------
+
+--- Detect cliproxyapi's "missing/invalid upstream credential" failure in a raw
+--- response and return the model name. cliproxyapi collapses a missing-credential
+--- into `"unknown provider for model <X>"` (verified in the source:
+--- util.GetProviderName only reads the dynamic registry, so an unloaded auth
+--- makes the model unresolvable). Returns the model name, or nil.
+---@param raw_response string
+---@return string|nil model
+function M.detect_auth_failure(raw_response)
+    if type(raw_response) ~= "string" then
+        return nil
+    end
+    return raw_response:match("unknown provider for model%s+([%w%-%._]+)")
+end
+
+-- cliproxyapi's fixed channel set → the :ParleyProxy login provider it needs.
+-- The channel keys ARE the providers (cliproxyapi static catalog); vertex uses a
+-- service account (no OAuth login) so it's intentionally absent.
+local CHANNEL_LOGIN = {
+    claude = "claude",
+    codex = "codex",
+    gemini = "google",
+    ["gemini-cli"] = "google",
+    aistudio = "google",
+    kimi = "kimi",
+    antigravity = "antigravity",
+    xai = "xai",
+}
+
+--- Resolve which login a model needs, from parley's own `oauth-model-alias`
+--- config (NOT a name heuristic): find the channel whose entries include the
+--- model (by name or alias), then map channel → login provider.
+---@param model string
+---@param oauth_model_alias table # the rendered config's oauth-model-alias block
+---@return string|nil login_provider
+function M.resolve_login_provider(model, oauth_model_alias)
+    if type(model) ~= "string" or type(oauth_model_alias) ~= "table" then
+        return nil
+    end
+    for channel, entries in pairs(oauth_model_alias) do
+        if type(entries) == "table" then
+            for _, e in ipairs(entries) do
+                if type(e) == "table" and (e.name == model or e.alias == model) then
+                    return CHANNEL_LOGIN[channel]
+                end
+            end
+        end
+    end
+    return nil
+end
+
 --- Pull the sha256 for `asset` out of a checksums.txt body
 --- ("<sha256>  <filename>" per line). Returns nil if absent.
 ---@param text string

--- a/lua/parley/config.lua
+++ b/lua/parley/config.lua
@@ -127,14 +127,20 @@ local config = {
 		config = {
 			-- skip the management-panel GitHub download for faster startup
 			["remote-management"] = { ["disable-control-panel"] = true },
-			-- Route these model NAMES to the Claude OAuth credential in auth-dir
-			-- (the cliproxyapi-provider agents below use them). Without this,
-			-- cliproxyapi answers "unknown provider for model claude-…". Extend
-			-- for custom models. Verified against cliproxyapi 7.1.71.
+			-- Route model NAMES to the Claude OAuth credential in auth-dir (the
+			-- cliproxyapi-provider agents below use them). Without this,
+			-- cliproxyapi answers "unknown provider for model claude-…". Keyed by
+			-- cliproxyapi's CANONICAL channel name (`claude`) — so the key == the
+			-- provider, which is how parley resolves "which login does this model
+			-- need" on an auth failure. Extend for custom models. Channels:
+			-- claude / codex / gemini-cli / vertex / aistudio / kimi / antigravity.
+			-- Verified against cliproxyapi 7.1.71.
 			["oauth-model-alias"] = {
-				["claude-sonnet"] = { { name = "claude-sonnet-4-6", alias = "claude-sonnet-4-6", fork = true } },
-				["claude-opus"] = { { name = "claude-opus-4-8", alias = "claude-opus-4-8", fork = true } },
-				["claude-fable"] = { { name = "claude-fable-5", alias = "claude-fable-5", fork = true } },
+				["claude"] = {
+					{ name = "claude-sonnet-4-6", alias = "claude-sonnet-4-6", fork = true },
+					{ name = "claude-opus-4-8", alias = "claude-opus-4-8", fork = true },
+					{ name = "claude-fable-5", alias = "claude-fable-5", fork = true },
+				},
 			},
 		},
 	},

--- a/lua/parley/config.lua
+++ b/lua/parley/config.lua
@@ -36,7 +36,12 @@ local config = {
 		googleai = os.getenv("GOOGLEAI_API_KEY"),
 		ollama = "dummy_secret", -- ollama typically uses a dummy token for local instances
 		copilot = os.getenv("GITHUB_TOKEN"), -- for GitHub Copilot
-		cliproxyapi = os.getenv("CLIPROXYAPI_API_KEY"),
+		-- Local client↔proxy handshake token (NOT your subscription auth — that
+		-- lives in the cliproxy auth-dir via :ParleyProxy login). In managed mode
+		-- parley renders this into the proxy's api-keys AND sends it as the bearer,
+		-- so a fixed local default works out-of-the-box over loopback. Override
+		-- via the env var if you point at a proxy that expects a specific key.
+		cliproxyapi = os.getenv("CLIPROXYAPI_API_KEY") or "parley-local",
 	},
 
 	-- Google Drive OAuth configuration for @@ URL references
@@ -98,23 +103,25 @@ local config = {
 		},
 	},
 
-	-- OPT-IN: let parley manage the cliproxyapi process itself (issue #131).
-	-- Off by default. When enabled, parley renders config.yaml from this block
-	-- on demand, and lazily starts / reuses / health-checks the proxy whenever a
-	-- cliproxyapi-provider agent is used. host:port come from the
-	-- providers.cliproxyapi.endpoint above (single source of truth). The
-	-- generated config is a derived artifact under stdpath('data') — your
-	-- committed Lua is the source of truth; secrets never land in it.
-	-- One manual, per-machine step: `:ParleyProxy login <provider>` (OAuth).
-	-- cliproxy = {
-	--   manage = true,
-	--   auth_dir = "~/.cli-proxy-api",   -- where OAuth tokens are stored (machine-local)
-	--   binary_path = nil,               -- optional; else `cliproxyapi`/`cli-proxy-api` on PATH
-	--   config = {                       -- raw cliproxyapi schema (passed through verbatim)
-	--     -- e.g. avoid the management-panel download for faster startup:
-	--     ["remote-management"] = { ["disable-control-panel"] = true },
-	--   },
-	-- },
+	-- Let parley manage the cliproxyapi process itself (issue #131). parley
+	-- renders config.yaml from this block on demand and lazily starts / reuses /
+	-- health-checks the proxy whenever a cliproxyapi-provider agent is used. It
+	-- is DORMANT unless such an agent runs, and it REUSES an already-running proxy
+	-- (e.g. `brew services`) if one answers healthy — so this default is safe even
+	-- if you don't use cliproxyapi. host:port come from providers.cliproxyapi.endpoint
+	-- (single source of truth); the generated config is a derived 0600 artifact
+	-- under stdpath('data') — your committed Lua is the source of truth, no secret
+	-- in it. A new machine needs only: `brew install cliproxyapi` + one-time
+	-- `:ParleyProxy login <provider>` (OAuth). Set manage=false to opt out.
+	cliproxy = {
+		manage = true,
+		-- auth_dir defaults to cliproxy's own ~/.cli-proxy-api when omitted.
+		-- binary_path = nil,  -- else `cliproxyapi` / `cli-proxy-api` on PATH
+		config = {
+			-- skip the management-panel GitHub download for faster startup
+			["remote-management"] = { ["disable-control-panel"] = true },
+		},
+	},
 
 	-- prefix for all commands
 	cmd_prefix = "Parley",

--- a/lua/parley/config.lua
+++ b/lua/parley/config.lua
@@ -117,13 +117,25 @@ local config = {
 		manage = true,
 		-- auth_dir defaults to cliproxy's own ~/.cli-proxy-api when omitted.
 		-- binary_path = nil,  -- else `cliproxyapi` / `cli-proxy-api` on PATH
-		-- auto_download = true,  -- opt-in: if no binary is found, fetch a pinned,
+		auto_download = true,  -- opt-in: if no binary is found, fetch a pinned,
 		--   checksum-verified release into stdpath('data') (skips `brew install`).
 		--   Left off by default — auto-fetching a binary is an explicit choice.
 		--   `:ParleyProxy update` re-fetches; `download_version` overrides the pin.
+		-- Raw cliproxyapi config, rendered into the proxy's config.yaml. This is
+		-- where parley drives cliproxyapi as a wrapped dependency — tinker here in
+		-- Lua instead of hand-editing /opt/homebrew/etc/cliproxyapi.conf.
 		config = {
 			-- skip the management-panel GitHub download for faster startup
 			["remote-management"] = { ["disable-control-panel"] = true },
+			-- Route these model NAMES to the Claude OAuth credential in auth-dir
+			-- (the cliproxyapi-provider agents below use them). Without this,
+			-- cliproxyapi answers "unknown provider for model claude-…". Extend
+			-- for custom models. Verified against cliproxyapi 7.1.71.
+			["oauth-model-alias"] = {
+				["claude-sonnet"] = { { name = "claude-sonnet-4-6", alias = "claude-sonnet-4-6", fork = true } },
+				["claude-opus"] = { { name = "claude-opus-4-8", alias = "claude-opus-4-8", fork = true } },
+				["claude-fable"] = { { name = "claude-fable-5", alias = "claude-fable-5", fork = true } },
+			},
 		},
 	},
 
@@ -233,7 +245,7 @@ local config = {
 		{
 			provider = "anthropic",
 			name = "ToolOpus",
-			model = { model = "claude-opus-4-8", temperature = 0.8 },
+			model = { model = "claude-opus-4-8" },
 			system_prompt = require("parley.defaults").chat_system_prompt,
 			tools = {"@readonly"},
 			-- Optional: defaults applied at setup time when absent

--- a/lua/parley/config.lua
+++ b/lua/parley/config.lua
@@ -117,10 +117,12 @@ local config = {
 		manage = true,
 		-- auth_dir defaults to cliproxy's own ~/.cli-proxy-api when omitted.
 		-- binary_path = nil,  -- else `cliproxyapi` / `cli-proxy-api` on PATH
-		auto_download = true,  -- opt-in: if no binary is found, fetch a pinned,
+		auto_download = true,  -- if no cliproxy binary is found, fetch a pinned,
 		--   checksum-verified release into stdpath('data') (skips `brew install`).
-		--   Left off by default — auto-fetching a binary is an explicit choice.
-		--   `:ParleyProxy update` re-fetches; `download_version` overrides the pin.
+		--   ON in this config. NOTE: auto-fetching an executable is a trust
+		--   decision — a general distribution may prefer to comment this out (the
+		--   original opt-in default; see issue #131 spec). `:ParleyProxy update`
+		--   re-fetches; `download_version` overrides the pin.
 		-- Raw cliproxyapi config, rendered into the proxy's config.yaml. This is
 		-- where parley drives cliproxyapi as a wrapped dependency — tinker here in
 		-- Lua instead of hand-editing /opt/homebrew/etc/cliproxyapi.conf.

--- a/lua/parley/config.lua
+++ b/lua/parley/config.lua
@@ -391,7 +391,7 @@ local config = {
 	-- if you want more real estate in your chat files and don't need the helper text
 	-- chat_template = require("parley.defaults").short_chat_template,
 	-- chat topic generation prompt
-	chat_topic_gen_prompt = "Summarize the topic of our conversation above"
+	chat_topic_gen_prompt = "Write a 3-5 word topic for the conversation below"
 		.. " in two or three words. Respond only with those words.",
 	-- chat topic model (string with model name or table with model name and parameters)
 	-- explicitly confirm deletion of a chat file

--- a/lua/parley/config.lua
+++ b/lua/parley/config.lua
@@ -98,6 +98,24 @@ local config = {
 		},
 	},
 
+	-- OPT-IN: let parley manage the cliproxyapi process itself (issue #131).
+	-- Off by default. When enabled, parley renders config.yaml from this block
+	-- on demand, and lazily starts / reuses / health-checks the proxy whenever a
+	-- cliproxyapi-provider agent is used. host:port come from the
+	-- providers.cliproxyapi.endpoint above (single source of truth). The
+	-- generated config is a derived artifact under stdpath('data') — your
+	-- committed Lua is the source of truth; secrets never land in it.
+	-- One manual, per-machine step: `:ParleyProxy login <provider>` (OAuth).
+	-- cliproxy = {
+	--   manage = true,
+	--   auth_dir = "~/.cli-proxy-api",   -- where OAuth tokens are stored (machine-local)
+	--   binary_path = nil,               -- optional; else `cliproxyapi`/`cli-proxy-api` on PATH
+	--   config = {                       -- raw cliproxyapi schema (passed through verbatim)
+	--     -- e.g. avoid the management-panel download for faster startup:
+	--     ["remote-management"] = { ["disable-control-panel"] = true },
+	--   },
+	-- },
+
 	-- prefix for all commands
 	cmd_prefix = "Parley",
 	-- optional curl parameters (for proxy, etc.)

--- a/lua/parley/config.lua
+++ b/lua/parley/config.lua
@@ -117,6 +117,10 @@ local config = {
 		manage = true,
 		-- auth_dir defaults to cliproxy's own ~/.cli-proxy-api when omitted.
 		-- binary_path = nil,  -- else `cliproxyapi` / `cli-proxy-api` on PATH
+		-- auto_download = true,  -- opt-in: if no binary is found, fetch a pinned,
+		--   checksum-verified release into stdpath('data') (skips `brew install`).
+		--   Left off by default — auto-fetching a binary is an explicit choice.
+		--   `:ParleyProxy update` re-fetches; `download_version` overrides the pin.
 		config = {
 			-- skip the management-panel GitHub download for faster startup
 			["remote-management"] = { ["disable-control-panel"] = true },

--- a/lua/parley/dispatcher.lua
+++ b/lua/parley/dispatcher.lua
@@ -382,12 +382,24 @@ end
 ---@param on_exit function | nil # optional on_exit handler
 ---@param callback function | nil # optional callback handler
 ---@param on_progress function | nil # optional progress/status handler
-D.query = function(buf, provider, payload, handler, on_exit, callback, on_progress)
+--- @param on_abort function | nil # optional abort handler. When an adapter's
+---   pre_query reports an error (e.g. the managed cliproxy can't be started),
+---   the dispatcher invokes on_abort(msg) INSTEAD of running the query — the
+---   caller uses it to tear down qid-free pre-query state (spinner, inserted
+---   blocks, in-flight guards) so the request fails fast instead of hanging.
+---   Additive + backward compatible: a one-arg pre_query (e.g. copilot) simply
+---   ignores the error callback the dispatcher passes it.
+D.query = function(buf, provider, payload, handler, on_exit, callback, on_progress, on_abort)
 	local adapter = providers.get(provider)
 	if adapter.pre_query then
 		return vault.run_with_secret(provider, function()
 			adapter.pre_query(function()
 				query(buf, provider, payload, handler, on_exit, callback, on_progress)
+			end, function(msg)
+				logger.error("pre_query abort [" .. tostring(provider) .. "]: " .. tostring(msg))
+				if type(on_abort) == "function" then
+					on_abort(msg)
+				end
 			end)
 		end)
 	end

--- a/lua/parley/dispatcher.lua
+++ b/lua/parley/dispatcher.lua
@@ -314,6 +314,12 @@ local query = function(buf, provider, payload, handler, on_exit, callback, on_pr
 					end
 				end
 
+				-- M3 (#131): detect a managed-cliproxy missing/invalid-credential
+				-- failure and offer the right :ParleyProxy login.
+				pcall(function()
+					require("parley.cliproxy").check_auth_failure(qt.provider, qt.raw_response)
+				end)
+
 				-- optional on_exit handler
 				if type(on_exit) == "function" then
 					on_exit(qid)

--- a/lua/parley/init.lua
+++ b/lua/parley/init.lua
@@ -293,7 +293,7 @@ local show_keybindings
 --- into — `status` just reports `managed: false`.
 ---@param prefix string # M.config.cmd_prefix (e.g. "Parley")
 M.register_proxy_command = function(prefix)
-	local SUBS = { "status", "start", "stop", "restart", "login" }
+	local SUBS = { "status", "start", "stop", "restart", "login", "update" }
 
 	vim.api.nvim_create_user_command(prefix .. "Proxy", function(params)
 		local cliproxy = require("parley.cliproxy")
@@ -322,6 +322,14 @@ M.register_proxy_command = function(prefix)
 		elseif sub == "stop" then
 			local n = cliproxy.stop()
 			vim.notify("cliproxy: stopped " .. n .. " parley-spawned proxy(ies)", vim.log.levels.INFO)
+		elseif sub == "update" then
+			vim.notify("cliproxy: downloading pinned release…", vim.log.levels.INFO)
+			local bin, err = cliproxy.update()
+			if bin then
+				vim.notify("cliproxy: updated → " .. bin, vim.log.levels.INFO)
+			else
+				vim.notify("cliproxy: update failed — " .. tostring(err), vim.log.levels.ERROR)
+			end
 		elseif sub == "restart" then
 			cliproxy.restart(function()
 				vim.notify("cliproxy: restarted", vim.log.levels.INFO)

--- a/lua/parley/init.lua
+++ b/lua/parley/init.lua
@@ -293,7 +293,6 @@ local show_keybindings
 --- into — `status` just reports `managed: false`.
 ---@param prefix string # M.config.cmd_prefix (e.g. "Parley")
 M.register_proxy_command = function(prefix)
-	local LOGIN_PROVIDERS = { "claude", "codex", "codex-device", "google", "kimi", "xai", "antigravity" }
 	local SUBS = { "status", "start", "stop", "restart", "login" }
 
 	vim.api.nvim_create_user_command(prefix .. "Proxy", function(params)
@@ -337,7 +336,7 @@ M.register_proxy_command = function(prefix)
 			end
 			-- Interactive OAuth — run in a terminal split so the URL/flow is visible.
 			vim.cmd("botright new")
-			vim.fn.termopen(argv)
+			vim.fn.jobstart(argv, { term = true })
 			vim.cmd("startinsert")
 		else
 			vim.notify("usage: " .. prefix .. "Proxy {status|start|stop|restart|login <provider>}", vim.log.levels.WARN)
@@ -352,7 +351,7 @@ M.register_proxy_command = function(prefix)
 				end, list)
 			end
 			if line:match("Proxy%s+login%s+%S*$") then
-				return starts(LOGIN_PROVIDERS)
+				return starts(require("parley.cliproxy").login_providers())
 			end
 			return starts(SUBS)
 		end,

--- a/lua/parley/init.lua
+++ b/lua/parley/init.lua
@@ -288,6 +288,77 @@ end
 -- Forward declaration so setup() closure can reference it (defined after setup())
 local show_keybindings
 
+--- Register `:<prefix>Proxy <subcommand>` to manage the optional bundled
+--- cliproxyapi instance (issue #131). Harmless when the feature isn't opted
+--- into — `status` just reports `managed: false`.
+---@param prefix string # M.config.cmd_prefix (e.g. "Parley")
+M.register_proxy_command = function(prefix)
+	local LOGIN_PROVIDERS = { "claude", "codex", "codex-device", "google", "kimi", "xai", "antigravity" }
+	local SUBS = { "status", "start", "stop", "restart", "login" }
+
+	vim.api.nvim_create_user_command(prefix .. "Proxy", function(params)
+		local cliproxy = require("parley.cliproxy")
+		local sub = params.fargs[1] or "status"
+		local arg = params.fargs[2]
+		if sub == "status" then
+			cliproxy.status(function(info)
+				vim.notify(table.concat({
+					"cliproxy status",
+					"  managed:       " .. tostring(info.managed),
+					"  health:        " .. tostring(info.health),
+					"  binary:        " .. tostring(info.binary) .. " (" .. info.binary_source .. ")",
+					"  endpoint:      " .. tostring(info.host) .. ":" .. tostring(info.port),
+					"  auth-dir:      " .. tostring(info.auth_dir),
+					"  config:        " .. tostring(info.config_path),
+					"  spawned by us: " .. tostring(info.spawned_by_parley),
+					"  config drift:  " .. tostring(info.config_drift),
+				}, "\n"), vim.log.levels.INFO)
+			end)
+		elseif sub == "start" then
+			cliproxy.start(function()
+				vim.notify("cliproxy: running", vim.log.levels.INFO)
+			end, function(msg)
+				vim.notify(msg, vim.log.levels.ERROR)
+			end)
+		elseif sub == "stop" then
+			local n = cliproxy.stop()
+			vim.notify("cliproxy: stopped " .. n .. " parley-spawned proxy(ies)", vim.log.levels.INFO)
+		elseif sub == "restart" then
+			cliproxy.restart(function()
+				vim.notify("cliproxy: restarted", vim.log.levels.INFO)
+			end, function(msg)
+				vim.notify(msg, vim.log.levels.ERROR)
+			end)
+		elseif sub == "login" then
+			local argv, err = cliproxy.login_argv(arg)
+			if not argv then
+				vim.notify(err, vim.log.levels.ERROR)
+				return
+			end
+			-- Interactive OAuth — run in a terminal split so the URL/flow is visible.
+			vim.cmd("botright new")
+			vim.fn.termopen(argv)
+			vim.cmd("startinsert")
+		else
+			vim.notify("usage: " .. prefix .. "Proxy {status|start|stop|restart|login <provider>}", vim.log.levels.WARN)
+		end
+	end, {
+		nargs = "*",
+		desc = "Manage the optional bundled cliproxyapi proxy",
+		complete = function(arglead, line)
+			local function starts(list)
+				return vim.tbl_filter(function(v)
+					return v:find(arglead, 1, true) == 1
+				end, list)
+			end
+			if line:match("Proxy%s+login%s+%S*$") then
+				return starts(LOGIN_PROVIDERS)
+			end
+			return starts(SUBS)
+		end,
+	})
+end
+
 -- setup function
 M._setup_called = false
 ---@param opts the one returned from config.lua, it can come from several sources, either fully specified
@@ -597,6 +668,9 @@ M.setup = function(opts)
 			M.logger.error("The hook '" .. hook .. "' does not exist.")
 		end)
 	end
+
+	-- :ParleyProxy <subcommand> — manage the optional bundled cliproxyapi (#131)
+	M.register_proxy_command(M.config.cmd_prefix)
 
 	-- Register all global keymaps from the keybinding registry
 	kb_registry.register_global(

--- a/lua/parley/memory_prefs.lua
+++ b/lua/parley/memory_prefs.lua
@@ -259,6 +259,11 @@ M.generate_preferences = function(buckets, callback)
 				_parley.logger.warning("memory_prefs: empty response for tag [" .. tag .. "]")
 			end
 			process_next()
+		end, nil, function(msg)
+			-- Abort teardown (#131): if the managed cliproxy can't start, skip
+			-- this tag and keep the batch moving instead of silently stalling.
+			_parley.logger.warning("memory_prefs: tag [" .. tag .. "] aborted: " .. tostring(msg))
+			process_next()
 		end)
 	end
 

--- a/lua/parley/providers.lua
+++ b/lua/parley/providers.lua
@@ -1102,6 +1102,19 @@ cliproxyapi.parse_usage = function(raw_response)
     return anthropic.parse_usage(raw_response)
 end
 
+-- Managed-proxy hook (issue #131). Reuses the dispatcher's existing pre_query
+-- seam (the one copilot uses to refresh its bearer) — no new dispatcher
+-- branch. When the user opts into managing the proxy, ensure it's running
+-- before the query; on failure drive the abort channel so the chat fails fast
+-- instead of hanging. No-op (immediate on_success) when not opted in.
+cliproxyapi.pre_query = function(on_success, on_error)
+    local ok, cliproxy = pcall(require, "parley.cliproxy")
+    if not ok or not cliproxy.is_managed() then
+        return on_success() -- bring-your-own / feature off
+    end
+    cliproxy.ensure_running(on_success, on_error or function() end)
+end
+
 --------------------------------------------------------------------------------
 -- Azure adapter (extends openai)
 --------------------------------------------------------------------------------

--- a/lua/parley/skill_runner.lua
+++ b/lua/parley/skill_runner.lua
@@ -328,6 +328,13 @@ end
 local _in_flight = {}
 local MAX_RESUBMITS = 3
 
+--- Test helper: is a skill run in flight for `buf`? (#131 abort-teardown test)
+---@param buf number
+---@return boolean
+function M.is_in_flight(buf)
+    return _in_flight[buf] == true
+end
+
 --- Run a skill on the current buffer.
 --- @param buf number  buffer handle
 --- @param skill table  skill definition

--- a/lua/parley/skill_runner.lua
+++ b/lua/parley/skill_runner.lua
@@ -461,6 +461,16 @@ function M.run(buf, skill, args, _resubmit_count)
     local chars_received = 0
     local last_progress = 0
 
+    -- Abort teardown (#131): clear the in-flight guard if the managed cliproxy
+    -- can't start, else this buffer's skill runs are blocked forever (the guard
+    -- is otherwise only cleared in the qid-coupled on_exit, which never fires).
+    local function on_abort(msg)
+        _in_flight[buf] = nil
+        vim.schedule(function()
+            vim.notify("Skill " .. skill.name .. ": " .. tostring(msg), vim.log.levels.WARN)
+        end)
+    end
+
     -- Step 7: headless LLM call
     dispatcher.query(
         nil, agent.provider, payload,
@@ -539,7 +549,9 @@ function M.run(buf, skill, args, _resubmit_count)
                 end
             end)
         end,
-        nil
+        nil,
+        nil,
+        on_abort
     )
 end
 

--- a/tests/fixtures/fake_cliproxy
+++ b/tests/fixtures/fake_cliproxy
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Process-level fake of cliproxyapi for issue #131 lifecycle tests.
+
+A real subprocess speaking the `/v1/models` identity protocol parley probes,
+so the lifecycle tests exercise spawn / health-probe / reuse against an actual
+HTTP server rather than function mocks (AGENTS.md external-service rule).
+
+Invocation mirrors the real binary closely enough for the module to spawn it:
+    fake_cliproxy -config <path.yaml>        # reads `port` from the JSON config
+    fake_cliproxy --port <p> [--mode <m>]    # direct, for health_probe tests
+
+Mode is taken from --mode or the PARLEY_FAKE_MODE env var (default: healthy),
+so the module's spawn path (which only passes `-config <path>`) can still
+select a behavior by setting the env before spawning.
+
+Modes:
+  healthy              200 {"object":"list","data":[{"id":"claude-x"}]}
+  needs_login          200 {"object":"list","data":[]}
+  client_key_mismatch  401
+  foreign              200 {"hello":"i am not cliproxy"}
+  slow                 accept the connection, never respond
+  crash                exit(1) immediately on startup
+"""
+import json
+import os
+import sys
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+def parse_args(argv):
+    port = None
+    mode = os.environ.get("PARLEY_FAKE_MODE", "healthy")
+    i = 0
+    while i < len(argv):
+        a = argv[i]
+        if a in ("-config", "--config"):
+            with open(argv[i + 1]) as f:
+                port = int(json.load(f).get("port"))
+            i += 2
+        elif a == "--port":
+            port = int(argv[i + 1])
+            i += 2
+        elif a == "--mode":
+            mode = argv[i + 1]
+            i += 2
+        else:
+            i += 1
+    return port, mode
+
+
+def main():
+    port, mode = parse_args(sys.argv[1:])
+    if mode == "crash":
+        sys.stderr.write("fake_cliproxy: crash mode — exiting\n")
+        sys.exit(1)
+    if port is None:
+        sys.stderr.write("fake_cliproxy: no port given\n")
+        sys.exit(2)
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, *_a):
+            pass
+
+        def _json(self, status, obj):
+            body = json.dumps(obj).encode()
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_GET(self):
+            if mode == "slow":
+                time.sleep(30)
+                return
+            if self.path.startswith("/v1/models"):
+                if mode == "client_key_mismatch":
+                    self._json(401, {"error": "unauthorized"})
+                elif mode == "foreign":
+                    self._json(200, {"hello": "i am not cliproxy"})
+                elif mode == "needs_login":
+                    self._json(200, {"object": "list", "data": []})
+                else:  # healthy
+                    self._json(200, {"object": "list", "data": [{"id": "claude-x"}]})
+                return
+            self.send_response(404)
+            self.end_headers()
+
+    HTTPServer(("127.0.0.1", port), Handler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/cliproxy_auth_login_spec.lua
+++ b/tests/integration/cliproxy_auth_login_spec.lua
@@ -3,6 +3,7 @@
 
 local parley = require("parley")
 local cliproxy = require("parley.cliproxy")
+cliproxy._set_data_dir(vim.fn.tempname()) -- never touch the real ~/.local/share/nvim
 
 local MANAGED = {
     cliproxy = {
@@ -64,6 +65,26 @@ describe("cliproxy.check_auth_failure", function()
         cliproxy.check_auth_failure("cliproxyapi", 'data: {"choices":[{"delta":{"content":"hi"}}]}')
         vim.wait(150, function() return false end)
         assert.is_false(prompted)
+    end)
+
+    it("WARNs (no prompt) when the model isn't in any oauth-model-alias channel", function()
+        parley.config = vim.deepcopy(MANAGED) -- alias only has claude-opus-4-8
+        local prompted, notified = false, nil
+        vim.ui.select = function()
+            prompted = true
+        end
+        local saved_notify = vim.notify
+        vim.notify = function(msg, lvl)
+            notified = { msg = msg, lvl = lvl }
+        end
+        cliproxy.check_auth_failure("cliproxyapi",
+            '{"error":{"message":"unknown provider for model some-unknown-model"}}')
+        vim.wait(300, function() return notified ~= nil end, 10)
+        vim.notify = saved_notify
+        assert.is_false(prompted) -- couldn't resolve a login → no prompt
+        assert.is_truthy(notified)
+        assert.equals(vim.log.levels.WARN, notified.lvl)
+        assert.is_truthy(notified.msg:find("some%-unknown%-model"))
     end)
 
     it("is a no-op for a non-cliproxy provider", function()

--- a/tests/integration/cliproxy_auth_login_spec.lua
+++ b/tests/integration/cliproxy_auth_login_spec.lua
@@ -1,0 +1,77 @@
+-- M3 (#131): on a cliproxy missing/invalid-credential failure, prompt the right
+-- :ParleyProxy login — resolved from parley's oauth-model-alias, not the name.
+
+local parley = require("parley")
+local cliproxy = require("parley.cliproxy")
+
+local MANAGED = {
+    cliproxy = {
+        manage = true,
+        config = {
+            ["oauth-model-alias"] = {
+                claude = { { name = "claude-opus-4-8", alias = "claude-opus-4-8", fork = true } },
+            },
+        },
+    },
+}
+
+describe("cliproxy.check_auth_failure", function()
+    local saved_config, saved_select
+
+    before_each(function()
+        saved_config = parley.config
+        saved_select = vim.ui.select
+        cliproxy._reset_login_prompt()
+    end)
+    after_each(function()
+        parley.config = saved_config
+        vim.ui.select = saved_select
+        cliproxy._reset_login_prompt()
+    end)
+
+    it("prompts the matching login on a cliproxy 'unknown provider' failure", function()
+        parley.config = vim.deepcopy(MANAGED)
+        local prompt
+        vim.ui.select = function(_items, opts, cb)
+            prompt = opts.prompt
+            cb(nil, 2) -- "Not now" — don't actually run the login command in the test
+        end
+        cliproxy.check_auth_failure("cliproxyapi",
+            '{"error":{"message":"unknown provider for model claude-opus-4-8","type":"server_error"}}')
+        vim.wait(500, function() return prompt ~= nil end, 10)
+        assert.is_truthy(prompt)
+        assert.is_truthy(prompt:find("claude")) -- resolved claude channel → claude login
+    end)
+
+    it("resolves the alias even when keyed by the canonical channel only", function()
+        -- the default ships `claude` as the channel key; a model under it resolves
+        parley.config = vim.deepcopy(MANAGED)
+        local prompt
+        vim.ui.select = function(_items, opts, cb)
+            prompt = opts.prompt
+            cb(nil, 2)
+        end
+        cliproxy.check_auth_failure("cliproxyapi",
+            '{"error":{"message":"unknown provider for model claude-opus-4-8"}}')
+        vim.wait(500, function() return prompt ~= nil end, 10)
+        assert.is_truthy(prompt and prompt:find("claude"))
+    end)
+
+    it("is a no-op on a normal streamed response", function()
+        parley.config = vim.deepcopy(MANAGED)
+        local prompted = false
+        vim.ui.select = function() prompted = true end
+        cliproxy.check_auth_failure("cliproxyapi", 'data: {"choices":[{"delta":{"content":"hi"}}]}')
+        vim.wait(150, function() return false end)
+        assert.is_false(prompted)
+    end)
+
+    it("is a no-op for a non-cliproxy provider", function()
+        parley.config = vim.deepcopy(MANAGED)
+        local prompted = false
+        vim.ui.select = function() prompted = true end
+        cliproxy.check_auth_failure("openai", '{"error":{"message":"unknown provider for model x"}}')
+        vim.wait(150, function() return false end)
+        assert.is_false(prompted)
+    end)
+end)

--- a/tests/integration/cliproxy_caller_teardown_spec.lua
+++ b/tests/integration/cliproxy_caller_teardown_spec.lua
@@ -1,0 +1,169 @@
+-- Per-caller on_abort teardown tests (issue #131, boundary-review Important #3).
+--
+-- The e2e spec proves the abort CHAIN reaches on_abort via a spy; these drive
+-- the REAL teardown bodies at each D.query caller so an arg-position regression
+-- or a collapse_empty_answer bug is actually caught.
+
+local uv = vim.uv or vim.loop
+local FAKE = vim.fn.getcwd() .. "/tests/fixtures/fake_cliproxy"
+
+local tmp_dir = (os.getenv("TMPDIR") or "/tmp") .. "/parley-cliproxy-teardown-" .. os.time()
+vim.fn.mkdir(tmp_dir, "p")
+
+local parley = require("parley")
+parley.setup({
+    chat_dir = tmp_dir,
+    state_dir = tmp_dir .. "/state",
+    providers = {},
+    api_keys = {},
+})
+
+local cliproxy = require("parley.cliproxy")
+local vault = require("parley.vault")
+
+local started = {}
+
+local function free_port()
+    local s = uv.new_tcp()
+    s:bind("127.0.0.1", 0)
+    local port = s:getsockname().port
+    s:close()
+    return port
+end
+
+local function start_fake(port, mode)
+    local handle, pid = uv.spawn(FAKE, { args = { "--port", tostring(port), "--mode", mode } }, function() end)
+    assert(handle, "spawn fake")
+    table.insert(started, pid)
+    vim.wait(5000, function()
+        local ok = false
+        local c = uv.new_tcp()
+        c:connect("127.0.0.1", port, function(err)
+            ok = err == nil
+            c:close()
+        end)
+        vim.wait(100, function() return false end)
+        return ok
+    end, 50)
+    return pid
+end
+
+describe("cliproxy on_abort teardown per caller", function()
+    after_each(function()
+        for _, pid in ipairs(started) do
+            pcall(uv.kill, pid, "sigkill")
+        end
+        for _, pid in ipairs(cliproxy.spawned_pids()) do
+            pcall(uv.kill, pid, "sigkill")
+        end
+        cliproxy._reset_spawned()
+        started = {}
+        parley.config.cliproxy = nil
+    end)
+
+    -- memory_prefs: real chain — a foreign proxy aborts each tag, process_next
+    -- must keep the batch moving so the callback still fires (no stall).
+    it("memory_prefs advances the batch past aborted tags", function()
+        local port = free_port()
+        start_fake(port, "foreign")
+        parley.dispatcher.providers.cliproxyapi = {
+            endpoint = ("http://127.0.0.1:%d/v1/chat/completions"):format(port),
+        }
+        vault.add_secret("cliproxyapi", "testkey")
+        parley.config.cliproxy = { manage = true, binary_path = FAKE }
+
+        local saved_get_agent = parley.get_agent
+        parley.get_agent = function()
+            return { provider = "cliproxyapi", model = { model = "claude-x" } }
+        end
+
+        local done
+        require("parley.memory_prefs").generate_preferences(
+            { topicA = { "s1" }, topicB = { "s2" } },
+            function(prefs) done = prefs end
+        )
+        vim.wait(9000, function() return done ~= nil end, 20)
+        parley.get_agent = saved_get_agent
+
+        assert.is_truthy(done) -- callback fired → on_abort → process_next past BOTH tags
+    end)
+
+    -- chat_respond main path: mock D.query to invoke the real on_abort (arg 8);
+    -- assert it's wired at the right position AND collapses the inserted answer
+    -- block (default, non-web-search path — the round-2 gate's demanded test).
+    it("chat_respond on_abort collapses the inserted empty answer block", function()
+        -- filename needs a timestamp format to pass not_chat validation
+        local test_file = tmp_dir .. "/2026-03-01-abort-" .. os.time() .. ".md"
+        vim.fn.writefile({ "", "# topic: t", "- file: x.md", "---", "", "💬: What is Lua?" }, test_file)
+        vim.cmd("edit " .. test_file)
+        local buf = vim.api.nvim_get_current_buf()
+        vim.api.nvim_win_set_cursor(0, { 6, 0 }) -- on the 💬 question line
+
+        local saved_query = parley.dispatcher.query
+        local mock_called, saw_fn, lines_at_query = false, false, nil
+        parley.dispatcher.query = function(_b, _p, _pl, _h, _oe, _cb, _op, on_abort)
+            mock_called = true
+            saw_fn = type(on_abort) == "function"
+            lines_at_query = vim.api.nvim_buf_line_count(buf)
+            if on_abort then on_abort("test abort") end
+        end
+        local notes = {}
+        local saved_notify = vim.notify
+        vim.notify = function(msg, level)
+            table.insert(notes, { msg = msg, level = level })
+        end
+
+        pcall(function() parley.chat_respond({ range = 0 }) end)
+        vim.wait(1000, function()
+            return vim.tbl_contains(vim.tbl_map(function(n) return n.msg end, notes), "test abort")
+        end, 10)
+
+        parley.dispatcher.query = saved_query
+        vim.notify = saved_notify
+
+        assert.is_true(mock_called, "dispatcher.query mock was not reached") -- respond got to the query
+        assert.is_true(saw_fn) -- on_abort passed at arg position 8
+        assert.is_truthy(lines_at_query) -- the placeholder was inserted before the query
+        assert.is_truthy(vim.tbl_contains(vim.tbl_map(function(n) return n.msg end, notes), "test abort"))
+        local lines_after = vim.api.nvim_buf_line_count(buf)
+        assert.is_truthy(lines_after < lines_at_query) -- collapse removed the empty answer block
+    end)
+
+    -- skill_runner: mock D.query to invoke the real on_abort (arg 8); assert the
+    -- _in_flight guard is cleared so the buffer isn't blocked forever.
+    it("skill_runner on_abort clears the _in_flight guard", function()
+        local skill_runner = require("parley.skill_runner")
+
+        -- a minimal real file + buffer to satisfy M.run's file-path/save steps
+        local doc = tmp_dir .. "/doc.md"
+        vim.fn.writefile({ "hello world" }, doc)
+        vim.cmd("edit " .. doc)
+        local buf = vim.api.nvim_get_current_buf()
+
+        -- a minimal skill with a non-empty SKILL.md and an agent
+        local skilldir = tmp_dir .. "/skill"
+        vim.fn.mkdir(skilldir, "p")
+        vim.fn.writefile({ "System prompt for the test skill." }, skilldir .. "/SKILL.md")
+        local skill = { name = "testskill", _dir = skilldir, agent = "agentX" }
+
+        local saved_get_agent = parley.get_agent
+        parley.get_agent = function()
+            return { provider = "cliproxyapi", model = { model = "claude-x" }, name = "agentX" }
+        end
+        local saved_query = parley.dispatcher.query
+        local saw_fn = false
+        parley.dispatcher.query = function(_b, _p, _pl, _h, _oe, _cb, _op, on_abort)
+            saw_fn = type(on_abort) == "function"
+            if on_abort then on_abort("test abort") end
+        end
+
+        pcall(function() skill_runner.run(buf, skill, {}) end)
+        vim.wait(300, function() return not skill_runner.is_in_flight(buf) end, 10)
+
+        parley.get_agent = saved_get_agent
+        parley.dispatcher.query = saved_query
+
+        assert.is_true(saw_fn) -- on_abort wired at arg position 8
+        assert.is_false(skill_runner.is_in_flight(buf)) -- guard cleared, buffer not blocked
+    end)
+end)

--- a/tests/integration/cliproxy_command_spec.lua
+++ b/tests/integration/cliproxy_command_spec.lua
@@ -1,0 +1,31 @@
+-- Integration test for the :ParleyProxy command registration (issue #131).
+
+local tmp_dir = vim.fn.tempname()
+vim.fn.mkdir(tmp_dir, "p")
+
+local parley = require("parley")
+parley.setup({
+    chat_dir = tmp_dir,
+    state_dir = tmp_dir .. "/state",
+    providers = {},
+    api_keys = {},
+    cliproxy = { manage = true },
+})
+
+describe(":ParleyProxy command", function()
+    it("is registered after setup", function()
+        assert.equals(2, vim.fn.exists(":ParleyProxy"))
+    end)
+
+    it("an unknown subcommand prints usage without erroring (no probe)", function()
+        assert.has_no.errors(function()
+            vim.cmd("ParleyProxy bogus")
+        end)
+    end)
+
+    it("can be registered under a custom prefix", function()
+        parley.register_proxy_command("Zed")
+        assert.equals(2, vim.fn.exists(":ZedProxy"))
+        pcall(vim.api.nvim_del_user_command, "ZedProxy")
+    end)
+end)

--- a/tests/integration/cliproxy_dispatch_spec.lua
+++ b/tests/integration/cliproxy_dispatch_spec.lua
@@ -1,0 +1,136 @@
+-- End-to-end dispatch integration for managed cliproxy (issue #131).
+--
+-- Drives the REAL chain with no stubs on the cliproxy side:
+--   dispatcher.query("cliproxyapi", …, on_abort)
+--     → providers.cliproxyapi.pre_query  (real)
+--       → cliproxy.ensure_running         (real)
+--         → health_probe against a process-level fake
+--           → on_error  → dispatcher abort channel → on_abort
+-- proving the spec's central invariant: a failed managed proxy fails the
+-- dispatch fast (never hangs) and a healthy one lets the query proceed.
+
+local uv = vim.uv or vim.loop
+local FAKE = vim.fn.getcwd() .. "/tests/fixtures/fake_cliproxy"
+
+local dispatcher = require("parley.dispatcher")
+local cliproxy = require("parley.cliproxy")
+local vault = require("parley.vault")
+local tasker = require("parley.tasker")
+local parley = require("parley")
+
+local started = {}
+
+local function free_port()
+    local s = uv.new_tcp()
+    s:bind("127.0.0.1", 0)
+    local port = s:getsockname().port
+    s:close()
+    return port
+end
+
+local function start_fake(port, mode)
+    local handle, pid = uv.spawn(FAKE, { args = { "--port", tostring(port), "--mode", mode } }, function() end)
+    assert(handle, "spawn fake")
+    table.insert(started, pid)
+    vim.wait(5000, function()
+        local ok = false
+        local c = uv.new_tcp()
+        c:connect("127.0.0.1", port, function(err)
+            ok = err == nil
+            c:close()
+        end)
+        vim.wait(100, function() return false end)
+        return ok
+    end, 50)
+    return pid
+end
+
+describe("managed cliproxy dispatch (e2e)", function()
+    local saved_config, saved_providers, saved_tasker_run
+    local ran_query
+
+    before_each(function()
+        saved_config = parley.config
+        saved_providers = dispatcher.providers.cliproxyapi
+        saved_tasker_run = tasker.run
+        ran_query = false
+        -- Capture whether the real query() proceeded to launch curl.
+        tasker.run = function() ran_query = true end
+        vault.add_secret("cliproxyapi", "testkey")
+    end)
+
+    after_each(function()
+        parley.config = saved_config
+        dispatcher.providers.cliproxyapi = saved_providers
+        tasker.run = saved_tasker_run
+        for _, pid in ipairs(started) do
+            pcall(uv.kill, pid, "sigkill")
+        end
+        for _, pid in ipairs(cliproxy.spawned_pids()) do
+            pcall(uv.kill, pid, "sigkill")
+        end
+        cliproxy._reset_spawned()
+        started = {}
+    end)
+
+    local function dispatch(port)
+        dispatcher.providers.cliproxyapi = {
+            endpoint = ("http://127.0.0.1:%d/v1/chat/completions"):format(port),
+        }
+        local outcome = { aborted = false, exited = false }
+        dispatcher.query(
+            nil, "cliproxyapi",
+            { model = "claude-x", messages = { { role = "user", content = "hi" } } },
+            function() end,           -- handler
+            function() outcome.exited = true end, -- on_exit (qid-coupled)
+            nil, nil,
+            function(msg)             -- on_abort
+                outcome.aborted = true
+                outcome.msg = msg
+            end
+        )
+        return outcome
+    end
+
+    it("aborts the dispatch (no hang) when the managed proxy is foreign", function()
+        local port = free_port()
+        start_fake(port, "foreign")
+        parley.config = { cliproxy = { manage = true, binary_path = FAKE } }
+        local outcome = dispatch(port)
+        vim.wait(9000, function() return outcome.aborted or ran_query end, 20)
+        assert.is_true(outcome.aborted)   -- on_abort fired (fast-fail)
+        assert.is_false(ran_query)        -- the query never launched
+        assert.is_truthy(outcome.msg:find("non%-cliproxy"))
+    end)
+
+    it("proceeds to the query when the managed proxy is healthy", function()
+        local port = free_port()
+        start_fake(port, "healthy")
+        parley.config = { cliproxy = { manage = true, binary_path = FAKE } }
+        local outcome = dispatch(port)
+        vim.wait(9000, function() return outcome.aborted or ran_query end, 20)
+        assert.is_true(ran_query)         -- query() launched
+        assert.is_false(outcome.aborted)  -- no abort
+    end)
+
+    it("cold-starts then proceeds, and after stop re-spawns (transient stop)", function()
+        local port = free_port()
+        vim.env.PARLEY_FAKE_MODE = "healthy"
+        parley.config = { cliproxy = { manage = true, binary_path = FAKE } }
+        -- nothing listening → ensure_running spawns the fake, then proceeds
+        local o1 = dispatch(port)
+        vim.wait(9000, function() return o1.aborted or ran_query end, 20)
+        assert.is_true(ran_query)
+        assert.is_false(o1.aborted)
+        assert.is_truthy(#cliproxy.spawned_pids() >= 1)
+        -- :ParleyProxy stop is transient — the next dispatch revives it
+        cliproxy.stop()
+        assert.equals(0, #cliproxy.spawned_pids())
+        ran_query = false
+        local o2 = dispatch(port)
+        vim.wait(9000, function() return o2.aborted or ran_query end, 20)
+        assert.is_true(ran_query)
+        assert.is_truthy(#cliproxy.spawned_pids() >= 1) -- re-spawned, no manual start
+        vim.env.PARLEY_FAKE_MODE = nil
+    end)
+end)

--- a/tests/integration/cliproxy_dispatch_spec.lua
+++ b/tests/integration/cliproxy_dispatch_spec.lua
@@ -14,6 +14,7 @@ local FAKE = vim.fn.getcwd() .. "/tests/fixtures/fake_cliproxy"
 
 local dispatcher = require("parley.dispatcher")
 local cliproxy = require("parley.cliproxy")
+cliproxy._set_data_dir(vim.fn.tempname()) -- never touch the real ~/.local/share/nvim
 local vault = require("parley.vault")
 local tasker = require("parley.tasker")
 local parley = require("parley")

--- a/tests/integration/cliproxy_download_spec.lua
+++ b/tests/integration/cliproxy_download_spec.lua
@@ -1,0 +1,101 @@
+-- Integration test for M2 auto_download (issue #131).
+-- Serves a fixture release over a local HTTP server (no network) and verifies
+-- download → checksum-verify → extract, AND that a tampered checksum is refused.
+
+local uv = vim.uv or vim.loop
+local cliproxy = require("parley.cliproxy")
+local cc = require("parley.cliproxy_config")
+
+local function free_port()
+    local s = uv.new_tcp()
+    s:bind("127.0.0.1", 0)
+    local port = s:getsockname().port
+    s:close()
+    return port
+end
+
+local function wait_listening(port)
+    vim.wait(5000, function()
+        local ok = false
+        local c = uv.new_tcp()
+        c:connect("127.0.0.1", port, function(err)
+            ok = err == nil
+            c:close()
+        end)
+        vim.wait(100, function() return false end)
+        return ok
+    end, 50)
+end
+
+-- Fixture + HTTP server built once at file load (plenary busted has no setup()).
+local version = "9.9.9"
+local asset = cc.asset_name(version, cc.platform())
+local serve_dir = vim.fn.tempname()
+local sums_path = serve_dir .. "/v" .. version .. "/checksums.txt"
+local good_sha, base_url, http_handle
+do
+    local vdir = serve_dir .. "/v" .. version
+    vim.fn.mkdir(vdir, "p")
+    local stage = vim.fn.tempname()
+    vim.fn.mkdir(stage, "p")
+    vim.fn.writefile({ "#!/bin/sh", "echo fake-cliproxy" }, stage .. "/cli-proxy-api")
+    vim.fn.system({ "chmod", "+x", stage .. "/cli-proxy-api" })
+    local asset_path = vdir .. "/" .. asset
+    vim.fn.system({ "tar", "-czf", asset_path, "-C", stage, "cli-proxy-api" })
+    good_sha = vim.trim(vim.fn.system({ "shasum", "-a", "256", asset_path })):match("^(%x+)")
+    vim.fn.writefile({ good_sha .. "  " .. asset }, sums_path)
+
+    local port = free_port()
+    http_handle = uv.spawn("python3",
+        { args = { "-m", "http.server", tostring(port) }, cwd = serve_dir }, function() end)
+    assert(http_handle, "failed to start fixture http server")
+    base_url = "http://127.0.0.1:" .. port
+    wait_listening(port)
+    -- reap the server when this test nvim exits
+    vim.api.nvim_create_autocmd("VimLeavePre", {
+        callback = function()
+            pcall(function()
+                if http_handle and not http_handle:is_closing() then
+                    http_handle:kill("sigkill")
+                end
+            end)
+        end,
+    })
+end
+
+describe("cliproxy auto_download", function()
+    before_each(function()
+        -- start each case from a clean managed bin dir
+        local mb = cliproxy.managed_binary()
+        if mb then
+            vim.fn.delete(mb)
+        end
+        -- restore the good checksums (a prior case may have tampered it)
+        vim.fn.writefile({ good_sha .. "  " .. asset }, sums_path)
+    end)
+
+    it("downloads, checksum-verifies, and extracts the binary", function()
+        local bin, err = cliproxy.download({ version = version, base_url = base_url })
+        assert.is_truthy(bin, "download failed: " .. tostring(err))
+        assert.equals(1, vim.fn.executable(bin))
+        assert.equals(bin, cliproxy.managed_binary())
+    end)
+
+    it("makes the downloaded binary discoverable", function()
+        cliproxy.download({ version = version, base_url = base_url })
+        -- nothing on PATH override needed: managed dir is in discover_binary's chain
+        local saved = require("parley").config
+        require("parley").config = { cliproxy = { manage = true } }
+        assert.equals(cliproxy.managed_binary(), cliproxy.discover_binary())
+        require("parley").config = saved
+    end)
+
+    it("REFUSES to install on a checksum mismatch", function()
+        -- tamper the served checksum
+        vim.fn.writefile({ ("0"):rep(64) .. "  " .. asset }, sums_path)
+        local bin, err = cliproxy.download({ version = version, base_url = base_url })
+        assert.is_nil(bin)
+        assert.is_truthy(err and err:find("checksum mismatch"))
+        assert.is_nil(cliproxy.managed_binary()) -- nothing installed
+    end)
+end)

--- a/tests/integration/cliproxy_download_spec.lua
+++ b/tests/integration/cliproxy_download_spec.lua
@@ -4,6 +4,7 @@
 
 local uv = vim.uv or vim.loop
 local cliproxy = require("parley.cliproxy")
+cliproxy._set_data_dir(vim.fn.tempname()) -- never touch the real ~/.local/share/nvim
 local cc = require("parley.cliproxy_config")
 
 local function free_port()

--- a/tests/integration/cliproxy_lifecycle_spec.lua
+++ b/tests/integration/cliproxy_lifecycle_spec.lua
@@ -71,13 +71,18 @@ describe("cliproxy IO lifecycle", function()
     after_each(function()
         parley.config = saved_config
         vim.env.PATH = saved_path
+        vim.env.PARLEY_FAKE_MODE = nil
         for _, p in ipairs(started) do
             pcall(function()
-                if p.handle and not p.handle:is_closing() then
-                    uv.kill(p.pid, "sigkill")
-                end
+                uv.kill(p.pid, "sigkill")
             end)
         end
+        for _, pid in ipairs(cliproxy.spawned_pids()) do
+            pcall(function()
+                uv.kill(pid, "sigkill")
+            end)
+        end
+        cliproxy._reset_spawned()
         started = {}
     end)
 
@@ -172,6 +177,221 @@ describe("cliproxy IO lifecycle", function()
                 cliproxy.health_probe("127.0.0.1", port, "k", done)
             end)
             assert.equals("down", state)
+        end)
+    end)
+
+    --------------------------------------------------------------------------
+    -- spawn
+    --------------------------------------------------------------------------
+    describe("spawn", function()
+        it("starts a detached, PID-tracked process that becomes healthy", function()
+            local port = free_port()
+            -- a -config file the fake reads its port from
+            local cfgfile = vim.fn.tempname() .. ".yaml"
+            vim.fn.writefile({ vim.json.encode({ port = port }) }, cfgfile)
+            vim.env.PARLEY_FAKE_MODE = "healthy"
+            local pid = cliproxy.spawn(FAKE, cfgfile)
+            assert.is_truthy(pid)
+            assert.is_truthy(vim.tbl_contains(cliproxy.spawned_pids(), pid))
+            wait_listening(port)
+            local state = await(function(done)
+                cliproxy.health_probe("127.0.0.1", port, "k", done)
+            end)
+            assert.equals("healthy", state)
+        end)
+    end)
+
+    --------------------------------------------------------------------------
+    -- ensure_running — reuse / spawn / failure modes
+    --------------------------------------------------------------------------
+    describe("ensure_running", function()
+        local saved_providers
+
+        local function set_endpoint(port)
+            parley.dispatcher = parley.dispatcher or {}
+            parley.dispatcher.providers = parley.dispatcher.providers or {}
+            parley.dispatcher.providers.cliproxyapi = {
+                endpoint = ("http://127.0.0.1:%d/v1/chat/completions"):format(port),
+            }
+            require("parley.vault").add_secret("cliproxyapi", "testkey")
+        end
+
+        local function run_ensure()
+            local outcome
+            cliproxy.ensure_running(function()
+                outcome = { ok = true }
+            end, function(msg)
+                outcome = { ok = false, msg = msg }
+            end)
+            vim.wait(9000, function()
+                return outcome ~= nil
+            end, 20)
+            assert(outcome, "ensure_running never resolved (hang!)")
+            return outcome
+        end
+
+        before_each(function()
+            saved_providers = parley.dispatcher and parley.dispatcher.providers
+        end)
+        after_each(function()
+            if parley.dispatcher then
+                parley.dispatcher.providers = saved_providers
+            end
+        end)
+
+        it("no-op pass-through when not managed", function()
+            parley.config = { cliproxy = { manage = false } }
+            local outcome = run_ensure()
+            assert.is_true(outcome.ok)
+        end)
+
+        it("reuses an already-healthy proxy without spawning", function()
+            local port = free_port()
+            set_endpoint(port)
+            start_fake(port, "healthy")
+            wait_listening(port)
+            parley.config = { cliproxy = { manage = true, binary_path = FAKE } }
+            local outcome = run_ensure()
+            assert.is_true(outcome.ok)
+            assert.equals(0, #cliproxy.spawned_pids()) -- did NOT spawn
+        end)
+
+        it("proceeds on needs_login (up but not logged in)", function()
+            local port = free_port()
+            set_endpoint(port)
+            start_fake(port, "needs_login")
+            wait_listening(port)
+            parley.config = { cliproxy = { manage = true, binary_path = FAKE } }
+            assert.is_true(run_ensure().ok)
+        end)
+
+        it("cold-starts: spawns when nothing is listening, then proceeds", function()
+            local port = free_port()
+            set_endpoint(port)
+            vim.env.PARLEY_FAKE_MODE = "healthy"
+            parley.config = { cliproxy = { manage = true, binary_path = FAKE } }
+            local outcome = run_ensure()
+            assert.is_true(outcome.ok)
+            assert.is_truthy(#cliproxy.spawned_pids() >= 1) -- it spawned
+        end)
+
+        it("errors (no hang) on a foreign process holding the port", function()
+            local port = free_port()
+            set_endpoint(port)
+            start_fake(port, "foreign")
+            wait_listening(port)
+            parley.config = { cliproxy = { manage = true, binary_path = FAKE } }
+            local outcome = run_ensure()
+            assert.is_false(outcome.ok)
+            assert.is_truthy(outcome.msg:find("non%-cliproxy"))
+        end)
+
+        it("errors on a client api-key mismatch", function()
+            local port = free_port()
+            set_endpoint(port)
+            start_fake(port, "client_key_mismatch")
+            wait_listening(port)
+            parley.config = { cliproxy = { manage = true, binary_path = FAKE } }
+            local outcome = run_ensure()
+            assert.is_false(outcome.ok)
+            assert.is_truthy(outcome.msg:find("api%-key"))
+        end)
+
+        it("errors (no hang) when the spawned binary crashes", function()
+            local port = free_port()
+            set_endpoint(port)
+            vim.env.PARLEY_FAKE_MODE = "crash"
+            parley.config = { cliproxy = { manage = true, binary_path = FAKE } }
+            local outcome = run_ensure()
+            assert.is_false(outcome.ok)
+            assert.is_truthy(outcome.msg:find("exited"))
+        end)
+
+        it("errors (no hang) when the proxy never becomes healthy", function()
+            local port = free_port()
+            set_endpoint(port)
+            vim.env.PARLEY_FAKE_MODE = "slow"
+            parley.config = { cliproxy = { manage = true, binary_path = FAKE } }
+            local outcome = run_ensure()
+            assert.is_false(outcome.ok)
+            assert.is_truthy(outcome.msg:find("did not become healthy"))
+        end)
+
+        it("errors when no binary is found", function()
+            local port = free_port()
+            set_endpoint(port)
+            -- A PATH with curl (so health_probe can run) but NO cliproxyapi.
+            local bindir = vim.fn.tempname()
+            vim.fn.mkdir(bindir, "p")
+            uv.fs_symlink(vim.fn.exepath("curl"), bindir .. "/curl")
+            vim.env.PATH = bindir
+            parley.config = { cliproxy = { manage = true, binary_path = "/no/such/bin" } }
+            local outcome = run_ensure()
+            assert.is_false(outcome.ok)
+            assert.is_truthy(outcome.msg:find("no cliproxy binary"))
+        end)
+    end)
+
+    --------------------------------------------------------------------------
+    -- commands: status / stop / login
+    --------------------------------------------------------------------------
+    describe("commands", function()
+        local function set_endpoint(port)
+            parley.dispatcher = parley.dispatcher or {}
+            parley.dispatcher.providers = { cliproxyapi = {
+                endpoint = ("http://127.0.0.1:%d/v1/chat/completions"):format(port),
+            } }
+            require("parley.vault").add_secret("cliproxyapi", "testkey")
+        end
+
+        it("stop() kills only parley-spawned proxies and clears tracking", function()
+            local port = free_port()
+            set_endpoint(port)
+            vim.env.PARLEY_FAKE_MODE = "healthy"
+            parley.config = { cliproxy = { manage = true, binary_path = FAKE } }
+            -- cold-start to spawn one
+            local outcome
+            cliproxy.ensure_running(function() outcome = true end, function() outcome = false end)
+            vim.wait(9000, function() return outcome ~= nil end, 20)
+            assert.is_true(outcome)
+            assert.is_truthy(#cliproxy.spawned_pids() >= 1)
+            local killed = cliproxy.stop()
+            assert.is_truthy(killed >= 1)
+            assert.equals(0, #cliproxy.spawned_pids())
+        end)
+
+        it("status() reports health, host:port, binary, and no drift after render", function()
+            local port = free_port()
+            set_endpoint(port)
+            start_fake(port, "healthy")
+            wait_listening(port)
+            parley.config = { cliproxy = { manage = true, binary_path = FAKE } }
+            -- render the config once (so drift can be evaluated)
+            local done
+            cliproxy.ensure_running(function() done = true end, function() done = true end)
+            vim.wait(9000, function() return done ~= nil end, 20)
+
+            local info = await(function(cb)
+                cliproxy.status(cb)
+            end)
+            assert.equals("healthy", info.health)
+            assert.equals("127.0.0.1", info.host)
+            assert.equals(port, info.port)
+            assert.equals(FAKE, info.binary)
+            assert.is_true(info.managed)
+            assert.is_false(info.config_drift)
+        end)
+
+        it("login_argv maps providers to per-provider flags", function()
+            parley.config = { cliproxy = { manage = true, binary_path = FAKE } }
+            local argv = cliproxy.login_argv("claude")
+            assert.equals(FAKE, argv[1])
+            assert.equals("-config", argv[2])
+            assert.equals("-claude-login", argv[4])
+            assert.equals("-login", cliproxy.login_argv("google")[4]) -- google uses -login
+            local bad, err = cliproxy.login_argv("bogus")
+            assert.is_nil(bad)
+            assert.is_truthy(err:find("unknown login provider"))
         end)
     end)
 end)

--- a/tests/integration/cliproxy_lifecycle_spec.lua
+++ b/tests/integration/cliproxy_lifecycle_spec.lua
@@ -348,6 +348,52 @@ describe("cliproxy IO lifecycle", function()
             assert.is_false(outcome.ok)
             assert.is_truthy(outcome.msg:find("no cliproxy binary"))
         end)
+
+        -- The M2 trigger: ensure_running must call download() iff auto_download is
+        -- set and nothing else is found (boundary-review Important #1).
+        local function path_without_cliproxy()
+            -- PATH with curl (health probe) + python3 (the FAKE's interpreter)
+            -- but NOT cliproxyapi/cli-proxy-api, so discover_binary finds nothing.
+            local bindir = vim.fn.tempname()
+            vim.fn.mkdir(bindir, "p")
+            uv.fs_symlink(vim.fn.exepath("curl"), bindir .. "/curl")
+            uv.fs_symlink(vim.fn.exepath("python3"), bindir .. "/python3")
+            vim.env.PATH = bindir
+        end
+
+        it("auto_download=true triggers download when no binary is found, then proceeds", function()
+            local port = free_port()
+            set_endpoint(port)
+            path_without_cliproxy()
+            vim.env.PARLEY_FAKE_MODE = "healthy"
+            parley.config = { cliproxy = { manage = true, auto_download = true, binary_path = "/no/such" } }
+            local saved_dl, dl_called = cliproxy.download, false
+            cliproxy.download = function() -- stand in for the network fetch; hand back a spawnable binary
+                dl_called = true
+                return FAKE
+            end
+            local outcome = run_ensure()
+            cliproxy.download = saved_dl
+            assert.is_true(dl_called) -- the auto_download branch fired
+            assert.is_true(outcome.ok) -- the downloaded binary spawned + became healthy
+        end)
+
+        it("does NOT download when auto_download is unset", function()
+            local port = free_port()
+            set_endpoint(port)
+            path_without_cliproxy()
+            parley.config = { cliproxy = { manage = true, binary_path = "/no/such" } } -- no auto_download
+            local saved_dl, dl_called = cliproxy.download, false
+            cliproxy.download = function()
+                dl_called = true
+                return FAKE
+            end
+            local outcome = run_ensure()
+            cliproxy.download = saved_dl
+            assert.is_false(dl_called) -- gate held — no fetch attempted
+            assert.is_false(outcome.ok)
+            assert.is_truthy(outcome.msg:find("no cliproxy binary"))
+        end)
     end)
 
     --------------------------------------------------------------------------

--- a/tests/integration/cliproxy_lifecycle_spec.lua
+++ b/tests/integration/cliproxy_lifecycle_spec.lua
@@ -256,6 +256,24 @@ describe("cliproxy IO lifecycle", function()
             assert.equals(0, #cliproxy.spawned_pids()) -- did NOT spawn
         end)
 
+        it("writes the rendered config 0600 with the resolved secret on disk", function()
+            local port = free_port()
+            set_endpoint(port) -- adds vault secret "testkey"
+            start_fake(port, "healthy")
+            wait_listening(port)
+            parley.config = { cliproxy = { manage = true, binary_path = FAKE } }
+            local done
+            cliproxy.ensure_running(function() done = true end, function() done = true end)
+            vim.wait(9000, function() return done ~= nil end, 20)
+            local path = cliproxy._config_path()
+            local stat = uv.fs_stat(path)
+            assert.is_truthy(stat)
+            assert.equals(tonumber("600", 8), require("bit").band(stat.mode, tonumber("777", 8)))
+            local content = table.concat(vim.fn.readfile(path), "\n")
+            assert.is_truthy(content:find("testkey", 1, true)) -- secret landed on disk
+            assert.is_truthy(content:find('"api%-keys"')) -- as the api-keys array
+        end)
+
         it("proceeds on needs_login (up but not logged in)", function()
             local port = free_port()
             set_endpoint(port)
@@ -392,6 +410,17 @@ describe("cliproxy IO lifecycle", function()
             local bad, err = cliproxy.login_argv("bogus")
             assert.is_nil(bad)
             assert.is_truthy(err:find("unknown login provider"))
+        end)
+
+        it("login_providers is the single source for completion + validation", function()
+            parley.config = { cliproxy = { manage = true, binary_path = FAKE } }
+            local provs = cliproxy.login_providers()
+            assert.is_truthy(#provs >= 7)
+            assert.is_truthy(vim.tbl_contains(provs, "claude"))
+            -- every advertised provider must actually build an argv (no drift)
+            for _, p in ipairs(provs) do
+                assert.is_truthy(cliproxy.login_argv(p), "login_argv failed for " .. p)
+            end
         end)
     end)
 end)

--- a/tests/integration/cliproxy_lifecycle_spec.lua
+++ b/tests/integration/cliproxy_lifecycle_spec.lua
@@ -6,6 +6,10 @@ local uv = vim.uv or vim.loop
 
 local FAKE = vim.fn.getcwd() .. "/tests/fixtures/fake_cliproxy"
 
+-- Redirect cliproxy's derived-artifact dir to a temp dir so this spec NEVER
+-- touches the real ~/.local/share/nvim, even run bare (no XDG redirect).
+require("parley.cliproxy")._set_data_dir(vim.fn.tempname())
+
 -- Track fake processes started by a test so after_each can reap them.
 local started = {}
 

--- a/tests/integration/cliproxy_lifecycle_spec.lua
+++ b/tests/integration/cliproxy_lifecycle_spec.lua
@@ -424,6 +424,33 @@ describe("cliproxy IO lifecycle", function()
             assert.equals(0, #cliproxy.spawned_pids())
         end)
 
+        it("stop reaps a leftover cliproxy on the port not spawned this session", function()
+            local port = free_port()
+            set_endpoint(port)
+            start_fake(port, "healthy") -- tracked in `started`, NOT in _spawned
+            wait_listening(port)
+            assert.equals(0, #cliproxy.spawned_pids()) -- this session spawned nothing
+            local n = cliproxy.stop()
+            assert.is_truthy(n >= 1) -- reaped the leftover via port identity
+            local state = await(function(done)
+                cliproxy.health_probe("127.0.0.1", port, "testkey", done)
+            end)
+            assert.equals("down", state) -- the leftover is dead
+        end)
+
+        it("stop does NOT kill a foreign process holding the port", function()
+            local port = free_port()
+            set_endpoint(port)
+            start_fake(port, "foreign") -- not a cliproxy
+            wait_listening(port)
+            local n = cliproxy.stop()
+            assert.equals(0, n) -- nothing reaped — identity probe said "foreign"
+            local state = await(function(done)
+                cliproxy.health_probe("127.0.0.1", port, "testkey", done)
+            end)
+            assert.equals("foreign", state) -- still alive
+        end)
+
         it("status() reports health, host:port, binary, and no drift after render", function()
             local port = free_port()
             set_endpoint(port)

--- a/tests/integration/cliproxy_lifecycle_spec.lua
+++ b/tests/integration/cliproxy_lifecycle_spec.lua
@@ -1,0 +1,177 @@
+-- Integration tests for lua/parley/cliproxy.lua (issue #131).
+-- Exercises the IO seam against a process-level fake (tests/fixtures/fake_cliproxy),
+-- not function mocks (AGENTS.md external-service rule).
+
+local uv = vim.uv or vim.loop
+
+local FAKE = vim.fn.getcwd() .. "/tests/fixtures/fake_cliproxy"
+
+-- Track fake processes started by a test so after_each can reap them.
+local started = {}
+
+local function free_port()
+    local s = uv.new_tcp()
+    s:bind("127.0.0.1", 0)
+    local port = s:getsockname().port
+    s:close()
+    return port
+end
+
+-- Start the fake on `port` in `mode`; returns the pid.
+local function start_fake(port, mode)
+    local handle, pid = uv.spawn(FAKE, {
+        args = { "--port", tostring(port), "--mode", mode },
+    }, function() end)
+    assert(handle, "failed to spawn fake_cliproxy")
+    table.insert(started, { handle = handle, pid = pid })
+    return pid
+end
+
+-- Run an async fn(done) and block until it calls done(result); return result.
+local function await(fn)
+    local result, got = nil, false
+    fn(function(r)
+        result = r
+        got = true
+    end)
+    vim.wait(8000, function()
+        return got
+    end, 20)
+    assert(got, "async call timed out")
+    return result
+end
+
+-- Poll until the fake answers, so probes aren't racing startup.
+local function wait_listening(port)
+    vim.wait(5000, function()
+        local ok = false
+        local c = uv.new_tcp()
+        c:connect("127.0.0.1", port, function(err)
+            ok = err == nil
+            c:close()
+        end)
+        vim.wait(100, function()
+            return false
+        end)
+        return ok
+    end, 50)
+end
+
+describe("cliproxy IO lifecycle", function()
+    local parley = require("parley")
+    local cliproxy = require("parley.cliproxy")
+    local saved_config, saved_path
+
+    before_each(function()
+        saved_config = parley.config
+        saved_path = vim.env.PATH
+        parley.config = { cliproxy = { manage = true } }
+    end)
+
+    after_each(function()
+        parley.config = saved_config
+        vim.env.PATH = saved_path
+        for _, p in ipairs(started) do
+            pcall(function()
+                if p.handle and not p.handle:is_closing() then
+                    uv.kill(p.pid, "sigkill")
+                end
+            end)
+        end
+        started = {}
+    end)
+
+    --------------------------------------------------------------------------
+    -- is_managed
+    --------------------------------------------------------------------------
+    describe("is_managed", function()
+        it("is true only when manage == true", function()
+            parley.config = { cliproxy = { manage = true } }
+            assert.is_true(cliproxy.is_managed())
+            parley.config = { cliproxy = { manage = false } }
+            assert.is_false(cliproxy.is_managed())
+            parley.config = {}
+            assert.is_false(cliproxy.is_managed())
+        end)
+    end)
+
+    --------------------------------------------------------------------------
+    -- discover_binary
+    --------------------------------------------------------------------------
+    describe("discover_binary", function()
+        it("returns binary_path when set and executable", function()
+            parley.config = { cliproxy = { manage = true, binary_path = FAKE } }
+            assert.equals(FAKE, cliproxy.discover_binary())
+        end)
+
+        it("falls back to a cliproxyapi on PATH", function()
+            local dir = vim.fn.tempname()
+            vim.fn.mkdir(dir, "p")
+            local bin = dir .. "/cliproxyapi"
+            vim.fn.writefile({ "#!/bin/sh", "true" }, bin)
+            uv.fs_chmod(bin, 493) -- 0755
+            vim.env.PATH = dir
+            parley.config = { cliproxy = { manage = true } }
+            assert.equals(bin, cliproxy.discover_binary())
+        end)
+
+        it("returns nil when nothing is found", function()
+            vim.env.PATH = vim.fn.tempname() -- empty, nonexistent dir
+            parley.config = { cliproxy = { manage = true, binary_path = "/no/such/bin" } }
+            assert.is_nil(cliproxy.discover_binary())
+        end)
+    end)
+
+    --------------------------------------------------------------------------
+    -- health_probe + classification
+    --------------------------------------------------------------------------
+    describe("health_probe", function()
+        it("classifies a healthy proxy", function()
+            local port = free_port()
+            start_fake(port, "healthy")
+            wait_listening(port)
+            local state = await(function(done)
+                cliproxy.health_probe("127.0.0.1", port, "k", done)
+            end)
+            assert.equals("healthy", state)
+        end)
+
+        it("classifies needs_login (200 + empty data)", function()
+            local port = free_port()
+            start_fake(port, "needs_login")
+            wait_listening(port)
+            local state = await(function(done)
+                cliproxy.health_probe("127.0.0.1", port, "k", done)
+            end)
+            assert.equals("needs_login", state)
+        end)
+
+        it("classifies a client key mismatch (401)", function()
+            local port = free_port()
+            start_fake(port, "client_key_mismatch")
+            wait_listening(port)
+            local state = await(function(done)
+                cliproxy.health_probe("127.0.0.1", port, "k", done)
+            end)
+            assert.equals("client_key_mismatch", state)
+        end)
+
+        it("classifies a foreign server", function()
+            local port = free_port()
+            start_fake(port, "foreign")
+            wait_listening(port)
+            local state = await(function(done)
+                cliproxy.health_probe("127.0.0.1", port, "k", done)
+            end)
+            assert.equals("foreign", state)
+        end)
+
+        it("classifies down when nothing is listening", function()
+            local port = free_port()
+            local state = await(function(done)
+                cliproxy.health_probe("127.0.0.1", port, "k", done)
+            end)
+            assert.equals("down", state)
+        end)
+    end)
+end)

--- a/tests/integration/topic_gen_spec.lua
+++ b/tests/integration/topic_gen_spec.lua
@@ -9,6 +9,36 @@ local parley = require("parley")
 parley.setup({ chat_dir = tmp_dir, state_dir = tmp_dir .. "/state", providers = {}, api_keys = {} })
 local chat_respond = require("parley.chat_respond")
 
+describe("_conversation_after_lead (drops system-prompt + ancestors)", function()
+    it("drops a synthetic system prompt (lead=2) — the user-turn + ack form", function()
+        local msgs = {
+            { role = "user", content = "SYSTEM with 🧠 mandate" }, -- synthetic sysprompt
+            { role = "assistant", content = "Got it." }, -- ack
+            { role = "user", content = "what is lua?" },
+            { role = "assistant", content = "Lua is a language." },
+        }
+        assert.same({
+            { role = "user", content = "what is lua?" },
+            { role = "assistant", content = "Lua is a language." },
+        }, chat_respond._conversation_after_lead(msgs, 2))
+    end)
+
+    it("drops a default system prompt (lead=1)", function()
+        local msgs = { { role = "system", content = "sys" }, { role = "user", content = "q" } }
+        assert.same({ { role = "user", content = "q" } }, chat_respond._conversation_after_lead(msgs, 1))
+    end)
+
+    it("drops system + ancestor messages (lead = sys + ancestors)", function()
+        local msgs = {
+            { role = "system", content = "sys" },
+            { role = "user", content = "anc-q" },
+            { role = "assistant", content = "anc-a" },
+            { role = "user", content = "cur-q" },
+        }
+        assert.same({ { role = "user", content = "cur-q" } }, chat_respond._conversation_after_lead(msgs, 3))
+    end)
+end)
+
 describe("generate_topic", function()
     it("drops the system prompt and uses the minimal topic prompt", function()
         local captured

--- a/tests/integration/topic_gen_spec.lua
+++ b/tests/integration/topic_gen_spec.lua
@@ -1,0 +1,41 @@
+-- generate_topic must NOT carry the persona system prompt into the topic
+-- request — the default system prompt mandates a `🧠:` thinking block, which an
+-- obedient model emits and which then lands as the "topic".
+
+local tmp_dir = (os.getenv("TMPDIR") or "/tmp") .. "/parley-topic-gen-" .. os.time()
+vim.fn.mkdir(tmp_dir, "p")
+
+local parley = require("parley")
+parley.setup({ chat_dir = tmp_dir, state_dir = tmp_dir .. "/state", providers = {}, api_keys = {} })
+local chat_respond = require("parley.chat_respond")
+
+describe("generate_topic", function()
+    it("drops the system prompt and uses the minimal topic prompt", function()
+        local captured
+        local saved = parley.dispatcher.query
+        parley.dispatcher.query = function(_buf, _provider, payload)
+            captured = payload
+        end
+
+        chat_respond.generate_topic({
+            { role = "system", content = "...always begin with a 🧠: thinking block..." },
+            { role = "user", content = "what is lua?" },
+            { role = "assistant", content = "🧠: reasoning here\n\nLua is a scripting language." },
+        }, "openai", { model = "gpt-x" }, function() end)
+
+        parley.dispatcher.query = saved
+
+        assert.is_truthy(captured) -- the query was issued
+        -- NO system message reaches the topic-gen request
+        for _, m in ipairs(captured.messages) do
+            assert.not_equals("system", m.role)
+        end
+        -- the minimal topic prompt is the final (user) message
+        local last = captured.messages[#captured.messages]
+        assert.equals("user", last.role)
+        assert.equals(parley.config.chat_topic_gen_prompt, last.content)
+        assert.is_truthy(last.content:lower():find("topic"))
+        -- and it carries no 🧠: thinking mandate
+        assert.is_nil(last.content:find("🧠"))
+    end)
+end)

--- a/tests/unit/cliproxy_config_spec.lua
+++ b/tests/unit/cliproxy_config_spec.lua
@@ -93,6 +93,19 @@ describe("render", function()
         local cfg = cc.render({ host = "h", port = 8317, secret = "", config = {} })
         assert.is_nil(cfg["api-keys"])
     end)
+
+    it("preserves a nested map+list passthrough (oauth-model-alias) through encode", function()
+        -- the structure cliproxyapi needs to route claude-opus-4-8 → Claude OAuth;
+        -- guards the JSON-as-YAML emission of nested maps containing lists of maps.
+        local raw = {
+            ["oauth-model-alias"] = {
+                ["claude-opus"] = { { name = "claude-opus-4-8", alias = "claude-opus-4-8", fork = true } },
+            },
+        }
+        local cfg = cc.render({ host = "127.0.0.1", port = 8317, secret = "s", config = raw })
+        local back = vim.json.decode(cc.encode(cfg))
+        assert.same(raw["oauth-model-alias"], back["oauth-model-alias"])
+    end)
 end)
 
 --------------------------------------------------------------------------------

--- a/tests/unit/cliproxy_config_spec.lua
+++ b/tests/unit/cliproxy_config_spec.lua
@@ -1,0 +1,110 @@
+-- Unit tests for lua/parley/cliproxy_config.lua (issue #131).
+-- Pure config core: no IO, no mocks.
+
+local cc = require("parley.cliproxy_config")
+
+--------------------------------------------------------------------------------
+-- parse_endpoint
+--------------------------------------------------------------------------------
+describe("parse_endpoint", function()
+    it("extracts host and numeric port from a standard endpoint", function()
+        local host, port = cc.parse_endpoint("http://127.0.0.1:8317/v1/chat/completions")
+        assert.equals("127.0.0.1", host)
+        assert.equals(8317, port)
+    end)
+
+    it("handles https and a hostname", function()
+        local host, port = cc.parse_endpoint("https://localhost:9000/v1/chat/completions")
+        assert.equals("localhost", host)
+        assert.equals(9000, port)
+    end)
+
+    it("defaults the port when none is given", function()
+        local host, port = cc.parse_endpoint("http://localhost/v1/chat/completions")
+        assert.equals("localhost", host)
+        assert.equals(80, port)
+    end)
+
+    it("defaults https to 443 when port-less", function()
+        local host, port = cc.parse_endpoint("https://example.com/v1/chat/completions")
+        assert.equals("example.com", host)
+        assert.equals(443, port)
+    end)
+
+    it("returns nil for an unparseable endpoint", function()
+        local host, port = cc.parse_endpoint("not-a-url")
+        assert.is_nil(host)
+        assert.is_nil(port)
+    end)
+
+    it("returns nil for a non-string", function()
+        local host, port = cc.parse_endpoint(nil)
+        assert.is_nil(host)
+        assert.is_nil(port)
+    end)
+end)
+
+--------------------------------------------------------------------------------
+-- render
+--------------------------------------------------------------------------------
+describe("render", function()
+    it("overlays wiring fields and injects the resolved secret", function()
+        local cfg = cc.render({
+            host = "127.0.0.1", port = 8317,
+            auth_dir = "~/.cli-proxy-api",
+            secret = "sk-local-123",
+            config = { ["some-provider"] = { model = "x" } },
+        })
+        assert.equals("127.0.0.1", cfg.host)
+        assert.equals(8317, cfg.port)
+        assert.equals("~/.cli-proxy-api", cfg["auth-dir"])
+        assert.equals("number", type(cfg.port))
+        assert.same({ "sk-local-123" }, cfg["api-keys"])
+        assert.same({ model = "x" }, cfg["some-provider"]) -- passthrough preserved
+    end)
+
+    it("binds to the dialed host (loopback), not 0.0.0.0", function()
+        local cfg = cc.render({ host = "127.0.0.1", port = 8317, secret = "s", config = {} })
+        assert.equals("127.0.0.1", cfg.host)
+    end)
+
+    it("does not mutate the input config table", function()
+        local raw = { port = 1 }
+        cc.render({ host = "h", port = 8317, secret = "s", config = raw })
+        assert.equals(1, raw.port) -- original untouched
+    end)
+
+    it("reports overridden raw-config keys for the caller to warn on", function()
+        local _, overrides = cc.render({
+            host = "127.0.0.1", port = 8317, secret = "s",
+            config = { host = "0.0.0.0", port = 9999 },
+        })
+        table.sort(overrides)
+        assert.same({ "host", "port" }, overrides)
+    end)
+
+    it("omits api-keys entirely when no secret is present", function()
+        -- vim.json.encode({}) is `{}` (object), not `[]` (array); omit instead.
+        local cfg = cc.render({ host = "h", port = 8317, config = {} })
+        assert.is_nil(cfg["api-keys"])
+    end)
+
+    it("omits api-keys when the secret is an empty string", function()
+        local cfg = cc.render({ host = "h", port = 8317, secret = "", config = {} })
+        assert.is_nil(cfg["api-keys"])
+    end)
+end)
+
+--------------------------------------------------------------------------------
+-- encode
+--------------------------------------------------------------------------------
+describe("encode", function()
+    it("emits JSON that round-trips and keeps api-keys a JSON array", function()
+        local cfg = cc.render({ host = "127.0.0.1", port = 8317, secret = "s", config = {} })
+        local str = cc.encode(cfg)
+        assert.is_truthy(str:find('"api%-keys":%s*%["s"%]')) -- wire format: array, not {}
+        local back = vim.json.decode(str)
+        assert.equals(8317, back.port)
+        assert.same({ "s" }, back["api-keys"])
+    end)
+end)

--- a/tests/unit/cliproxy_config_spec.lua
+++ b/tests/unit/cliproxy_config_spec.lua
@@ -108,3 +108,56 @@ describe("encode", function()
         assert.same({ "s" }, back["api-keys"])
     end)
 end)
+
+--------------------------------------------------------------------------------
+-- M2: release asset resolution
+--------------------------------------------------------------------------------
+describe("platform", function()
+    it("maps darwin/arm64 → darwin/aarch64", function()
+        assert.same({ os = "darwin", arch = "aarch64" },
+            cc.platform({ sysname = "Darwin", machine = "arm64" }))
+    end)
+    it("maps linux/x86_64 → linux/amd64", function()
+        assert.same({ os = "linux", arch = "amd64" },
+            cc.platform({ sysname = "Linux", machine = "x86_64" }))
+    end)
+    it("maps linux/aarch64 and freebsd/amd64 and windows/x86_64", function()
+        assert.same({ os = "linux", arch = "aarch64" }, cc.platform({ sysname = "Linux", machine = "aarch64" }))
+        assert.same({ os = "freebsd", arch = "amd64" }, cc.platform({ sysname = "FreeBSD", machine = "amd64" }))
+        assert.same({ os = "windows", arch = "amd64" }, cc.platform({ sysname = "Windows_NT", machine = "x86_64" }))
+    end)
+    it("returns nil for an unsupported os or arch", function()
+        assert.is_nil(cc.platform({ sysname = "Plan9", machine = "x86_64" }))
+        assert.is_nil(cc.platform({ sysname = "Linux", machine = "mips" }))
+    end)
+    it("works on the real host (returns a valid table)", function()
+        local p = cc.platform()
+        assert.is_truthy(p.os)
+        assert.is_truthy(p.arch)
+    end)
+end)
+
+describe("asset_name", function()
+    it("builds the tar.gz asset for unix", function()
+        assert.equals("CLIProxyAPI_7.1.71_darwin_aarch64.tar.gz",
+            cc.asset_name("7.1.71", { os = "darwin", arch = "aarch64" }))
+    end)
+    it("uses .zip on windows", function()
+        assert.equals("CLIProxyAPI_7.1.71_windows_amd64.zip",
+            cc.asset_name("7.1.71", { os = "windows", arch = "amd64" }))
+    end)
+end)
+
+describe("parse_checksums", function()
+    local sample = table.concat({
+        "bce9c508c15b205ceb8c6a26adf8eb3c20fbbdd5cba167debe6fd8d6983a46b3  CLIProxyAPI_7.1.71_darwin_aarch64.tar.gz",
+        "638d1791cced198c24509b4934951462999cab6ea39300c7ea67a8efb4d4b774  CLIProxyAPI_7.1.71_darwin_amd64.tar.gz",
+    }, "\n")
+    it("returns the sha for a known asset", function()
+        assert.equals("bce9c508c15b205ceb8c6a26adf8eb3c20fbbdd5cba167debe6fd8d6983a46b3",
+            cc.parse_checksums(sample, "CLIProxyAPI_7.1.71_darwin_aarch64.tar.gz"))
+    end)
+    it("returns nil for an asset not listed", function()
+        assert.is_nil(cc.parse_checksums(sample, "CLIProxyAPI_7.1.71_linux_amd64.tar.gz"))
+    end)
+end)

--- a/tests/unit/cliproxy_config_spec.lua
+++ b/tests/unit/cliproxy_config_spec.lua
@@ -161,6 +161,53 @@ describe("asset_name", function()
     end)
 end)
 
+--------------------------------------------------------------------------------
+-- M3: auth-failure detection + login-provider resolution
+--------------------------------------------------------------------------------
+describe("detect_auth_failure", function()
+    it("extracts the model from cliproxy's 'unknown provider' error", function()
+        local r = '{"error":{"message":"unknown provider for model claude-opus-4-8","type":"server_error"}}'
+        assert.equals("claude-opus-4-8", cc.detect_auth_failure(r))
+    end)
+    it("returns nil for a normal streamed response", function()
+        assert.is_nil(cc.detect_auth_failure('data: {"choices":[{"delta":{"content":"hi"}}]}'))
+    end)
+    it("returns nil for a non-string", function()
+        assert.is_nil(cc.detect_auth_failure(nil))
+    end)
+end)
+
+describe("resolve_login_provider", function()
+    local alias = {
+        claude = {
+            { name = "claude-opus-4-8", alias = "claude-opus-4-8", fork = true },
+            { name = "claude-sonnet-4-6", alias = "claude-sonnet-4-6", fork = true },
+        },
+        codex = { { name = "gpt-5-codex", alias = "gpt-5-codex", fork = true } },
+    }
+    it("resolves a claude-channel model → claude login", function()
+        assert.equals("claude", cc.resolve_login_provider("claude-opus-4-8", alias))
+    end)
+    it("resolves a codex-channel model → codex login", function()
+        assert.equals("codex", cc.resolve_login_provider("gpt-5-codex", alias))
+    end)
+    it("matches by alias when it differs from the name", function()
+        local a = { claude = { { name = "claude-opus-4-8", alias = "opus", fork = true } } }
+        assert.equals("claude", cc.resolve_login_provider("opus", a))
+    end)
+    it("maps the gemini-cli channel → google login", function()
+        local a = { ["gemini-cli"] = { { name = "gemini-2.5-pro", alias = "g", fork = true } } }
+        assert.equals("google", cc.resolve_login_provider("gemini-2.5-pro", a))
+    end)
+    it("returns nil for a model not in any channel", function()
+        assert.is_nil(cc.resolve_login_provider("mystery-model", alias))
+    end)
+    it("returns nil for a channel with no OAuth login (vertex)", function()
+        local a = { vertex = { { name = "gemini-2.5-pro", alias = "g", fork = true } } }
+        assert.is_nil(cc.resolve_login_provider("gemini-2.5-pro", a))
+    end)
+end)
+
 describe("parse_checksums", function()
     local sample = table.concat({
         "bce9c508c15b205ceb8c6a26adf8eb3c20fbbdd5cba167debe6fd8d6983a46b3  CLIProxyAPI_7.1.71_darwin_aarch64.tar.gz",

--- a/tests/unit/dispatcher_query_spec.lua
+++ b/tests/unit/dispatcher_query_spec.lua
@@ -524,4 +524,52 @@ describe("dispatcher.query internals", function()
             assert.equals("second query", on_progress_calls[1].text)
         end)
     end)
+
+    describe("Group H: pre_query abort channel", function()
+        local providers = require("parley.providers")
+        local original_get
+
+        before_each(function()
+            original_get = providers.get
+        end)
+        after_each(function()
+            providers.get = original_get
+        end)
+
+        it("H1: pre_query error invokes on_abort and does NOT run the query", function()
+            providers.get = function()
+                return {
+                    pre_query = function(_on_success, on_error)
+                        on_error("boom")
+                    end,
+                }
+            end
+            local abort_msg
+            dispatcher.query(nil, "managedprov", { model = "m", messages = {} },
+                make_handler(), make_on_exit(), make_callback(), nil,
+                function(msg)
+                    abort_msg = msg
+                end)
+            assert.equals("boom", abort_msg)
+            assert.is_nil(captured_out_reader) -- query() never ran → no tasker.run
+            assert.equals(0, #on_exit_calls) -- and the normal teardown path didn't fire either
+        end)
+
+        it("H2: pre_query success runs the query as before (backward compatible)", function()
+            providers.get = function()
+                return {
+                    pre_query = function(on_success)
+                        on_success()
+                    end, -- one-arg adapter ignores the error cb the dispatcher passes
+                    format_headers = function(_secret, _model, _payload, endpoint)
+                        return { "-H", "x: y" }, endpoint
+                    end,
+                }
+            end
+            dispatcher.providers["managedprov"] = { endpoint = "http://fake.test/v1/chat/completions" }
+            dispatcher.query(nil, "managedprov", { model = "m", messages = {} },
+                make_handler(), make_on_exit(), make_callback(), nil, function() end)
+            assert.is_not_nil(captured_out_reader) -- query() ran (tasker.run captured)
+        end)
+    end)
 end)

--- a/tests/unit/providers_pre_query_spec.lua
+++ b/tests/unit/providers_pre_query_spec.lua
@@ -1,0 +1,47 @@
+-- Unit tests for the cliproxyapi managed-proxy pre_query hook (issue #131).
+
+local providers = require("parley.providers")
+local cliproxy = require("parley.cliproxy")
+local parley = require("parley")
+
+describe("cliproxyapi.pre_query", function()
+    local saved_config, saved_ensure
+
+    before_each(function()
+        saved_config = parley.config
+        saved_ensure = cliproxy.ensure_running
+    end)
+    after_each(function()
+        parley.config = saved_config
+        cliproxy.ensure_running = saved_ensure
+    end)
+
+    it("is registered on the cliproxyapi adapter", function()
+        assert.is_function(providers.get("cliproxyapi").pre_query)
+    end)
+
+    it("no-op: calls on_success synchronously when not managed", function()
+        parley.config = { cliproxy = { manage = false } }
+        local ok, errored = false, false
+        providers.get("cliproxyapi").pre_query(function()
+            ok = true
+        end, function()
+            errored = true
+        end)
+        assert.is_true(ok)
+        assert.is_false(errored)
+    end)
+
+    it("delegates to ensure_running with BOTH callbacks when managed", function()
+        parley.config = { cliproxy = { manage = true } }
+        local got
+        cliproxy.ensure_running = function(on_success, on_error)
+            got = { on_success, on_error }
+        end
+        local s = function() end
+        local e = function() end
+        providers.get("cliproxyapi").pre_query(s, e)
+        assert.equals(s, got[1])
+        assert.equals(e, got[2])
+    end)
+end)

--- a/workshop/issues/000128-skill-system-redesign-declarative-modules-over-one-engine.md
+++ b/workshop/issues/000128-skill-system-redesign-declarative-modules-over-one-engine.md
@@ -111,18 +111,17 @@ likely finish + register and have `repo_discovery` grant them.
 
 ## Plan
 
-_Non-trivial — write a plan doc (`superpowers-writing-plans` →
-`workshop/plans/000128-*-plan.md`) before implementing; milestones TBD there.
-Rough shape:_
+Decomposed into review-boundary milestones — task detail in
+`workshop/plans/000128-skill-system-redesign-plan.md` (M1 task-detailed; M2–M5
+sketched). The original rough shape is folded into the milestones below.
 
-- [ ] manifest schema + provider-based `discover_skills` (disk / user / repo / virtual)
-- [ ] `read_skill` tool (source-agnostic, cwd-scope-exempt, transcript-visible)
-- [ ] route skills through the chat loop; delete `skill_runner` forced pipeline; salvage edit/diagnostic helpers into `propose_edits`
-- [ ] per-turn assembly (always-on + menu + pull); activation flags
-- [ ] port `review` + `voice_apply` to manifests
-- [ ] `repo_discovery` virtual skill (consumes #116 registry)
-- [ ] resolve `glob.lua` / `list_dir.lua`
-- [ ] layer #129 permission model onto `tools`/`elevated`
+- [ ] M1 — declarative manifest + provider-based discovery: `SkillManifest` shape+`validate`; disk/virtual providers (closure `source`, kills the `debug.getinfo` dance); registry union+dedup; `review`/`voice_apply` re-expressed as manifests — **no chat-loop change**
+- [ ] M2 — `read_skill` tool (cwd-exempt, transcript-visible) + per-turn assembly (per-buffer `ActiveSkills` state + pure `assemble_turn`) + route through the chat loop
+- [ ] M3 — `propose_edits` builtin (salvage `compute_edits`/`apply_edits` + highlight/diagnostics) + `force_tool`; port `review` end-to-end through the loop
+- [ ] M4 — port `voice_apply`; delete `skill_runner` forced pipeline; reconcile callers (`skill_picker`/`review.lua`/keybindings); resolve `glob`/`list_dir` (YAGNI decision — they don't exist)
+- [ ] M5 — `repo_discovery` virtual skill (consumes #116 M1 `render()`) — the merge point
+
+(**#129** capability permission model layers onto `tools`/`elevated` **after** this issue — a separate issue, not a milestone here.)
 
 ## Log
 

--- a/workshop/issues/000131-managed-cliproxy.md
+++ b/workshop/issues/000131-managed-cliproxy.md
@@ -1,0 +1,227 @@
+---
+id: 000131
+status: open
+deps: []
+github_issue:
+created: 2026-06-12
+updated: 2026-06-12
+estimate_hours:
+---
+
+# Manage cliproxyapi lifecycle + config
+
+## Problem
+
+Parley talks to `cliproxyapi` as a normal provider (`lua/parley/config.lua` →
+`http://127.0.0.1:8317/v1/chat/completions`, dual OpenAI/Anthropic adapter in
+`providers.lua`), but assumes the proxy is **already running and configured
+out-of-band**. Today that means: `brew install`, `brew services start`, and
+hand-editing config under `/opt/homebrew` — a path that can't live in the user's
+version-controlled dotfiles (yadm). Setup friction + non-committable config +
+manual lifecycle. Parley owns the client cleanly and owns *nothing* of the
+proxy's binary / config / lifecycle. This issue closes that gap.
+
+## Spec
+
+Make parley able to **manage a cliproxyapi instance** — opt-in, off by default,
+distributable to parley's general users (not just one machine).
+
+### Decisions (brainstorm 2026-06-12)
+- **Audience:** parley's general users → portable, no brew/Go assumption, no
+  personal paths in core logic, **opt-in / off by default**.
+- **Ownership:** orchestrator spine (config + lifecycle, bring-your-own-binary)
+  as the M1 default; `auto_download` (parley fetches the binary) deferred to M2.
+- **Config source of truth:** rendered from Lua `setup{}` — the generated
+  `config.yaml` is a *derived, gitignored artifact*, so nothing hand-maintained
+  ever lives in `/opt/homebrew` again. The committed Lua **is** the config.
+- **Platforms:** macOS + Linux tested in v1; Windows written portably,
+  best-effort, not gated on.
+
+### Verified cliproxyapi facts (research 2026-06-12)
+- `--config /path/to/config.yaml` flag → we can point it anywhere.
+- Config holds `host`/`port` (default `8317`), `api-keys` (client tokens), and
+  an `auth-dir` pointer (default `~/.cli-proxy-api`).
+- **Clean secret split already exists:** static config in `config.yaml`
+  (committable); OAuth subscription tokens are JSON files in `auth-dir`, written
+  by `cli-proxy-api login`. Secrets never need to touch config or git.
+- Prebuilt release tarballs for every platform:
+  `CLIProxyAPI_<ver>_{darwin,linux,freebsd,windows}_{aarch64,amd64}.tar.gz` +
+  `checksums.txt`. **Source builds are unnecessary** (kills brainstorm idea #1).
+- `login` is interactive OAuth (`--no-browser` prints the URL) — the one
+  unavoidable per-machine manual step.
+
+### Activation & config model
+Activated only when `setup{}` contains a `cliproxy = { manage = true, ... }`
+block. Shape:
+```lua
+cliproxy = {
+  manage = true,
+  auth_dir = "~/.cli-proxy-api",  -- machine-local OAuth token dir
+  binary_path = nil,              -- optional explicit path (else PATH lookup)
+  config = { ... },               -- raw passthrough of cliproxy's own schema (ARCH-DRY: don't re-model it)
+}
+```
+Parley merges its wiring fields **over** the raw `config` table, then writes the
+result to a derived path *outside the user's dotfiles repo*
+(`stdpath('data')/parley/cliproxy/config.yaml`, perms `0600`) on each
+ensure-start, and spawns `cli-proxy-api --config <that path>`.
+
+### host:port — single source of truth (resolves the double-source risk)
+The existing `providers.cliproxyapi.endpoint` (`config.lua`,
+`http://127.0.0.1:8317/v1/chat/completions`) already says *where the client
+dials*. That endpoint is **the** source of truth: parley **parses host:port out
+of the provider endpoint** and renders those into the proxy config's `host`/
+`port` (and uses them for the health probe). There is deliberately **no
+`cliproxy.port` field** — a second port knob is exactly the drift the reviewer
+flagged. If the raw `config` passthrough also sets `host`/`port`, the
+endpoint-derived values win and parley logs a warning naming both. Net: change
+the port in one place (the provider endpoint) and client + proxy stay aligned.
+*M1 note:* decide bind-vs-dial host explicitly — the client dials `127.0.0.1`
+but the proxy may need `host: localhost`/`0.0.0.0` to bind; don't render the dial
+host blindly as the bind host.
+
+**Emission:** JSON is valid YAML 1.2 and parley already has `vim.json.encode`,
+so it writes JSON-as-`.yaml` and needs no YAML emitter. **This bet is an early
+gating task in M1** (write a render, feed it to a real `cli-proxy-api --config`,
+confirm it boots) — go/no-go *before* the lifecycle work, so a failure can't
+silently balloon M1. If it fails, the fallback emitter must handle **nested maps
++ lists** (the config has an `api-keys` list and nested sections) — a flat
+emitter is not a viable fallback; budget it as its own M1 sub-task if triggered.
+
+### Secret & auth-dir wiring (must NOT leak)
+- **Client token:** the `cliproxyapi` secret can be a plaintext string, an env
+  var, **or a command table** (`{ "cat", "/path" }`, keychain lookup, …) per
+  `config.lua`. Parley resolves it through the **existing vault**
+  (`vault.get_secret`, already populated at setup — ARCH-DRY, don't re-read
+  `api_keys`) and injects the *resolved* value into the rendered config's
+  `api-keys` list — single source; proxy and client can't drift.
+- **Plaintext-on-disk, acknowledged:** the rendered `config.yaml` therefore
+  contains the resolved client token in cleartext under `stdpath('data')`. That
+  is why the file is written `0600`. This is a real (small) exposure the spec
+  owns explicitly rather than hides. The *committed Lua* still holds zero
+  secrets — the on-disk artifact is machine-local and unversioned.
+- **OAuth tokens:** stay in `auth_dir` (machine-local JSON), never rendered into
+  config, never committed.
+
+### Binary discovery (M1, bring-your-own)
+Order: `cliproxy.binary_path` → managed download dir (M2) → `cli-proxy-api` on
+PATH. None found → actionable error naming `brew install …` / `auto_download`.
+
+### Lifecycle
+- **Lazy:** ensure-running fires on first dispatch to a cliproxy-provider agent,
+  never on nvim launch.
+- **Reuse-if-healthy:** probe the endpoint's host:port first; spawn only if
+  nothing healthy answers (cooperative with an existing brew service / other
+  nvim).
+- **Detached & shared:** spawned via `vim.uv` detached so it outlives nvim and
+  is shared across instances. Never auto-killed; stopped only explicitly.
+
+### Health probe & failure modes (the dispatch path must never hang)
+The probe must **identify cliproxy specifically**, not just accept any TCP
+listener — hit a cliproxy-distinguishing HTTP route (e.g. its models endpoint),
+so a foreign server squatting the port isn't mistaken for ours.
+- **Spawn fails** (missing/!exec/wrong-arch binary, immediate exit): surface a
+  clear error on the dispatch path and **fail the request** — never hang the
+  chat — pointing at `:ParleyProxy status`.
+- **Foreign process on the port:** probe fails the cliproxy-identity check →
+  error "port N held by a non-cliproxy process" (don't spawn a doomed second
+  instance, don't silently dial the stranger).
+- **Spawned but never healthy:** bounded wait (~5s, a few retries); on timeout,
+  abort with an error and leave the (logged) process for `:ParleyProxy status`
+  to report — the dispatch does not block indefinitely.
+- **Healthy but unauthenticated (login not done → 401 storm):** this is the
+  *most likely* first-run state. Lifecycle is parley's job; OAuth is the manual
+  step. `status` reports **auth state** (probe returns 401 / `auth_dir` empty),
+  and the not-yet-logged-in error tells the user to run `:ParleyProxy login`.
+
+### Module boundary (ARCH-PURE)
+Two units, tested independently:
+- `cliproxy_config.lua` — **pure**: merge raw `config` with wiring fields, parse
+  host:port from the endpoint, inject the resolved secret, emit JSON-as-YAML,
+  map platform→asset name (M2). No IO. Colocated unit tests.
+- `cliproxy.lua` — **IO**: binary discovery, `vim.uv` spawn, health probe,
+  reuse logic, the `:ParleyProxy` commands. Tested against a process-level fake
+  proxy binary. Resolves the secret via the existing vault; writes the file.
+
+### Commands
+`:ParleyProxy status | start | stop | restart | login`. `login` wraps
+`cli-proxy-api login [--no-browser]`. `status` reports binary source,
+running/healthy, **auth state**, host:port, auth-dir, rendered-config path, and
+flags **"running config differs from rendered"** so the user knows a `restart`
+is needed after a Lua change. `stop`/`restart` are **best-effort by port/PID**;
+since the daemon is shared, other nvim instances simply re-spawn lazily on their
+next request. *M1 note:* `stop` should only stop a daemon **parley spawned**
+(track our PID); a reused/foreign daemon (brew service) is left alone.
+
+### M2 — auto_download (deferred)
+`auto_download = true` → fetch the **pinned** (not "latest") release tarball for
+detected os/arch, verify against `checksums.txt`, extract into the managed dir.
+Adds `:ParleyProxy update`; binary-discovery falls through to the managed dir.
+
+### Explicitly OUT (YAGNI)
+Management-center/GUI integration; multi-proxy orchestration; auto-restart on
+config change (Lua change needs explicit `:ParleyProxy restart`); managing the
+OAuth flow beyond shelling out to `login`.
+
+## Done when
+
+Parley-verifiable (no manual login needed):
+- `cliproxy = { manage = true, ... }` is opt-in; absent → zero behavior change,
+  no spawn on nvim launch.
+- A cliproxy-provider chat with no proxy running lazily renders config from Lua,
+  starts the binary, the proxy becomes healthy, and the request reaches it.
+- A healthy proxy already on the port (e.g. brew service) is reused, not
+  re-spawned; a foreign process on the port produces the identity-check error,
+  not a silent mis-dial.
+- Spawn failure / never-healthy each surface an error on the dispatch path
+  within the bounded timeout — the chat never hangs.
+- Rendered `config.yaml` carries the *resolved* `cliproxyapi` secret in
+  `api-keys` at perms `0600`; no secret appears in any committed file; the port
+  in the rendered config matches the provider endpoint.
+- `:ParleyProxy status` reports binary source, healthy/auth state, host:port,
+  and config-drift accurately.
+
+Requires manual one-time login (documented as such):
+- Post-`:ParleyProxy login`, a real cliproxy-provider completion returns
+  end-to-end.
+
+Platform:
+- The above pass on macOS + Linux.
+
+## Plan
+
+- [ ] M1 — orchestrator spine (macOS + Linux). Gating task FIRST: prove
+      JSON-as-YAML boots a real `cli-proxy-api --config` (go/no-go before the
+      rest). Then: pure `cliproxy_config.lua` (merge, parse host:port from
+      endpoint, vault-resolved secret injection, JSON-as-YAML emit) +
+      colocated unit tests; IO `cliproxy.lua` (binary discovery, `vim.uv`
+      detached spawn, cliproxy-identifying health probe with bounded timeout,
+      reuse-if-healthy, `:ParleyProxy status|start|stop|restart|login`) tested
+      against a process-level fake proxy binary (per AGENTS.md external-service
+      rule). Failure modes (spawn-fail, foreign-port, never-healthy, 401/auth)
+      each covered.
+- [ ] M2 — `auto_download`: platform→asset-name mapping (pure, with its
+      consumer here — not M1), pinned cross-platform release fetch + checksum
+      verify + extract; `:ParleyProxy update`; discovery falls through to managed
+      dir.
+
+## Log
+
+### 2026-06-12
+- Brainstormed via superpowers-brainstorming. Converged design captured in
+  `## Spec`. Five decisions logged inline (audience, ownership, config source,
+  auto_download deferral, platform scope). cliproxyapi CLI/release facts
+  verified against help.router-for.me + GitHub releases API (latest v7.1.68).
+- Idea "build cliproxyapi from source" rejected: prebuilt tarballs exist for all
+  platforms; source build would force a Go toolchain on every machine for no
+  gain.
+- Fresh-eyes spec review (subagent) found 2 blockers + arch gap; spec revised:
+  (1) **host:port single source of truth** — dropped `cliproxy.port`, parse it
+  from the provider endpoint (kills the double-source drift). (2) **secret
+  resolution** — resolve via existing vault (handles command-table/env forms),
+  acknowledge plaintext-on-disk at `0600`. (3) **lifecycle failure modes** —
+  added health-identity probe, spawn-fail / foreign-port / never-healthy bounded
+  timeout / 401-auth handling; dispatch never hangs. (4) **module boundary** —
+  pure `cliproxy_config.lua` vs IO `cliproxy.lua`. (5) JSON-as-YAML made an early
+  M1 go/no-go gating task; platform→asset mapping moved to M2 (its consumer);
+  Done-when split into parley-verifiable vs post-login.

--- a/workshop/issues/000131-managed-cliproxy.md
+++ b/workshop/issues/000131-managed-cliproxy.md
@@ -240,6 +240,10 @@ Platform:
   with zero env setup. Safe: dormant unless a cliproxyapi agent runs, and
   reuses an existing proxy. README + atlas updated to "on by default but dormant".
   make test still exit 0 (94 specs).
+- **Live e2e validated by operator** (the last Done-when, "post-login real
+  completion"): fresh nvim, brew service stopped → parley spawned its own
+  cliproxyapi and a cliproxyapi-provider chat completed end-to-end. The
+  real-subscription path the automated tests couldn't exercise now confirmed.
 - Brainstormed via superpowers-brainstorming. Converged design captured in
   `## Spec`. Five decisions logged inline (audience, ownership, config source,
   auto_download deferral, platform scope). cliproxyapi CLI/release facts

--- a/workshop/issues/000131-managed-cliproxy.md
+++ b/workshop/issues/000131-managed-cliproxy.md
@@ -1,11 +1,11 @@
 ---
 id: 000131
-status: open
+status: working
 deps: []
 github_issue:
 created: 2026-06-12
 updated: 2026-06-12
-estimate_hours:
+estimate_hours: 16
 ---
 
 # Manage cliproxyapi lifecycle + config

--- a/workshop/issues/000131-managed-cliproxy.md
+++ b/workshop/issues/000131-managed-cliproxy.md
@@ -215,7 +215,7 @@ Platform:
       consumer here — not M1), pinned cross-platform release fetch + checksum
       verify + extract; `:ParleyProxy update`; discovery falls through to managed
       dir.
-- [ ] M3 — auth-failure → guided login. On a cliproxy response that fails for a
+- [x] M3 — auth-failure → guided login. On a cliproxy response that fails for a
       missing/invalid upstream credential (cliproxyapi collapses this to
       `"unknown provider for model <X>"` — verified against the source:
       `util.GetProviderName` only reads the *dynamic* registry, so an unloaded
@@ -232,6 +232,8 @@ Platform:
 
 ## Log
 
+
+- 2026-06-14: closed M3 — measured increment = total 11.51h - (M1 2.74 + M2 1.29) (sdlc actual cannot scope per-milestone; this window had heavy interactive debugging + reading the CLIProxyAPI Go source). make test exit 0 (JOBS=4): 97 spec files, luacheck 0/0 across 185. M3: cliproxy_config detect_auth_failure + resolve_login_provider 9 unit tests; cliproxy_auth_login 4 integration (prompt-on-failure / no-op-success / no-op-non-cliproxy / canonical-channel resolution). Resolution is CONFIG-DRIVEN (oauth-model-alias channel key == provider), NOT name inference — verified against the CLIProxyAPI source (dynamic registry drops models at auth-error time; static catalog keyed by canonical channels claude/codex/gemini-cli/...). Re-keyed default to canonical `claude` channel, verified it serves the whole family against real 7.1.71. Window also covers post-M2 side-quests: stop-reaps-by-port (2 tests), oauth-model-alias default (verified e2e), and two topic-gen fixes (system-prompt leak into the title, incl the synthetic leading-user-turn form).; review verdict: FIX-THEN-SHIP
 ### 2026-06-12
 - 2026-06-12: closed M2 — measured increment = total 4.03h - M1 2.74h (sdlc actual cannot scope per-milestone). make test exit 0: 95 spec files, luacheck 0/0 across 183. M2: cliproxy_config platform/asset_name/parse_checksums 9 unit (injectable uname, deterministic); cliproxy_download 3 integration (fixture release over local HTTP, no network: download→sha256-verify→extract + tampered-checksum REFUSAL); discover_binary managed-dir fall-through; ensure_running auto_download trigger (opt-in); :ParleyProxy update. Grounded on real release v7.1.71 (asset naming aarch64, "<sha>  <name>" checksums, tarball roots cli-proxy-api).; review verdict: FIX-THEN-SHIP
 - **M2 FIX-THEN-SHIP resolved (no Critical; 2 Important + minors).** (1) Added the
@@ -312,6 +314,21 @@ Platform:
   the dispatcher's cliproxy response path; 4 integration tests. Re-keyed the
   default oauth-model-alias to the canonical `claude` channel. make test exit 0:
   97 spec files, luacheck 0/0 across 185.
+- **M3 FIX-THEN-SHIP resolved (no Critical).** (1) **Test-isolation bug (also hit
+  the operator live):** `config_path()`/`bin_dir()` used `stdpath('data')`
+  unconditionally, so a bare `PlenaryBustedFile` run (no XDG redirect) wrote to
+  the real `~/.local/share/nvim/parley/cliproxy/` — it had clobbered the
+  operator's rendered config with a test `testkey`/ephemeral-port, then a proxy
+  spawned from it rejected the real bearer (`client_key_mismatch`). Fix: a
+  `data_root()` with a `cliproxy._set_data_dir` test seam; every cliproxy spec
+  redirects to a temp dir at load. Verified a BARE lifecycle run is now 28/0 AND
+  leaves the real dir untouched. (2) Added the untested `check_auth_failure`
+  no-login-resolved WARN branch test (model absent from the alias → notify, no
+  prompt). (3) `auto_download = true` is the operator's intentional default —
+  kept on, fixed the now-false "off by default" comment to note it's a trust
+  decision a general distribution may revert. **Revision:** auto_download default
+  off→on is the operator's choice for this config (Spec's stated default is
+  opt-in). make test exit 0: 97 spec files, luacheck 0/0 across 185.
 
 ### 2026-06-13 (follow-up — oauth-model-alias default)
 - After auto_download spawned a clean 7.1.71, a cliproxy chat failed with

--- a/workshop/issues/000131-managed-cliproxy.md
+++ b/workshop/issues/000131-managed-cliproxy.md
@@ -279,3 +279,30 @@ Platform:
   by `on_exit` + `on_abort` (ARCH-DRY); test asserts blocks removed on the
   *default* path. Minor folds: port-less-endpoint caveat; read merged config via
   `require("parley").config.cliproxy`, not the module's `M`.
+
+### 2026-06-12 (build)
+- Chunk 1 SHIPPED: `lua/parley/cliproxy_config.lua` (parse_endpoint/render/encode),
+  13 unit tests green, luacheck clean, traceability key `providers/cliproxy-managed`
+  registered. Commit e98a432.
+- **Task 2.0 gating check → GO.** Rendered a config via the real `cliproxy_config`
+  module (JSON written to `.yaml`) and booted the installed `cliproxyapi`
+  (v7.1.60) on a throwaway port 8319: **it boots cleanly from JSON-as-YAML — the
+  bet holds, no fallback YAML emitter needed.** Decisions:
+  - **Identity/health route = `/v1/models`** (no `/health` → 404). Probe WITH the
+    client bearer.
+  - **401 semantics (resolves plan-quality INFO):** with the *correct* bearer,
+    `/v1/models` returns **200 `{"data":[],"object":"list"}`** even with NO
+    upstream login. So: **401 = client-key drift** (wrong/absent `api-keys`);
+    **200 + empty `data` = up but not logged in** (the "run login" signal);
+    refused = down; 200 non-`{object:"list"}` = foreign.
+  - **Binary name is `cliproxyapi`** (brew), NOT `cli-proxy-api`. `discover_binary`
+    tries both.
+  - **Config flag `-config`** (single dash; Go flag also accepts `--config`).
+  - **Login = per-provider flags**, NOT a subcommand: `-claude-login`,
+    `-codex-login`, `-codex-device-login`, `-login` (Google), `-kimi-login`,
+    `-xai-login`, `-antigravity-login`, `-no-browser`. `:ParleyProxy login <provider>`
+    → `-<provider>-login`.
+  - `api-keys` (plural) confirmed; `host`/`port`/`auth-dir` as rendered; `~` ok.
+  - Boot downloads a management control-panel asset from GitHub; docs should
+    recommend `remote-management: { disable-control-panel: true }` in the user's
+    `config` passthrough (avoids the network hit, faster lazy-spawn readiness).

--- a/workshop/issues/000131-managed-cliproxy.md
+++ b/workshop/issues/000131-managed-cliproxy.md
@@ -244,6 +244,20 @@ Platform:
   completion"): fresh nvim, brew service stopped → parley spawned its own
   cliproxyapi and a cliproxyapi-provider chat completed end-to-end. The
   real-subscription path the automated tests couldn't exercise now confirmed.
+
+### 2026-06-12 (M2 — auto_download)
+- M2 SHIPPED: pure `cliproxy_config.platform/asset_name/parse_checksums` (9 unit
+  tests, injectable uname); `cliproxy.download()` resolves the pinned release
+  (7.1.71) for the host platform, curls tarball + checksums.txt, **sha256-verifies
+  (refuses on mismatch)**, extracts `cli-proxy-api` into stdpath('data')/.../bin;
+  `discover_binary` falls through binary_path → managed dir → PATH;
+  `ensure_running` auto-downloads (one-time, notify) when `auto_download` is set;
+  `:ParleyProxy update` re-fetches. Integration test serves a fixture release over
+  local HTTP (no network) — download/extract + tampered-checksum refusal (3 tests).
+  Grounded on the real release (asset naming `aarch64`, `<sha>  <name>` checksums,
+  tarball roots `cli-proxy-api`). `auto_download` kept **opt-in** (auto-fetching a
+  binary is an explicit choice; brainstorm's "A is opt-in").
+- Full suite: **make test exit 0 — 95 spec files, luacheck 0/0 across 183.**
 - Brainstormed via superpowers-brainstorming. Converged design captured in
   `## Spec`. Five decisions logged inline (audience, ownership, config source,
   auto_download deferral, platform scope). cliproxyapi CLI/release facts

--- a/workshop/issues/000131-managed-cliproxy.md
+++ b/workshop/issues/000131-managed-cliproxy.md
@@ -279,6 +279,22 @@ Platform:
   classifier), so a foreign process is never killed. `restart` inherits it.
   2 integration tests (reap-leftover, don't-kill-foreign). make test exit 0 — 95
   spec files, luacheck 0/0.
+
+### 2026-06-13 (follow-up — oauth-model-alias default)
+- After auto_download spawned a clean 7.1.71, a cliproxy chat failed with
+  "unknown provider for model claude-opus-4-8": the minimal rendered config had
+  no provider/model routing. Root cause (operator-diagnosed): the brew conf's
+  `oauth-model-alias` block maps model NAMES → the Claude OAuth credential
+  (`fork: true`); the auth-dir token alone isn't enough. Per operator direction
+  ("use parley's config to control cliproxyapi as a wrapped dependency"), baked a
+  default `oauth-model-alias` into `config.lua` `cliproxy.config` for the models
+  parley's cliproxyapi agents use (claude-sonnet-4-6 / claude-opus-4-8 /
+  claude-fable-5). **Verified end-to-end**: rendered via the real module, booted
+  the downloaded 7.1.71 against the real auth-dir → `/v1/models` now lists
+  claude-opus-4-8 (+ the family). Added a unit test that the nested map+list
+  passthrough survives JSON-as-YAML round-trip. make test exit 0 — 95 specs,
+  luacheck 0/0. (Confirmed the chat_dirs failures were a parallel-runner load
+  flake — isolated + JOBS=4 runs are green.)
 - Brainstormed via superpowers-brainstorming. Converged design captured in
   `## Spec`. Five decisions logged inline (audience, ownership, config source,
   auto_download deferral, platform scope). cliproxyapi CLI/release facts

--- a/workshop/issues/000131-managed-cliproxy.md
+++ b/workshop/issues/000131-managed-cliproxy.md
@@ -215,6 +215,20 @@ Platform:
       consumer here — not M1), pinned cross-platform release fetch + checksum
       verify + extract; `:ParleyProxy update`; discovery falls through to managed
       dir.
+- [ ] M3 — auth-failure → guided login. On a cliproxy response that fails for a
+      missing/invalid upstream credential (cliproxyapi collapses this to
+      `"unknown provider for model <X>"` — verified against the source:
+      `util.GetProviderName` only reads the *dynamic* registry, so an unloaded
+      auth makes the model unresolvable), detect it and resolve which login the
+      model needs **from parley's own `oauth-model-alias` config** (NOT name
+      inference): find the channel whose model list contains `<X>` → map channel
+      → login flag over cliproxyapi's fixed channel set (claude/codex/gemini-cli/
+      vertex/aistudio/kimi/antigravity). Then prompt-and-confirm
+      `:ParleyProxy login <provider>`. Also: re-key the default oauth-model-alias
+      to the canonical `claude` channel (verified to serve the whole family), so
+      the config key == the provider. Pure resolution functions in
+      `cliproxy_config` (unit-tested); detection wired at the dispatcher's
+      cliproxy response path.
 
 ## Log
 
@@ -279,6 +293,25 @@ Platform:
   classifier), so a foreign process is never killed. `restart` inherits it.
   2 integration tests (reap-leftover, don't-kill-foreign). make test exit 0 — 95
   spec files, luacheck 0/0.
+
+### 2026-06-13 (M3 — auth-failure → guided login)
+- Read the cliproxyapi Go source (../CLIProxyAPI): it keeps the model→provider
+  map in a STATIC catalog (`model_definitions.go` + embedded models.json) keyed
+  by canonical channels (claude/codex/gemini-cli/vertex/aistudio/kimi/antigravity)
+  and exposes it auth-independently via the management API
+  (`/v0/management/model-definitions/:channel`, `/oauth-model-alias`, `/config`).
+  But `/v1/models` + the "unknown provider" error read the DYNAMIC registry
+  (loaded auth only) — so the model vanishes at error time. Conclusion: resolve
+  from parley's OWN `oauth-model-alias` config (the channel key == provider), no
+  name inference. Verified the canonical `claude` channel key serves the whole
+  family.
+- M3 SHIPPED: pure `cliproxy_config.detect_auth_failure` (pulls the model from
+  the error) + `resolve_login_provider` (channel→login over the fixed channel
+  set) with 9 unit tests; IO `cliproxy.check_auth_failure` (detect → resolve →
+  `vim.ui.select` prompt → `:ParleyProxy login <provider>`, throttled) wired at
+  the dispatcher's cliproxy response path; 4 integration tests. Re-keyed the
+  default oauth-model-alias to the canonical `claude` channel. make test exit 0:
+  97 spec files, luacheck 0/0 across 185.
 
 ### 2026-06-13 (follow-up — oauth-model-alias default)
 - After auto_download spawned a clean 7.1.71, a cliproxy chat failed with

--- a/workshop/issues/000131-managed-cliproxy.md
+++ b/workshop/issues/000131-managed-cliproxy.md
@@ -306,3 +306,17 @@ Platform:
   - Boot downloads a management control-panel asset from GitHub; docs should
     recommend `remote-management: { disable-control-panel: true }` in the user's
     `config` passthrough (avoids the network hit, faster lazy-spawn readiness).
+- Chunk 2 SHIPPED: `cliproxy.lua` IO seam — discover_binary, health_probe
+  (/v1/models classification), spawn (detached/PID-tracked), ensure_running
+  (reuse → spawn → poll, full failure matrix, never hangs), status/stop/restart/
+  login_argv. 22 integration tests vs the process-level fake. Commits 69e8f36,
+  6178867.
+- Chunk 3 SHIPPED: D.query abort channel + cliproxyapi.pre_query (reuses the
+  copilot pre_query seam; additive, backward-compatible) [34b6248]; on_abort
+  teardown at all 4 D.query callers with a shared `collapse_empty_answer` helper,
+  + e2e spec driving the real chain (foreign aborts fast / healthy proceeds /
+  cold-start + transient-stop revive) [86867a4]; `:ParleyProxy` command
+  [#131 M1 commit]; docs + atlas [fd0a252].
+- **Full suite green: `make test` exit 0 — 93 spec files pass, luacheck 0/0
+  across 181 files.** No regressions in chat_respond/skill_runner/memory_prefs/
+  dispatcher/init from the shared-surface changes.

--- a/workshop/issues/000131-managed-cliproxy.md
+++ b/workshop/issues/000131-managed-cliproxy.md
@@ -253,3 +253,17 @@ Platform:
   `pre_query` fires.
 - Branch hygiene: #131 spec commits were relocated off the in-flight #128 branch
   onto a fresh `000131-managed-cliproxy` branch based on `main`; #128 restored.
+- `change-code` plan-quality gate FAILED (correctly): the planned abort path
+  (pre_query not calling its callback) returns from `D.query` cleanly but leaves
+  the caller's spinner — started in `chat_respond.lua` *before* `D.query`, torn
+  down only in the qid-coupled `on_exit` — running forever, so the chat hangs
+  from the user's view (violates "dispatch must never hang"). Both prior reviews
+  missed it (they stopped at `D.query`, not the caller). Plan revised: add an
+  **abort channel** — `pre_query(on_success, on_error)` + a trailing `on_abort`
+  on `D.query`; on pre_query error the dispatcher calls `on_abort`, and
+  `chat_respond` passes a qid-free `on_abort` that stops the spinner + clears the
+  indicator + `vim.notify`s the actionable error. New Task 3.0 (dispatcher) +
+  3.2 (chat_respond teardown) + a spinner-stopped test (Task 3.2/3.4). Also
+  folded: 401-semantics decision into the Task 2.0 gating check; secret name via
+  `providers.get_secret_name` not a literal (ARCH-DRY). Contract is additive —
+  copilot's one-arg `pre_query` ignores the new arg.

--- a/workshop/issues/000131-managed-cliproxy.md
+++ b/workshop/issues/000131-managed-cliproxy.md
@@ -108,8 +108,16 @@ Order: `cliproxy.binary_path` → managed download dir (M2) → `cli-proxy-api` 
 PATH. None found → actionable error naming `brew install …` / `auto_download`.
 
 ### Lifecycle
-- **Lazy:** ensure-running fires on first dispatch to a cliproxy-provider agent,
-  never on nvim launch.
+- **Lazy:** ensure-running fires on dispatch to a cliproxy-provider agent, never
+  on nvim launch.
+- **Ensure-on-every-use (auto-revive):** ensure-running runs on **every** such
+  dispatch, not once-per-session — it's just a cheap health probe. So if the
+  proxy died, crashed, or was explicitly stopped, the next dependent request
+  transparently re-spawns it. There is **no persistent "disabled" state**.
+- **`stop` is transient:** `:ParleyProxy stop` means "kill it now" (free the
+  port / force a fresh config render); it is **not** a suppress flag — the next
+  cliproxy-provider call revives it. (To actually stop using the proxy, switch
+  off `manage` or stop using cliproxy-provider agents.)
 - **Reuse-if-healthy:** probe the endpoint's host:port first; spawn only if
   nothing healthy answers (cooperative with an existing brew service / other
   nvim).
@@ -175,6 +183,9 @@ Parley-verifiable (no manual login needed):
   not a silent mis-dial.
 - Spawn failure / never-healthy each surface an error on the dispatch path
   within the bounded timeout — the chat never hangs.
+- After the proxy dies or is `:ParleyProxy stop`'d, the **next**
+  cliproxy-provider dispatch transparently re-spawns it (no persistent disabled
+  state; no manual `start` required).
 - Rendered `config.yaml` carries the *resolved* `cliproxyapi` secret in
   `api-keys` at perms `0600`; no secret appears in any committed file; the port
   in the rendered config matches the provider endpoint.
@@ -225,3 +236,8 @@ Platform:
   pure `cliproxy_config.lua` vs IO `cliproxy.lua`. (5) JSON-as-YAML made an early
   M1 go/no-go gating task; platform→asset mapping moved to M2 (its consumer);
   Done-when split into parley-verifiable vs post-login.
+- Clarified (user): `:ParleyProxy stop` is **transient**, not a disabled state.
+  Ensure-running runs on *every* cliproxy dispatch (cheap health probe), so a
+  dead/stopped/crashed proxy auto-revives on the next dependent request — no
+  manual restart. Already implied by lazy + reuse-if-healthy; now stated
+  explicitly in Lifecycle + Done-when.

--- a/workshop/issues/000131-managed-cliproxy.md
+++ b/workshop/issues/000131-managed-cliproxy.md
@@ -233,6 +233,13 @@ Platform:
   termopen; doc note that `api_keys.cliproxyapi` is required even when managed.
   Recorded Python-fake + tests-at-close deviations in the plan `## Revisions`.
   Re-verified: **make test exit 0 — 94 spec files, luacheck 0/0 across 182.**
+- Side-quest (user request): ship managed cliproxy **on by default** — `config.lua`
+  now has an active `cliproxy = { manage = true, config = {disable-control-panel} }`,
+  and `api_keys.cliproxyapi` defaults to `"parley-local"` (a loopback-only
+  client↔proxy handshake token, not subscription auth) so a fresh machine works
+  with zero env setup. Safe: dormant unless a cliproxyapi agent runs, and
+  reuses an existing proxy. README + atlas updated to "on by default but dormant".
+  make test still exit 0 (94 specs).
 - Brainstormed via superpowers-brainstorming. Converged design captured in
   `## Spec`. Five decisions logged inline (audience, ownership, config source,
   auto_download deferral, platform scope). cliproxyapi CLI/release facts

--- a/workshop/issues/000131-managed-cliproxy.md
+++ b/workshop/issues/000131-managed-cliproxy.md
@@ -201,7 +201,7 @@ Platform:
 
 ## Plan
 
-- [ ] M1 — orchestrator spine (macOS + Linux). Gating task FIRST: prove
+- [x] M1 — orchestrator spine (macOS + Linux). Gating task FIRST: prove
       JSON-as-YAML boots a real `cli-proxy-api --config` (go/no-go before the
       rest). Then: pure `cliproxy_config.lua` (merge, parse host:port from
       endpoint, vault-resolved secret injection, JSON-as-YAML emit) +
@@ -219,6 +219,20 @@ Platform:
 ## Log
 
 ### 2026-06-12
+- 2026-06-12: closed M1 — make test exit 0: 93 spec files pass, luacheck 0/0 across 181 files. New: cliproxy_config 13 unit (pure, no mocks), cliproxy_lifecycle 22 integration (process-level fake: discover/probe/spawn/ensure_running full failure matrix, never hangs), cliproxy_dispatch 3 e2e (real pre_query→ensure_running→on_abort chain: foreign aborts fast/healthy proceeds/transient-stop revive), cliproxy_command 3, dispatcher Group H abort channel, providers_pre_query 3. Task 2.0 gating validated against real cliproxyapi v7.1.60 (JSON-as-YAML boots; /v1/models identity route; 401 vs 200-empty semantics).; review verdict: FIX-THEN-SHIP
+- **FIX-THEN-SHIP resolved (no Critical; 4 Important + minors fixed).**
+  (1) ARCH-DRY: extracted `cliproxy.render_opts()` (write/drift/status share it);
+  (2) ARCH-DRY: `cliproxy.login_providers()` is the single source for completion
+  + validation. (3) Per-caller on_abort teardowns now tested for real —
+  `cliproxy_caller_teardown_spec`: memory_prefs via the real abort chain
+  (process_next keeps the batch moving), chat_respond + skill_runner via a
+  D.query mock invoking the real on_abort (block-collapse on the default path /
+  `_in_flight` clear), exposed `skill_runner.is_in_flight`. (4) Added a 0600 +
+  secret-in-`api-keys`-on-disk assertion. Minors: `login_argv` renders config
+  first (honors custom auth_dir); `jobstart({term=true})` over deprecated
+  termopen; doc note that `api_keys.cliproxyapi` is required even when managed.
+  Recorded Python-fake + tests-at-close deviations in the plan `## Revisions`.
+  Re-verified: **make test exit 0 — 94 spec files, luacheck 0/0 across 182.**
 - Brainstormed via superpowers-brainstorming. Converged design captured in
   `## Spec`. Five decisions logged inline (audience, ownership, config source,
   auto_download deferral, platform scope). cliproxyapi CLI/release facts

--- a/workshop/issues/000131-managed-cliproxy.md
+++ b/workshop/issues/000131-managed-cliproxy.md
@@ -211,7 +211,7 @@ Platform:
       against a process-level fake proxy binary (per AGENTS.md external-service
       rule). Failure modes (spawn-fail, foreign-port, never-healthy, 401/auth)
       each covered.
-- [ ] M2 — `auto_download`: platform→asset-name mapping (pure, with its
+- [x] M2 — `auto_download`: platform→asset-name mapping (pure, with its
       consumer here — not M1), pinned cross-platform release fetch + checksum
       verify + extract; `:ParleyProxy update`; discovery falls through to managed
       dir.
@@ -219,6 +219,16 @@ Platform:
 ## Log
 
 ### 2026-06-12
+- 2026-06-12: closed M2 — measured increment = total 4.03h - M1 2.74h (sdlc actual cannot scope per-milestone). make test exit 0: 95 spec files, luacheck 0/0 across 183. M2: cliproxy_config platform/asset_name/parse_checksums 9 unit (injectable uname, deterministic); cliproxy_download 3 integration (fixture release over local HTTP, no network: download→sha256-verify→extract + tampered-checksum REFUSAL); discover_binary managed-dir fall-through; ensure_running auto_download trigger (opt-in); :ParleyProxy update. Grounded on real release v7.1.71 (asset naming aarch64, "<sha>  <name>" checksums, tarball roots cli-proxy-api).; review verdict: FIX-THEN-SHIP
+- **M2 FIX-THEN-SHIP resolved (no Critical; 2 Important + minors).** (1) Added the
+  missing test for the `ensure_running` auto_download *trigger* (auto_download=true
+  + nothing found → download() called → spawn proceeds; unset → not called → "no
+  binary"). (2) Bounded the download curls (`--connect-timeout`/`--max-time`) so a
+  stalled synchronous fetch can't freeze the editor. Minors: `BIN_NAME` const;
+  `os.remove(tmp)` on the download-failure path; FreeBSD-best-effort comment.
+  Re-verified after `make test-clean-env`: make test exit 0 — 95 spec files,
+  luacheck 0/0 across 183 (a transient chat_dirs failure was test-env pollution
+  from manual single-file runs, not a regression).
 - 2026-06-12: closed M1 — make test exit 0: 93 spec files pass, luacheck 0/0 across 181 files. New: cliproxy_config 13 unit (pure, no mocks), cliproxy_lifecycle 22 integration (process-level fake: discover/probe/spawn/ensure_running full failure matrix, never hangs), cliproxy_dispatch 3 e2e (real pre_query→ensure_running→on_abort chain: foreign aborts fast/healthy proceeds/transient-stop revive), cliproxy_command 3, dispatcher Group H abort channel, providers_pre_query 3. Task 2.0 gating validated against real cliproxyapi v7.1.60 (JSON-as-YAML boots; /v1/models identity route; 401 vs 200-empty semantics).; review verdict: FIX-THEN-SHIP
 - **FIX-THEN-SHIP resolved (no Critical; 4 Important + minors fixed).**
   (1) ARCH-DRY: extracted `cliproxy.render_opts()` (write/drift/status share it);

--- a/workshop/issues/000131-managed-cliproxy.md
+++ b/workshop/issues/000131-managed-cliproxy.md
@@ -241,3 +241,15 @@ Platform:
   dead/stopped/crashed proxy auto-revives on the next dependent request — no
   manual restart. Already implied by lazy + reuse-if-healthy; now stated
   explicitly in Lifecycle + Done-when.
+- Claimed (est 16h) → working. `start-plan`: ARCH-DRY + ARCH-PURE delivered;
+  both already shaped the design (reuse `pre_query`/`vault`; pure config core vs
+  IO shell). Implementation plan written to
+  `workshop/plans/000131-managed-cliproxy-plan.md` via superpowers-writing-plans.
+  Fresh-eyes plan review found 2 real issues — a dead line in `parse_endpoint`
+  and `make test-spec SPEC=` being a traceability key (not a filename, would
+  no-op the TDD loop) — both fixed; reviewer confirmed the `pre_query` abort path
+  genuinely can't hang the chat (D.query only runs the query inside the
+  callback) and that `vault.get_secret` is resolved by `run_with_secret` before
+  `pre_query` fires.
+- Branch hygiene: #131 spec commits were relocated off the in-flight #128 branch
+  onto a fresh `000131-managed-cliproxy` branch based on `main`; #128 restored.

--- a/workshop/issues/000131-managed-cliproxy.md
+++ b/workshop/issues/000131-managed-cliproxy.md
@@ -267,3 +267,15 @@ Platform:
   folded: 401-semantics decision into the Task 2.0 gating check; secret name via
   `providers.get_secret_name` not a literal (ARCH-DRY). Contract is additive —
   copilot's one-arg `pre_query` ignores the new arg.
+- `change-code` round 2 FAILED (correctly), two more real gaps: (1) the abort
+  channel was wired at only 2 of **4** `D.query` callers — `skill_runner.lua`
+  (leaks `_in_flight[buf]=true` → that buffer's skill runs blocked forever) and
+  `memory_prefs.lua` (batch stalls) also route through cliproxy. (2) The
+  main-path teardown/test was spinner-scoped, but the spinner is
+  web-search-gated — off the default path nothing spins; the real leftover is
+  the inserted `agent_header`/`stream_placeholder` blocks, and the "spinner
+  stopped" test passes vacuously. Fixed: wire `on_abort` at all 4 callers
+  (per-caller teardown); extract a shared `collapse_empty_answer` helper reused
+  by `on_exit` + `on_abort` (ARCH-DRY); test asserts blocks removed on the
+  *default* path. Minor folds: port-less-endpoint caveat; read merged config via
+  `require("parley").config.cliproxy`, not the module's `M`.

--- a/workshop/issues/000131-managed-cliproxy.md
+++ b/workshop/issues/000131-managed-cliproxy.md
@@ -1,11 +1,12 @@
 ---
 id: 000131
-status: working
+status: done
 deps: []
 github_issue:
 created: 2026-06-12
-updated: 2026-06-12
+updated: 2026-06-14
 estimate_hours: 16
+actual_hours: 11.81
 ---
 
 # Manage cliproxyapi lifecycle + config
@@ -233,6 +234,8 @@ Platform:
 ## Log
 
 
+
+- 2026-06-14: closed — All 3 milestones shipped + boundary-reviewed (M1 orchestrator spine, M2 auto_download, M3 auth-failure→login), each FIX-THEN-SHIP resolved with no Critical. make test exit 0 (JOBS=4): 97 spec files, luacheck 0/0 across 185. Operator validated the full flow end-to-end on real subscription: render→spawn→reuse-if-healthy→transient-stop/reap-by-port→auto_download (7.1.71, checksum-verified)→oauth-model-alias (claude family served)→auth-failure guided login. Test-isolation contamination (tests writing the real ~/.local/share/nvim) root-caused + fixed via data_root + _set_data_dir seam; a bare lifecycle run is now 28/0 and leaves the real dir untouched (verified).
 - 2026-06-14: closed M3 — measured increment = total 11.51h - (M1 2.74 + M2 1.29) (sdlc actual cannot scope per-milestone; this window had heavy interactive debugging + reading the CLIProxyAPI Go source). make test exit 0 (JOBS=4): 97 spec files, luacheck 0/0 across 185. M3: cliproxy_config detect_auth_failure + resolve_login_provider 9 unit tests; cliproxy_auth_login 4 integration (prompt-on-failure / no-op-success / no-op-non-cliproxy / canonical-channel resolution). Resolution is CONFIG-DRIVEN (oauth-model-alias channel key == provider), NOT name inference — verified against the CLIProxyAPI source (dynamic registry drops models at auth-error time; static catalog keyed by canonical channels claude/codex/gemini-cli/...). Re-keyed default to canonical `claude` channel, verified it serves the whole family against real 7.1.71. Window also covers post-M2 side-quests: stop-reaps-by-port (2 tests), oauth-model-alias default (verified e2e), and two topic-gen fixes (system-prompt leak into the title, incl the synthetic leading-user-turn form).; review verdict: FIX-THEN-SHIP
 ### 2026-06-12
 - 2026-06-12: closed M2 — measured increment = total 4.03h - M1 2.74h (sdlc actual cannot scope per-milestone). make test exit 0: 95 spec files, luacheck 0/0 across 183. M2: cliproxy_config platform/asset_name/parse_checksums 9 unit (injectable uname, deterministic); cliproxy_download 3 integration (fixture release over local HTTP, no network: download→sha256-verify→extract + tampered-checksum REFUSAL); discover_binary managed-dir fall-through; ensure_running auto_download trigger (opt-in); :ParleyProxy update. Grounded on real release v7.1.71 (asset naming aarch64, "<sha>  <name>" checksums, tarball roots cli-proxy-api).; review verdict: FIX-THEN-SHIP

--- a/workshop/issues/000131-managed-cliproxy.md
+++ b/workshop/issues/000131-managed-cliproxy.md
@@ -268,6 +268,17 @@ Platform:
   tarball roots `cli-proxy-api`). `auto_download` kept **opt-in** (auto-fetching a
   binary is an explicit choice; brainstorm's "A is opt-in").
 - Full suite: **make test exit 0 — 95 spec files, luacheck 0/0 across 183.**
+
+### 2026-06-12 (follow-up — stop reaps by port)
+- Operator hit the detached-proxy rough edge: a leftover cliproxy parley spawned
+  in an earlier session (brew 7.1.60 on :8317) was reused by reuse-if-healthy, so
+  a no-binary auto_download test never fired the download (correct, but the
+  leftover was unreachable — `:ParleyProxy stop` was session-scoped). Fixed:
+  `stop` now reaps a leftover cliproxy on the managed port across sessions
+  (lsof → kill), but **identity-probes the port first** (same `/v1/models`
+  classifier), so a foreign process is never killed. `restart` inherits it.
+  2 integration tests (reap-leftover, don't-kill-foreign). make test exit 0 — 95
+  spec files, luacheck 0/0.
 - Brainstormed via superpowers-brainstorming. Converged design captured in
   `## Spec`. Five decisions logged inline (audience, ownership, config source,
   auto_download deferral, platform scope). cliproxyapi CLI/release facts

--- a/workshop/parley/2026-06-12.13-14-32.700_kaggle-competitions-guide.md
+++ b/workshop/parley/2026-06-12.13-14-32.700_kaggle-competitions-guide.md
@@ -1,0 +1,11 @@
+---
+topic: Kaggle competitions guide
+file: 2026-06-12.13-14-32.700_kaggle-competitions-guide.md
+tags:
+---
+
+💬: tell me about kaggle competition and how can I get some help to learn about it. 
+
+🤖:[ToolOpus*]
+
+💬: 

--- a/workshop/plans/000131-managed-cliproxy-plan.md
+++ b/workshop/plans/000131-managed-cliproxy-plan.md
@@ -1,0 +1,459 @@
+# Managed cliproxyapi Implementation Plan
+
+> **For agentic workers:** Consult AGENTS.md Section 3 (Subagent Strategy) to determine the appropriate execution approach: use superpowers-subagent-driven-development (if subagents are suitable per AGENTS.md) or superpowers-executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let parley opt-in to *managing* a cliproxyapi instance — render its `config.yaml` from Lua `setup{}`, and lazily start/health-check/reuse the proxy on demand — so users stop hand-maintaining `/opt/homebrew` config and `brew services`.
+
+**Architecture:** A **pure config core** (`cliproxy_config.lua`: parse host:port from the provider endpoint, merge the raw `config` passthrough with wiring fields, inject the resolved client secret, emit JSON-as-YAML) injected into a **thin IO shell** (`cliproxy.lua`: binary discovery, `vim.uv` detached spawn, identity-checked health probe, reuse-if-healthy, the `:ParleyProxy` commands). The shell is reached through the **existing `pre_query` adapter seam** (the one copilot already uses to prep before a query) — no new dispatcher branch. ARCH-PURE (pure core, thin IO) and ARCH-DRY (reuse `pre_query` + `vault`, don't re-model cliproxy's schema) shape the split.
+
+**Tech Stack:** Lua (Neovim), `vim.uv` (libuv) for process spawn + TCP, `vim.json` for JSON-as-YAML emission, `curl` (already parley's transport) for the health probe, Plenary/busted for tests.
+
+**Spec:** `workshop/issues/000131-managed-cliproxy.md` (`## Spec`).
+
+---
+
+## Core Concepts
+
+### Pure entities
+
+| Name | Lives in | Status |
+|------|----------|--------|
+| `parse_endpoint` | `lua/parley/cliproxy_config.lua` | new |
+| `render` | `lua/parley/cliproxy_config.lua` | new |
+| `encode` | `lua/parley/cliproxy_config.lua` | new |
+| `asset_name` | `lua/parley/cliproxy_config.lua` | new (M2) |
+
+- **parse_endpoint** — `"http://127.0.0.1:8317/v1/chat/completions"` → `host="127.0.0.1", port=8317`. The provider endpoint is the single source of truth for host:port (spec §"host:port — single source of truth"); everything downstream derives from it. ARCH-DRY: kills the "second port knob" drift.
+  - **Relationships:** 1:1 with the resolved `D.providers.cliproxyapi.endpoint` string.
+  - **Future extensions:** unix-socket endpoints; scheme-aware default ports.
+
+- **render** — given `{ host, port, auth_dir, secret, config }`, returns the cliproxy config *table*: deep-copies the raw `config` passthrough, overlays the wiring fields (`host`, `port`, `auth-dir`), and injects the resolved `secret` as the sole `api-keys` entry. Returns `(config_table, overrides)` where `overrides` lists any raw-config keys it clobbered (so the IO caller can warn). PURE: takes the already-resolved secret as an argument — it does **not** touch the vault. ARCH-DRY: does not re-model cliproxy's schema; unknown keys pass through untouched.
+  - **Relationships:** consumes `parse_endpoint` output + the `M.config.cliproxy` block + a resolved secret string.
+  - **DRY rationale:** one place that knows the wiring-field names (`host`/`port`/`auth-dir`/`api-keys`); the rest of cliproxy's schema is the user's.
+  - **Future extensions:** multiple `api-keys`; per-model routing helpers.
+
+- **encode** — `config_table` → string via `vim.json.encode` (JSON is valid YAML 1.2, so cliproxy's YAML parser accepts it — the spec's gating bet). PURE (vim.json is deterministic, no IO).
+  - **Future extensions:** a minimal nested+list YAML emitter fallback **iff** the gating task proves cliproxy rejects JSON (spec §Emission).
+
+- **asset_name** *(M2)* — `{os, arch, version}` → `"CLIProxyAPI_<version>_<os>_<arch>.tar.gz"`. PURE. Lives with its only consumer (M2 download), not M1.
+
+### Integration points
+
+| Name | Lives in | Status | Wraps |
+|------|----------|--------|-------|
+| `Cliproxy.ensure_running` | `lua/parley/cliproxy.lua` | new | process + TCP + vault + fs |
+| `Cliproxy.health_probe` | `lua/parley/cliproxy.lua` | new | `curl` subprocess |
+| `Cliproxy.spawn` | `lua/parley/cliproxy.lua` | new | `vim.uv.spawn` |
+| `Cliproxy.discover_binary` | `lua/parley/cliproxy.lua` | new | PATH / fs |
+| `Cliproxy` commands | `lua/parley/cliproxy.lua` + `init.lua` | new | user commands |
+| `cliproxyapi.pre_query` | `lua/parley/providers.lua` | modified | dispatcher seam |
+| `fake_cliproxy` | `tests/fixtures/fake_cliproxy.lua` | new | process-level fake |
+
+- **Cliproxy.ensure_running(callback, on_error)** — the heart. Reads `M.config.cliproxy` + the resolved endpoint, resolves the secret via `vault.get_secret("cliproxyapi")`, renders + writes `config.yaml` (`0600`), health-probes host:port; if healthy → `callback()`; if down → `discover_binary` → `spawn` → poll health (bounded ~5s) → `callback()`; on any failure → `on_error(msg)` so the dispatch path fails fast, never hangs.
+  - **Injected into:** called from `cliproxyapi.pre_query`. The pure `render`/`encode`/`parse_endpoint` are injected here (this is the only place IO meets the pure core).
+  - **Future extensions:** M2 `auto_download` slots into `discover_binary`'s fall-through.
+
+- **Cliproxy.health_probe(host, port, secret, cb)** — `curl` GET to the cliproxy **identity route**, classifies: `healthy` (200, cliproxy-shaped) / `unauthenticated` (401 → login needed) / `foreign` (200 but not cliproxy-shaped) / `down` (connection refused). The identity route is confirmed during the M1 gating task (candidates `/v1/models`, `/health`).
+  - **Injected into:** `ensure_running`, `status`.
+
+- **Cliproxy.spawn(binary, config_path)** — `vim.uv.spawn` **detached** (`detached=true`, `uv.unref` the handle) so the daemon outlives nvim and is shared; records our PID so `stop` only kills a parley-spawned proxy.
+
+- **Cliproxy.discover_binary()** — `cliproxy.binary_path` → (M2 managed dir) → `cli-proxy-api` on PATH. Returns path or nil.
+
+- **Cliproxy commands** — `:ParleyProxy status|start|stop|restart|login`, registered in `init.lua` under `M.config.cmd_prefix`. `login` shells out to `cli-proxy-api login [--no-browser]`; `status` reports binary source, health/auth state, host:port, auth-dir, rendered-config path, and config-drift.
+
+- **cliproxyapi.pre_query** — a 6-line adapter hook delegating to `require("parley.cliproxy").ensure_running`. ARCH-DRY: reuses the dispatcher's existing `pre_query` mechanism (dispatcher.lua:387) — copilot already proves the pattern. No-op (immediate callback) when `manage` is off.
+
+- **fake_cliproxy** — a real subprocess (Lua via `nvim -l`, or a tiny TCP listener) used by integration tests. Modes: `healthy` (answers identity route 200), `foreign` (200 wrong shape), `unauth` (401), `slow` (never healthy), `crash` (exits immediately). Process-level per AGENTS.md external-service rule — function mocks would miss the reuse-vs-spawn and identity-classification bugs.
+
+---
+
+## Chunk 1: Pure config core
+
+`## Chunk 1` — `lua/parley/cliproxy_config.lua` + `tests/unit/cliproxy_config_spec.lua`. No IO; tests run without mocks.
+
+### Task 1.1: `parse_endpoint`
+
+**Files:**
+- Create: `lua/parley/cliproxy_config.lua`
+- Test: `tests/unit/cliproxy_config_spec.lua`
+- Modify: `atlas/traceability.yaml`
+
+- [ ] **Step 0: Register the traceability key** (so `make test-spec SPEC=…` resolves — `SPEC` is a key in `atlas/traceability.yaml`, *not* a filename; without this the runner prints "No tests mapped" and runs nothing). Add under `atlas:`:
+
+```yaml
+  providers/cliproxy-managed:
+    code:
+      - lua/parley/cliproxy_config.lua
+      - lua/parley/cliproxy.lua
+      - lua/parley/providers.lua
+    tests:
+      - tests/unit/cliproxy_config_spec.lua
+      - tests/unit/providers_pre_query_spec.lua
+      - tests/integration/cliproxy_lifecycle_spec.lua
+      - tests/integration/cliproxy_dispatch_spec.lua
+```
+
+(Inner-loop alternative while iterating on one file: `make test-unit` auto-discovers every `tests/unit/*_spec.lua` and prints `PASS:`/`FAIL:` per file — grep for the new spec. `make test-spec SPEC=providers/cliproxy-managed` runs exactly this feature's mapped files.)
+
+- [ ] **Step 1: Write the failing test**
+
+```lua
+-- tests/unit/cliproxy_config_spec.lua
+local cc = require("parley.cliproxy_config")
+
+describe("parse_endpoint", function()
+    it("extracts host and numeric port from a standard endpoint", function()
+        local host, port = cc.parse_endpoint("http://127.0.0.1:8317/v1/chat/completions")
+        assert.equals("127.0.0.1", host)
+        assert.equals(8317, port)
+    end)
+
+    it("handles https and a hostname", function()
+        local host, port = cc.parse_endpoint("https://localhost:9000/v1/chat/completions")
+        assert.equals("localhost", host)
+        assert.equals(9000, port)
+    end)
+
+    it("defaults the port when none is given", function()
+        local host, port = cc.parse_endpoint("http://localhost/v1/chat/completions")
+        assert.equals("localhost", host)
+        assert.equals(80, port)
+    end)
+
+    it("returns nil for an unparseable endpoint", function()
+        local host, port = cc.parse_endpoint("not-a-url")
+        assert.is_nil(host)
+        assert.is_nil(port)
+    end)
+end)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `make test-spec SPEC=providers/cliproxy-managed`
+Expected: FAIL — `module 'parley.cliproxy_config' not found`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```lua
+-- lua/parley/cliproxy_config.lua
+-- Pure config core for the managed cliproxyapi instance (issue #131).
+-- No IO: every function here is deterministic and unit-tested without mocks
+-- (ARCH-PURE). The IO shell lives in parley/cliproxy.lua.
+local M = {}
+
+--- Parse host:port out of a provider endpoint URL.
+--- The provider endpoint is the single source of truth for host:port
+--- (spec §"host:port — single source of truth").
+---@param endpoint string
+---@return string|nil host, number|nil port
+function M.parse_endpoint(endpoint)
+    if type(endpoint) ~= "string" then
+        return nil, nil
+    end
+    local host, port = endpoint:match("^https?://([^:/]+):(%d+)")
+    if host and port then
+        return host, tonumber(port)
+    end
+    local scheme, h = endpoint:match("^(https?)://([^:/]+)")
+    if scheme and h then
+        return h, scheme == "https" and 443 or 80
+    end
+    return nil, nil
+end
+
+return M
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `make test-spec SPEC=providers/cliproxy-managed`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lua/parley/cliproxy_config.lua tests/unit/cliproxy_config_spec.lua
+git commit -m "#131 M1: cliproxy_config.parse_endpoint (pure host:port from endpoint)"
+```
+
+### Task 1.2: `render`
+
+**Files:**
+- Modify: `lua/parley/cliproxy_config.lua`
+- Test: `tests/unit/cliproxy_config_spec.lua`
+
+**Bind-vs-dial decision (spec §host:port M1 note):** for a *locally managed* proxy we bind to the **same host the client dials** (`127.0.0.1`) — loopback-only is the safe default (no `0.0.0.0` exposure). So `render` passes `opts.host` straight through as the proxy `host`; the test below pins that. (Revisit only if a future config dials a non-loopback host.)
+
+- [ ] **Step 1: Write the failing test**
+
+```lua
+describe("render", function()
+    it("overlays wiring fields and injects the resolved secret", function()
+        local cfg = cc.render({
+            host = "127.0.0.1", port = 8317,
+            auth_dir = "~/.cli-proxy-api",
+            secret = "sk-local-123",
+            config = { ["some-provider"] = { model = "x" } },
+        })
+        assert.equals("127.0.0.1", cfg.host)
+        assert.equals(8317, cfg.port)
+        assert.equals("~/.cli-proxy-api", cfg["auth-dir"])
+        assert.equals("number", type(cfg.port))  -- stays numeric for YAML/JSON
+        assert.same({ "sk-local-123" }, cfg["api-keys"])
+        assert.same({ model = "x" }, cfg["some-provider"])  -- passthrough preserved
+    end)
+
+    it("binds to the dialed host (loopback), not 0.0.0.0", function()
+        local cfg = cc.render({ host = "127.0.0.1", port = 8317, secret = "s", config = {} })
+        assert.equals("127.0.0.1", cfg.host)
+    end)
+
+    it("does not mutate the input config table", function()
+        local raw = { port = 1 }
+        cc.render({ host = "h", port = 8317, secret = "s", config = raw })
+        assert.equals(1, raw.port)  -- original untouched
+    end)
+
+    it("reports overridden raw-config keys for the caller to warn on", function()
+        local _, overrides = cc.render({
+            host = "127.0.0.1", port = 8317, secret = "s",
+            config = { host = "0.0.0.0", port = 9999 },
+        })
+        table.sort(overrides)
+        assert.same({ "host", "port" }, overrides)
+    end)
+
+    it("emits an empty api-keys list when no secret is present", function()
+        local cfg = cc.render({ host = "h", port = 8317, config = {} })
+        assert.same({}, cfg["api-keys"])
+    end)
+end)
+```
+
+- [ ] **Step 2: Run** `make test-spec SPEC=providers/cliproxy-managed` → FAIL (`render` nil).
+
+- [ ] **Step 3: Implement**
+
+```lua
+--- Merge the raw `config` passthrough with parley's wiring fields and the
+--- resolved client secret. Pure — the secret is passed in already resolved;
+--- this never touches the vault (ARCH-PURE). Unknown keys pass through
+--- untouched (ARCH-DRY: we do not re-model cliproxy's schema).
+---@param opts table # { host, port, auth_dir?, secret?, config? }
+---@return table config_table, string[] overrides
+function M.render(opts)
+    local cfg = vim.deepcopy(opts.config or {})
+    local overrides = {}
+    if cfg.host ~= nil and cfg.host ~= opts.host then
+        table.insert(overrides, "host")
+    end
+    if cfg.port ~= nil and cfg.port ~= opts.port then
+        table.insert(overrides, "port")
+    end
+    cfg.host = opts.host
+    cfg.port = opts.port
+    if opts.auth_dir ~= nil then
+        cfg["auth-dir"] = opts.auth_dir
+    end
+    if opts.secret ~= nil and opts.secret ~= "" then
+        cfg["api-keys"] = { opts.secret }
+    else
+        cfg["api-keys"] = {}
+    end
+    return cfg, overrides
+end
+```
+
+- [ ] **Step 4: Run** → PASS.
+- [ ] **Step 5: Commit** `#131 M1: cliproxy_config.render (merge wiring + secret, passthrough)`
+
+### Task 1.3: `encode` (JSON-as-YAML)
+
+**Files:** Modify `lua/parley/cliproxy_config.lua`; Test same spec.
+
+- [ ] **Step 1: Failing test**
+
+```lua
+describe("encode", function()
+    it("emits JSON that round-trips and keeps api-keys a list", function()
+        local cfg = cc.render({ host = "127.0.0.1", port = 8317, secret = "s", config = {} })
+        local str = cc.encode(cfg)
+        local back = vim.json.decode(str)
+        assert.equals(8317, back.port)
+        assert.same({ "s" }, back["api-keys"])  -- list, not object
+    end)
+end)
+```
+
+- [ ] **Step 2: Run** → FAIL.
+- [ ] **Step 3: Implement**
+
+```lua
+--- Emit the config as a string cliproxy's --config can read. JSON is valid
+--- YAML 1.2, so we emit JSON and skip a YAML emitter (spec §Emission; this is
+--- the M1 gating bet, validated against a real cli-proxy-api in Task 2.0).
+---@param config_table table
+---@return string
+function M.encode(config_table)
+    return vim.json.encode(config_table)
+end
+```
+
+- [ ] **Step 4: Run** → PASS.
+- [ ] **Step 5: Commit** `#131 M1: cliproxy_config.encode (JSON-as-YAML)`
+
+> **Chunk 1 review:** dispatch plan/code review of `cliproxy_config.lua` + spec before Chunk 2 (per AGENTS.md the milestone review runs at `sdlc milestone-close`; this is an optional mid-chunk sanity check).
+
+---
+
+## Chunk 2: IO lifecycle shell + process-level fake
+
+`## Chunk 2` — `lua/parley/cliproxy.lua`, `tests/fixtures/fake_cliproxy.lua`, `tests/integration/cliproxy_lifecycle_spec.lua`.
+
+### Task 2.0: Gating task — prove JSON-as-YAML boots a real proxy (GO/NO-GO)
+
+**Manual, before writing lifecycle code. Spec §Emission makes this a hard gate.**
+
+- [ ] **Step 1:** Install a real binary locally (`brew install cliproxyapi` or download a pinned release tarball for this machine). Record the version + identity route in `## Log`.
+- [ ] **Step 2:** In a scratch nvim, build a minimal config via `cliproxy_config.render` + `encode`, write it to a temp `.yaml`, and run `cli-proxy-api --config <tmp>`.
+- [ ] **Step 3:** Confirm it boots and answers an HTTP probe. **Decide the identity route** (`/health` vs `/v1/models`) and record it. Also confirm `auth-dir` `~` handling: the cliproxy docs say `auth-dir` "supports `~` for home directory", so `render` writes it **literally** (no `vim.fn.expand`) — verify the booted proxy resolves `~` itself; record the result.
+- [ ] **GO:** proceed. **NO-GO** (parser rejects JSON): add a nested+list YAML emitter as Task 1.4 (its own sub-task — *not* a flat emitter; spec says flat is non-viable), then continue. Log the decision either way.
+
+### Task 2.1: `discover_binary`
+
+**Files:** Create `lua/parley/cliproxy.lua`; Test `tests/integration/cliproxy_lifecycle_spec.lua` (integration: touches fs/PATH).
+
+- [ ] **Step 1: Failing test** — given an explicit `binary_path` that exists, returns it; given a bogus path + nothing on PATH, returns nil. (Use a temp file as a fake binary; set `M.config.cliproxy.binary_path`.)
+- [ ] **Step 2: Run** `make test-spec SPEC=providers/cliproxy-managed` → FAIL.
+- [ ] **Step 3: Implement** `discover_binary()`: check `cfg.binary_path` (fs exists + executable), else `vim.fn.exepath("cli-proxy-api")`, else nil. (M2 inserts the managed dir between the two.)
+- [ ] **Step 4: Run** → PASS. **Step 5: Commit** `#131 M1: cliproxy.discover_binary`
+
+### Task 2.2: `health_probe` + identity classification
+
+**Files:** Modify `lua/parley/cliproxy.lua`; new `tests/fixtures/fake_cliproxy.lua`; Test the lifecycle spec.
+
+- [ ] **Step 1: Build the fake** — `tests/fixtures/fake_cliproxy.lua`: a `vim.uv` TCP server (run via `nvim -l`) that, by a `--mode` arg, answers the identity route with 200-cliproxy-shape / 200-foreign / 401 / never / exits immediately. It binds the port from `--port` and the identity route decided in Task 2.0.
+- [ ] **Step 2: Failing test** — start `fake_cliproxy --mode healthy --port <p>`; assert `health_probe` classifies `healthy`. Repeat for `foreign`→`foreign`, `unauth`→`unauthenticated`, nothing-listening→`down`.
+- [ ] **Step 3: Run** → FAIL.
+- [ ] **Step 4: Implement** `health_probe(host, port, secret, cb)`: `curl -s -o - -w "%{http_code}"` (or `vim.uv`) GET to the identity route with the bearer; classify by status + body shape. Async, calls `cb(state)`.
+- [ ] **Step 5: Run** → PASS. **Commit** `#131 M1: cliproxy.health_probe + fake_cliproxy (identity classification)`
+
+### Task 2.3: `spawn` (detached) + PID tracking
+
+- [ ] **Step 1: Failing test** — spawn `fake_cliproxy --mode healthy`; assert the process starts, a PID is recorded, and a subsequent `health_probe` goes `healthy`. Assert the recorded PID is parley-owned (so `stop` is scoped).
+- [ ] **Step 2–4:** Implement `spawn(binary, config_path)` via `vim.uv.spawn` with `detached=true`, `uv.unref(handle)`, capture `pid` into module state. Return the handle/pid.
+- [ ] **Step 5: Commit** `#131 M1: cliproxy.spawn (detached, PID-tracked)`
+
+### Task 2.4: `ensure_running` — reuse / spawn / failure modes
+
+This wires the pure core to IO. Cover **every** spec failure mode.
+
+- [ ] **Step 1: Failing tests** (one `it` each):
+  - reuse-if-healthy: a `healthy` fake already listening → `ensure_running` calls `callback`, **does not** spawn (assert PID unchanged / no new process).
+  - cold start: nothing listening + a `healthy`-mode fake as the discovered binary → spawns, polls healthy, calls `callback`.
+  - foreign port: a `foreign` fake listening → `on_error` with "non-cliproxy process", no spawn.
+  - never-healthy: discovered binary is the `slow` fake → bounded ~5s wait → `on_error("timed out")`, dispatch not blocked past the bound.
+  - spawn-fail: discovered binary is the `crash` fake → `on_error("exited")`.
+  - unauthenticated: a `unauth` fake → `on_error` mentioning `:ParleyProxy login` (login not done).
+- [ ] **Step 2: Run** → FAIL.
+Also implement `M.is_managed()` → `M.config.cliproxy and M.config.cliproxy.manage == true` (the gate the `pre_query` seam in Task 3.1 calls). Add a one-line test.
+
+- [ ] **Step 3: Implement** `ensure_running(callback, on_error)`:
+  1. read `M.config.cliproxy`; if `manage` is not true → `callback()` immediately (no-op path).
+  2. `host, port = cliproxy_config.parse_endpoint(D.providers.cliproxyapi.endpoint)`.
+  3. `secret = vault.get_secret("cliproxyapi")`.
+  4. `cfg, overrides = cliproxy_config.render{...}`; if `#overrides>0` log a warning naming them; write `encode(cfg)` to `stdpath('data')/parley/cliproxy/config.yaml` at `0600`.
+  5. `health_probe` → `healthy`: `callback()`. `foreign`: `on_error`. `unauthenticated`: `on_error` (login). `down`: `discover_binary` (nil → `on_error` naming `brew install`/`auto_download`) → `spawn` → poll `health_probe` every ~250ms up to ~5s → healthy `callback()` / else `on_error("timed out")`. Crash mid-poll → `on_error("exited")`.
+- [ ] **Step 4: Run** → all PASS.
+- [ ] **Step 5: Commit** `#131 M1: cliproxy.ensure_running (reuse/spawn + all failure modes)`
+
+### Task 2.5: commands — `status|start|stop|restart|login`
+
+- [ ] **Step 1: Failing tests** — `status()` returns a table with binary source, health/auth state, host:port, auth-dir, config path, and a `config_drift` bool (rendered ≠ running). `stop()` only kills a parley-spawned PID (a reused/foreign daemon is left alone). `restart()` = stop-if-ours + ensure. `login()` builds the `cli-proxy-api login` argv.
+- [ ] **Step 2–4:** Implement. Keep each a thin wrapper; `status` composes `discover_binary` + `health_probe` + a config-drift check (compare on-disk rendered file to a fresh `render`).
+- [ ] **Step 5: Commit** `#131 M1: cliproxy commands (status/start/stop/restart/login)`
+
+> **Chunk 2 review:** the process-level fake + `ensure_running` failure-mode matrix is the riskiest surface — sanity-review before wiring.
+
+---
+
+## Chunk 3: Dispatcher wiring + commands registration + activation
+
+`## Chunk 3` — `lua/parley/providers.lua`, `lua/parley/init.lua`, `tests/unit/providers_pre_query_spec.lua`, `tests/integration/cliproxy_dispatch_spec.lua`.
+
+### Task 3.1: `cliproxyapi.pre_query` adapter hook (the DRY seam)
+
+**Files:** Modify `lua/parley/providers.lua` (cliproxyapi adapter, ~line 993); Test `tests/unit/providers_pre_query_spec.lua`.
+
+- [ ] **Step 1: Failing test** — `cliproxyapi.pre_query` exists; with `manage=false` it calls its callback synchronously (no-op); with `manage=true` it delegates to an injected `ensure_running` (inject a stub via the module to avoid real IO).
+- [ ] **Step 2: Run** → FAIL.
+- [ ] **Step 3: Implement**
+
+```lua
+-- providers.lua, cliproxyapi adapter:
+cliproxyapi.pre_query = function(callback)
+    local ok, cliproxy = pcall(require, "parley.cliproxy")
+    if not ok or not cliproxy.is_managed() then
+        return callback()  -- no-op: bring-your-own / not opted in
+    end
+    cliproxy.ensure_running(callback, function(msg)
+        require("parley.logger").error("cliproxy: " .. msg)
+        -- do NOT call callback → the query is aborted, surfaced via logger;
+        -- the chat does not hang (dispatcher returns).
+    end)
+end
+```
+
+ARCH-DRY: reuses the dispatcher's existing `pre_query` path (dispatcher.lua:387) exactly as copilot does — no new provider branch in the dispatcher.
+
+- [ ] **Step 4: Run** → PASS. **Step 5: Commit** `#131 M1: cliproxyapi.pre_query delegates to ensure_running`
+
+### Task 3.2: register `:ParleyProxy` command
+
+**Files:** Modify `lua/parley/init.lua` (near the command/hook registration, ~line 591).
+
+- [ ] **Step 1: Failing test** (integration) — after `setup{ cliproxy = { manage = true, ... } }`, `vim.fn.exists(":ParleyProxy") == 2`; `:ParleyProxy status` runs without error and reports state.
+- [ ] **Step 2–4:** Register `M.config.cmd_prefix .. "Proxy"` → dispatch on the subcommand arg to `cliproxy.status/start/stop/restart/login`. Provide completion for the subcommands.
+- [ ] **Step 5: Commit** `#131 M1: :ParleyProxy command`
+
+### Task 3.3: end-to-end dispatch integration (the Done-when proof)
+
+**Files:** Test `tests/integration/cliproxy_dispatch_spec.lua`.
+
+- [ ] **Step 1: Failing test** — configure a cliproxy agent whose endpoint points at a free port; no proxy running; the discovered "binary" is `fake_cliproxy --mode healthy`. Drive a dispatch (or call `D.query` for the cliproxy provider) and assert: config.yaml was rendered (with the secret in `api-keys`, `0600`), the fake was spawned, became healthy, and the query proceeded. Then a second dispatch **reuses** (no second spawn). Then `:ParleyProxy stop`; the next dispatch **re-spawns** (auto-revive — spec §"stop is transient").
+- [ ] **Step 2: Run** → FAIL. **Step 3:** fix wiring until green. **Step 4: Run** → PASS.
+- [ ] **Step 5: Commit** `#131 M1: e2e dispatch integration (render→spawn→reuse→revive)`
+
+### Task 3.4: docs + README + atlas
+
+- [ ] Add a `cliproxy = { manage = true, ... }` example to `README.md` (provider section ~line 141) and the config docstring in `lua/parley/config.lua`. State the one manual step (`:ParleyProxy login`) and that it's opt-in/off-by-default.
+- [ ] Add `atlas/providers/cliproxy-managed.md` (the lifecycle + config-render flow) and link it from `atlas/index.md` (AGENTS.md §8).
+- [ ] **Commit** `#131 M1: docs + atlas for managed cliproxy`
+
+### Task 3.5: close M1
+
+- [ ] `make test` green (unit + integration) on macOS; run the same on a Linux box/CI (spec platform scope).
+- [ ] `sdlc milestone-close --issue 131 --milestone M1 ...` (boundary review auto-dispatches; fix Critical/Important before crossing). Tick the M1 row.
+
+---
+
+## Chunk 4 (M2, deferred): `auto_download`
+
+`## Chunk 4` — implement only after M1 ships. Outline:
+
+- **Task 4.1** `cliproxy_config.asset_name` (pure) + `platform()` detection (`vim.uv.os_uname` → `{os, arch}`), unit-tested (map every `darwin/linux/freebsd/windows × aarch64/amd64`).
+- **Task 4.2** `download(version)` — fetch the pinned tarball + `checksums.txt` via `curl`, verify the sha256, extract into `stdpath('data')/parley/cliproxy/bin/`. Pinned version constant in the module (not "latest").
+- **Task 4.3** insert the managed dir into `discover_binary`'s fall-through; add `:ParleyProxy update`.
+- **Task 4.4** integration test with a local file:// or fixture tarball + a deliberately-wrong checksum (must refuse).
+- **Task 4.5** `sdlc milestone-close --milestone M2`.
+
+---
+
+## Testing summary
+
+- **Pure** (`cliproxy_config`): `tests/unit/cliproxy_config_spec.lua`, no mocks (ARCH-PURE boundary visible from outside).
+- **IO** (`cliproxy`): `tests/integration/cliproxy_lifecycle_spec.lua` + `tests/fixtures/fake_cliproxy.lua` — a real subprocess speaking the identity route, exercising reuse/spawn/foreign/timeout/crash/unauth. No function-call mocks for the proxy.
+- **Wiring**: `tests/unit/providers_pre_query_spec.lua` (no-op vs delegate) + `tests/integration/cliproxy_dispatch_spec.lua` (the Done-when e2e).
+- Run: `make test-unit`, `make test-spec SPEC=<key>`, `make test` (full).

--- a/workshop/plans/000131-managed-cliproxy-plan.md
+++ b/workshop/plans/000131-managed-cliproxy-plan.md
@@ -537,3 +537,31 @@ ARCH-DRY: reuses the dispatcher's existing `pre_query` path (dispatcher.lua:387)
 - **IO** (`cliproxy`): `tests/integration/cliproxy_lifecycle_spec.lua` + `tests/fixtures/fake_cliproxy.lua` — a real subprocess speaking the identity route, exercising reuse/spawn/foreign/timeout/crash/unauth. No function-call mocks for the proxy.
 - **Wiring**: `tests/unit/dispatcher_query_spec.lua` (abort channel: pre_query `on_error` → `on_abort`, query not run) + `tests/unit/providers_pre_query_spec.lua` (no-op vs delegate) + `tests/integration/cliproxy_dispatch_spec.lua` (the Done-when e2e **including the abort case**: ensure_running failure → spinner stopped + WARN, the no-hang proof).
 - Run: `make test-unit`, `make test-spec SPEC=<key>`, `make test` (full).
+
+---
+
+## Revisions
+
+### 2026-06-12 — implementation deltas (recorded post-build)
+- **Process-level fake is Python, not Lua.** The Core Concepts table + Chunk 2
+  Task 2.2 specified `tests/fixtures/fake_cliproxy.lua` (Lua via `nvim -l`); it
+  shipped as `tests/fixtures/fake_cliproxy` (executable Python) — `http.server`
+  gives correct HTTP/`/v1/models` responses with far less code than a hand-rolled
+  `vim.uv` HTTP responder. Adds a `python3` test-host dependency (present on
+  macOS + the Linux CI target). Reason: simplicity; the process-level-fake intent
+  (real subprocess, not function mocks) is unchanged.
+- **Per-caller `on_abort` tests landed at the M1 boundary (FIX-THEN-SHIP).** The
+  boundary review flagged that Task 3.2's per-caller teardown bodies were covered
+  only e2e via a spy. Added `tests/integration/cliproxy_caller_teardown_spec.lua`:
+  `memory_prefs` via the real abort chain (foreign proxy → `process_next` keeps
+  the batch moving), `chat_respond` + `skill_runner` via a `D.query` mock that
+  invokes the real `on_abort` (arg-position + `collapse_empty_answer` block
+  removal on the default path / `_in_flight` clear). Exposed
+  `skill_runner.is_in_flight` for the assertion.
+- **ARCH-DRY fixes (boundary review):** extracted `cliproxy.render_opts()`
+  (consumed by write/drift/status); exposed `cliproxy.login_providers()` as the
+  single source for `:ParleyProxy login` completion + validation.
+- Minor: `login_argv` now renders the config first (honors a custom `auth_dir`
+  before any dispatch); `:ParleyProxy login` uses `jobstart({term=true})` not the
+  deprecated `termopen`; documented that `api_keys.cliproxyapi` is required even
+  when `manage = true`.

--- a/workshop/plans/000131-managed-cliproxy-plan.md
+++ b/workshop/plans/000131-managed-cliproxy-plan.md
@@ -48,7 +48,7 @@
 | `Cliproxy` commands | `lua/parley/cliproxy.lua` + `init.lua` | new | user commands |
 | `cliproxyapi.pre_query` | `lua/parley/providers.lua` | modified | dispatcher seam |
 | `D.query` abort channel | `lua/parley/dispatcher.lua` | modified | pre_query error → caller teardown |
-| `on_abort` teardown | `lua/parley/chat_respond.lua` | modified | spinner / progress indicator |
+| `on_abort` teardown (×4 callers) | `chat_respond.lua` + `skill_runner.lua` + `memory_prefs.lua` | modified | per-caller pre-query state |
 | `fake_cliproxy` | `tests/fixtures/fake_cliproxy.lua` | new | process-level fake |
 
 - **Cliproxy.ensure_running(callback, on_error)** — the heart. Reads `M.config.cliproxy` + the resolved endpoint, resolves the secret via `vault.get_secret("cliproxyapi")`, renders + writes `config.yaml` (`0600`), health-probes host:port; if healthy → `callback()`; if down → `discover_binary` → `spawn` → poll health (bounded ~5s) → `callback()`; on any failure → `on_error(msg)` so the dispatch path fails fast, never hangs.
@@ -69,7 +69,11 @@
 - **D.query abort channel** *(dispatcher.lua, modified)* — **why this exists:** the caller (`chat_respond.lua`) starts a spinner *before* `D.query` and only tears it down inside the query's `on_exit` (which is **qid-coupled** — `chat_respond.lua:1488-1493`, `if not qt then return`). If `pre_query` aborts and never runs `query()`, there is no qid, so `on_exit` can't fire and **the spinner spins forever** — the chat visibly hangs, violating the spec's "dispatch must never hang." Fix: `pre_query` gains a second arg `on_error`; `D.query` gains a trailing optional `on_abort` param. On a pre_query error the dispatcher invokes `on_abort(msg)` (qid-free) instead of `query()`. Contract is additive — copilot's one-arg `pre_query` ignores the extra arg (backward compatible).
   - **Injected into:** `chat_respond.lua` passes `on_abort` into `D.query`.
 
-- **on_abort teardown** *(chat_respond.lua, modified, both `D.query` sites — ~814 topic-gen and ~1483 main)* — a qid-free cleanup the dispatcher calls on abort: `stop_spinner()` + clear the progress-indicator line + `vim.notify(msg, WARN)` carrying the actionable error (e.g. "cliproxy down — run :ParleyProxy status / login"). This is the delivery mechanism for the spec's "clear, specific error."
+- **on_abort teardown** — a qid-free cleanup the dispatcher calls on abort, at **all four** `D.query` callers (a cliproxy-provider agent can route through any of them, so each leaks its own pre-query state on abort). Each undoes exactly what it set up *before* the query, plus a `vim.notify(msg, WARN)` carrying the actionable error:
+  - `chat_respond.lua:1483` (main) — `stop_spinner()` + clear indicator **+ remove the inserted `agent_header`/`stream_placeholder` blocks**. NB the spinner is web-search-gated (`spinner_active = _state.web_search`, `:1236`), so off the default path *nothing spins* — the real leftover is the **inserted answer blocks** (`:1270-1320`). Extract the empty-block collapse `on_exit` already does (`:1498-1511`) into a shared local `collapse_empty_answer(buf, model, target_idx, stream_block_idx)` that both `on_exit` (empty case) and `on_abort` call (ARCH-DRY) — do **not** re-drive the heavy `on_exit` (tool-loop, trailing-blank cleanup) against a query that never ran.
+  - `chat_respond.lua:814` (topic-gen) — stop the spinner timer + delete the temp `topic_buf` (mirrors its qid-free `on_exit`).
+  - `skill_runner.lua:465` — `_in_flight[buf] = nil`. Without this the re-entry guard (`:345`) stays set **forever → that buffer's skill runs are permanently blocked**.
+  - `memory_prefs.lua:251` — call `process_next()` to skip the failed tag and continue the batch (its teardown is in the *callback*, not `on_exit`, which is `nil` here) — else the chain silently stalls.
 
 - **fake_cliproxy** — a real subprocess (Lua via `nvim -l`, or a tiny TCP listener) used by integration tests. Modes: `healthy` (answers identity route 200), `foreign` (200 wrong shape), `unauth` (401), `slow` (never healthy), `crash` (exits immediately). Process-level per AGENTS.md external-service rule — function mocks would miss the reuse-vs-spawn and identity-classification bugs.
 
@@ -96,6 +100,8 @@
       - lua/parley/providers.lua
       - lua/parley/dispatcher.lua
       - lua/parley/chat_respond.lua
+      - lua/parley/skill_runner.lua
+      - lua/parley/memory_prefs.lua
     tests:
       - tests/unit/cliproxy_config_spec.lua
       - tests/unit/providers_pre_query_spec.lua
@@ -172,6 +178,10 @@ function M.parse_endpoint(endpoint)
     end
     return nil, nil
 end
+-- NB: a port-less endpoint resolves to 80/443 — it will NOT silently use
+-- cliproxy's 8317 default. The canonical endpoint carries `:8317`; if a user
+-- strips the port, ensure_running logs a warning (it can't know cliproxy's
+-- intended port). Documented in the config docstring (Task 3.5).
 
 return M
 ```
@@ -369,10 +379,10 @@ This wires the pure core to IO. Cover **every** spec failure mode.
   - spawn-fail: discovered binary is the `crash` fake → `on_error("exited")`.
   - unauthenticated: a `unauth` fake → `on_error` mentioning `:ParleyProxy login` (login not done).
 - [ ] **Step 2: Run** → FAIL.
-Also implement `M.is_managed()` → `M.config.cliproxy and M.config.cliproxy.manage == true` (the gate the `pre_query` seam in Task 3.1 calls). Add a one-line test.
+Also implement `M.is_managed()` → reads `require("parley").config.cliproxy` and returns `cfg ~= nil and cfg.manage == true` (the gate the `pre_query` seam in Task 3.1 calls). Add a one-line test (inject/stub the parley config).
 
 - [ ] **Step 3: Implement** `ensure_running(callback, on_error)`:
-  1. read `M.config.cliproxy`; if `manage` is not true → `callback()` immediately (no-op path).
+  1. read the merged config via `require("parley").config.cliproxy` (NOT the module's own `M` — `cliproxy.lua`'s `M` is the module table; the merged user config lives on the `parley` module, set in init.lua:386-388). Same for `is_managed()`. If `manage` is not true → `callback()` immediately (no-op path).
   2. `host, port = cliproxy_config.parse_endpoint(D.providers.cliproxyapi.endpoint)`.
   3. `secret = vault.get_secret(require("parley.providers").get_secret_name("cliproxyapi"))` — derive the secret name via the codebase's single source (providers.lua:1282), don't hardcode the literal (ARCH-DRY).
   4. `cfg, overrides = cliproxy_config.render{...}`; if `#overrides>0` log a warning naming them; write `encode(cfg)` to `stdpath('data')/parley/cliproxy/config.yaml` at `0600`.
@@ -446,14 +456,25 @@ ARCH-DRY: reuses the dispatcher's existing `pre_query` path (dispatcher.lua:387)
 
 - [ ] **Step 4: Run** → PASS. **Step 5: Commit** `#131 M1: cliproxyapi.pre_query delegates to ensure_running`
 
-### Task 3.2: wire `on_abort` teardown at the `D.query` call sites
+### Task 3.2: wire `on_abort` teardown at all four `D.query` callers
 
-**Files:** Modify `lua/parley/chat_respond.lua` (both `D.query` sites: topic-gen ~814, main response ~1483); Test `tests/integration/cliproxy_dispatch_spec.lua` (the spinner-stop assertion the plan-quality judge required).
+**Files:** Modify `lua/parley/chat_respond.lua` (sites ~814, ~1483), `lua/parley/skill_runner.lua` (~465), `lua/parley/memory_prefs.lua` (~251); Test `tests/integration/cliproxy_dispatch_spec.lua` + per-caller assertions. (`memory_prefs.lua` + `skill_runner.lua` join the `providers/cliproxy-managed` traceability `code:` list in Step 0.)
 
-- [ ] **Step 1: Failing test** — drive a cliproxy dispatch whose `ensure_running` fails (discovered binary = `fake_cliproxy --mode crash`); assert the spinner timer is **stopped** and the progress indicator cleared (e.g. expose `spinner_running`/an indicator flag for the test, or assert the indicator line is gone), and that a WARN notification fired. This is the test that would have caught the hang.
-- [ ] **Step 2: Run** → FAIL (spinner still running).
-- [ ] **Step 3: Implement** — define a qid-free `on_abort(msg)` in the response closure that calls `stop_spinner()`, clears the progress-indicator line, and `vim.notify(msg, vim.log.levels.WARN)`; pass it as the new trailing `on_abort` arg to `_parley.dispatcher.query(...)`. Repeat at the topic-gen site (its own spinner). Non-cliproxy providers never abort (their `pre_query` is absent or calls `on_success`), so `on_abort` is simply never invoked — zero behavior change for them.
-- [ ] **Step 4: Run** → PASS. **Step 5: Commit** `#131 M1: on_abort spinner/indicator teardown (no-hang on ensure_running failure)`
+**Why all four (plan-quality Critical):** any of these can run with a cliproxy-provider agent; each sets up state torn down only in a qid-coupled handler, so an abort (no qid) leaks it. Coverage is the fix.
+
+- [ ] **Step 1: Failing tests** (one per caller; drive `ensure_running` failure with `fake_cliproxy --mode crash`):
+  - **main chat, default (non-web-search) path** — assert the inserted `agent_header`/`stream_placeholder` blocks are **removed** from buffer + model (NOT merely "spinner stopped" — off the web-search path no spinner runs, so a spinner-only assertion passes vacuously; this is the plan-quality Important finding) and a WARN fired.
+  - **main chat, web-search path** — additionally assert the spinner timer is stopped.
+  - **topic-gen** — assert the topic spinner timer stopped + `topic_buf` deleted.
+  - **skill_runner** — assert `_in_flight[buf]` is cleared (a subsequent skill run on that buffer is **not** blocked).
+  - **memory_prefs** — assert the batch advances past the failed tag (`process_next` ran; remaining tags still processed) rather than stalling.
+- [ ] **Step 2: Run** → FAIL.
+- [ ] **Step 3: Implement**
+  - In `chat_respond.lua`, extract a shared local `collapse_empty_answer(buf, model, target_idx, stream_block_idx)` from the existing empty-block collapse in `on_exit` (`:1498-1511`); call it from both `on_exit` (replacing the inline block) and the new `on_abort` (ARCH-DRY). Main `on_abort(msg)` = `collapse_empty_answer(...)` + `stop_spinner()` + clear indicator + `vim.notify(msg, WARN)`. Topic-gen `on_abort` = stop timer + delete `topic_buf` + notify.
+  - In `skill_runner.lua`, `on_abort = function(msg) _in_flight[buf] = nil; vim.notify(msg, WARN) end`.
+  - In `memory_prefs.lua`, `on_abort = function(msg) logger.warning(...); process_next() end` (continue the batch).
+  - Pass each as the new trailing `on_abort` arg to `dispatcher.query(...)`. Non-cliproxy providers never abort (their `pre_query` is absent or calls `on_success`), so `on_abort` is never invoked — zero behavior change for them.
+- [ ] **Step 4: Run** → PASS. **Step 5: Commit** `#131 M1: on_abort teardown at all 4 D.query callers (no-hang/no-leak)`
 
 ### Task 3.3: register `:ParleyProxy` command
 

--- a/workshop/plans/000131-managed-cliproxy-plan.md
+++ b/workshop/plans/000131-managed-cliproxy-plan.md
@@ -47,6 +47,8 @@
 | `Cliproxy.discover_binary` | `lua/parley/cliproxy.lua` | new | PATH / fs |
 | `Cliproxy` commands | `lua/parley/cliproxy.lua` + `init.lua` | new | user commands |
 | `cliproxyapi.pre_query` | `lua/parley/providers.lua` | modified | dispatcher seam |
+| `D.query` abort channel | `lua/parley/dispatcher.lua` | modified | pre_query error → caller teardown |
+| `on_abort` teardown | `lua/parley/chat_respond.lua` | modified | spinner / progress indicator |
 | `fake_cliproxy` | `tests/fixtures/fake_cliproxy.lua` | new | process-level fake |
 
 - **Cliproxy.ensure_running(callback, on_error)** — the heart. Reads `M.config.cliproxy` + the resolved endpoint, resolves the secret via `vault.get_secret("cliproxyapi")`, renders + writes `config.yaml` (`0600`), health-probes host:port; if healthy → `callback()`; if down → `discover_binary` → `spawn` → poll health (bounded ~5s) → `callback()`; on any failure → `on_error(msg)` so the dispatch path fails fast, never hangs.
@@ -62,7 +64,12 @@
 
 - **Cliproxy commands** — `:ParleyProxy status|start|stop|restart|login`, registered in `init.lua` under `M.config.cmd_prefix`. `login` shells out to `cli-proxy-api login [--no-browser]`; `status` reports binary source, health/auth state, host:port, auth-dir, rendered-config path, and config-drift.
 
-- **cliproxyapi.pre_query** — a 6-line adapter hook delegating to `require("parley.cliproxy").ensure_running`. ARCH-DRY: reuses the dispatcher's existing `pre_query` mechanism (dispatcher.lua:387) — copilot already proves the pattern. No-op (immediate callback) when `manage` is off.
+- **cliproxyapi.pre_query** — adapter hook `pre_query(on_success, on_error)` delegating to `require("parley.cliproxy").ensure_running(on_success, on_error)`. ARCH-DRY: reuses the dispatcher's existing `pre_query` mechanism (dispatcher.lua:387) — copilot already proves the pattern. No-op (`on_success()`) when `manage` is off. The `on_error` is the new **abort channel** (below).
+
+- **D.query abort channel** *(dispatcher.lua, modified)* — **why this exists:** the caller (`chat_respond.lua`) starts a spinner *before* `D.query` and only tears it down inside the query's `on_exit` (which is **qid-coupled** — `chat_respond.lua:1488-1493`, `if not qt then return`). If `pre_query` aborts and never runs `query()`, there is no qid, so `on_exit` can't fire and **the spinner spins forever** — the chat visibly hangs, violating the spec's "dispatch must never hang." Fix: `pre_query` gains a second arg `on_error`; `D.query` gains a trailing optional `on_abort` param. On a pre_query error the dispatcher invokes `on_abort(msg)` (qid-free) instead of `query()`. Contract is additive — copilot's one-arg `pre_query` ignores the extra arg (backward compatible).
+  - **Injected into:** `chat_respond.lua` passes `on_abort` into `D.query`.
+
+- **on_abort teardown** *(chat_respond.lua, modified, both `D.query` sites — ~814 topic-gen and ~1483 main)* — a qid-free cleanup the dispatcher calls on abort: `stop_spinner()` + clear the progress-indicator line + `vim.notify(msg, WARN)` carrying the actionable error (e.g. "cliproxy down — run :ParleyProxy status / login"). This is the delivery mechanism for the spec's "clear, specific error."
 
 - **fake_cliproxy** — a real subprocess (Lua via `nvim -l`, or a tiny TCP listener) used by integration tests. Modes: `healthy` (answers identity route 200), `foreign` (200 wrong shape), `unauth` (401), `slow` (never healthy), `crash` (exits immediately). Process-level per AGENTS.md external-service rule — function mocks would miss the reuse-vs-spawn and identity-classification bugs.
 
@@ -87,9 +94,12 @@
       - lua/parley/cliproxy_config.lua
       - lua/parley/cliproxy.lua
       - lua/parley/providers.lua
+      - lua/parley/dispatcher.lua
+      - lua/parley/chat_respond.lua
     tests:
       - tests/unit/cliproxy_config_spec.lua
       - tests/unit/providers_pre_query_spec.lua
+      - tests/unit/dispatcher_query_spec.lua
       - tests/integration/cliproxy_lifecycle_spec.lua
       - tests/integration/cliproxy_dispatch_spec.lua
 ```
@@ -319,6 +329,7 @@ end
 - [ ] **Step 1:** Install a real binary locally (`brew install cliproxyapi` or download a pinned release tarball for this machine). Record the version + identity route in `## Log`.
 - [ ] **Step 2:** In a scratch nvim, build a minimal config via `cliproxy_config.render` + `encode`, write it to a temp `.yaml`, and run `cli-proxy-api --config <tmp>`.
 - [ ] **Step 3:** Confirm it boots and answers an HTTP probe. **Decide the identity route** (`/health` vs `/v1/models`) and record it. Also confirm `auth-dir` `~` handling: the cliproxy docs say `auth-dir` "supports `~` for home directory", so `render` writes it **literally** (no `vim.fn.expand`) — verify the booted proxy resolves `~` itself; record the result.
+- [ ] **Step 4: Confirm what a 401 on the identity route actually means** (plan-quality INFO). The rendered `api-keys` is the *client→proxy* token; a 401 might mean the probe sent a wrong/absent client key, **not** that upstream OAuth is missing. Probe with and without the bearer, with and without a completed `login`, and record which status/body distinguishes "up but client-unauthenticated" from "up but no upstream OAuth". `status`'s auth-state reporting (Task 2.5) is built on this recorded fact, not a guess.
 - [ ] **GO:** proceed. **NO-GO** (parser rejects JSON): add a nested+list YAML emitter as Task 1.4 (its own sub-task — *not* a flat emitter; spec says flat is non-viable), then continue. Log the decision either way.
 
 ### Task 2.1: `discover_binary`
@@ -363,7 +374,7 @@ Also implement `M.is_managed()` → `M.config.cliproxy and M.config.cliproxy.man
 - [ ] **Step 3: Implement** `ensure_running(callback, on_error)`:
   1. read `M.config.cliproxy`; if `manage` is not true → `callback()` immediately (no-op path).
   2. `host, port = cliproxy_config.parse_endpoint(D.providers.cliproxyapi.endpoint)`.
-  3. `secret = vault.get_secret("cliproxyapi")`.
+  3. `secret = vault.get_secret(require("parley.providers").get_secret_name("cliproxyapi"))` — derive the secret name via the codebase's single source (providers.lua:1282), don't hardcode the literal (ARCH-DRY).
   4. `cfg, overrides = cliproxy_config.render{...}`; if `#overrides>0` log a warning naming them; write `encode(cfg)` to `stdpath('data')/parley/cliproxy/config.yaml` at `0600`.
   5. `health_probe` → `healthy`: `callback()`. `foreign`: `on_error`. `unauthenticated`: `on_error` (login). `down`: `discover_binary` (nil → `on_error` naming `brew install`/`auto_download`) → `spawn` → poll `health_probe` every ~250ms up to ~5s → healthy `callback()` / else `on_error("timed out")`. Crash mid-poll → `on_error("exited")`.
 - [ ] **Step 4: Run** → all PASS.
@@ -383,26 +394,51 @@ Also implement `M.is_managed()` → `M.config.cliproxy and M.config.cliproxy.man
 
 `## Chunk 3` — `lua/parley/providers.lua`, `lua/parley/init.lua`, `tests/unit/providers_pre_query_spec.lua`, `tests/integration/cliproxy_dispatch_spec.lua`.
 
+### Task 3.0: `D.query` abort channel (so an aborted pre_query can't hang the chat)
+
+**Files:** Modify `lua/parley/dispatcher.lua` (`D.query`, lines 385-397); Test `tests/unit/dispatcher_query_spec.lua` (exists — add cases).
+
+**Why first:** without this, the `pre_query` error path (Task 3.1) has nowhere to deliver an abort, and the caller's qid-coupled `on_exit` can't tear down the spinner (see the "D.query abort channel" entity above). This task builds the channel; 3.1–3.3 use it.
+
+- [ ] **Step 1: Failing test** — stub an adapter whose `pre_query(on_success, on_error)` calls `on_error("boom")`. Call `D.query(..., on_abort)` with a spy `on_abort`. Assert: `on_abort` was called with `"boom"`, and the real `query()` (curl/tasker) was **not** invoked (spy `tasker.run` / no temp file written). Add a second case: an adapter with `pre_query(on_success)` that calls `on_success()` → query proceeds as before (backward compat); and a no-`pre_query` adapter → unchanged.
+- [ ] **Step 2: Run** `make test-spec SPEC=providers/cliproxy-managed` (after Step 0 maps `dispatcher_query_spec.lua`; or run that file directly) → FAIL.
+- [ ] **Step 3: Implement** — extend the signature to `D.query(buf, provider, payload, handler, on_exit, callback, on_progress, on_abort)` and the `pre_query` branch:
+
+```lua
+if adapter.pre_query then
+    return vault.run_with_secret(provider, function()
+        adapter.pre_query(function()
+            query(buf, provider, payload, handler, on_exit, callback, on_progress)
+        end, function(msg)  -- NEW: abort channel
+            require("parley.logger").error("pre_query abort [" .. provider .. "]: " .. tostring(msg))
+            if type(on_abort) == "function" then on_abort(msg) end
+        end)
+    end)
+end
+```
+
+The second `pre_query` arg is additive: copilot's `pre_query = function(callback)` simply ignores it (backward compatible). Add `dispatcher_query_spec.lua` to the `providers/cliproxy-managed` traceability entry (Step 0).
+
+- [ ] **Step 4: Run** → PASS. **Step 5: Commit** `#131 M1: D.query abort channel (pre_query on_error → on_abort)`
+
 ### Task 3.1: `cliproxyapi.pre_query` adapter hook (the DRY seam)
 
 **Files:** Modify `lua/parley/providers.lua` (cliproxyapi adapter, ~line 993); Test `tests/unit/providers_pre_query_spec.lua`.
 
-- [ ] **Step 1: Failing test** — `cliproxyapi.pre_query` exists; with `manage=false` it calls its callback synchronously (no-op); with `manage=true` it delegates to an injected `ensure_running` (inject a stub via the module to avoid real IO).
+- [ ] **Step 1: Failing test** — `cliproxyapi.pre_query(on_success, on_error)` exists; with `manage=false` it calls `on_success` synchronously (no-op, `on_error` untouched); with `manage=true` it delegates to an injected `ensure_running` passing **both** callbacks (inject a stub via the module to avoid real IO — assert the stub received the same `on_success`/`on_error`).
 - [ ] **Step 2: Run** → FAIL.
 - [ ] **Step 3: Implement**
 
 ```lua
 -- providers.lua, cliproxyapi adapter:
-cliproxyapi.pre_query = function(callback)
+cliproxyapi.pre_query = function(on_success, on_error)
     local ok, cliproxy = pcall(require, "parley.cliproxy")
     if not ok or not cliproxy.is_managed() then
-        return callback()  -- no-op: bring-your-own / not opted in
+        return on_success()  -- no-op: bring-your-own / not opted in
     end
-    cliproxy.ensure_running(callback, function(msg)
-        require("parley.logger").error("cliproxy: " .. msg)
-        -- do NOT call callback → the query is aborted, surfaced via logger;
-        -- the chat does not hang (dispatcher returns).
-    end)
+    -- ensure_running drives on_error → the dispatcher's abort channel (Task 3.0)
+    -- → the caller's on_abort teardown (Task 3.2). The chat never hangs.
+    cliproxy.ensure_running(on_success, on_error or function() end)
 end
 ```
 
@@ -410,7 +446,16 @@ ARCH-DRY: reuses the dispatcher's existing `pre_query` path (dispatcher.lua:387)
 
 - [ ] **Step 4: Run** → PASS. **Step 5: Commit** `#131 M1: cliproxyapi.pre_query delegates to ensure_running`
 
-### Task 3.2: register `:ParleyProxy` command
+### Task 3.2: wire `on_abort` teardown at the `D.query` call sites
+
+**Files:** Modify `lua/parley/chat_respond.lua` (both `D.query` sites: topic-gen ~814, main response ~1483); Test `tests/integration/cliproxy_dispatch_spec.lua` (the spinner-stop assertion the plan-quality judge required).
+
+- [ ] **Step 1: Failing test** — drive a cliproxy dispatch whose `ensure_running` fails (discovered binary = `fake_cliproxy --mode crash`); assert the spinner timer is **stopped** and the progress indicator cleared (e.g. expose `spinner_running`/an indicator flag for the test, or assert the indicator line is gone), and that a WARN notification fired. This is the test that would have caught the hang.
+- [ ] **Step 2: Run** → FAIL (spinner still running).
+- [ ] **Step 3: Implement** — define a qid-free `on_abort(msg)` in the response closure that calls `stop_spinner()`, clears the progress-indicator line, and `vim.notify(msg, vim.log.levels.WARN)`; pass it as the new trailing `on_abort` arg to `_parley.dispatcher.query(...)`. Repeat at the topic-gen site (its own spinner). Non-cliproxy providers never abort (their `pre_query` is absent or calls `on_success`), so `on_abort` is simply never invoked — zero behavior change for them.
+- [ ] **Step 4: Run** → PASS. **Step 5: Commit** `#131 M1: on_abort spinner/indicator teardown (no-hang on ensure_running failure)`
+
+### Task 3.3: register `:ParleyProxy` command
 
 **Files:** Modify `lua/parley/init.lua` (near the command/hook registration, ~line 591).
 
@@ -418,21 +463,21 @@ ARCH-DRY: reuses the dispatcher's existing `pre_query` path (dispatcher.lua:387)
 - [ ] **Step 2–4:** Register `M.config.cmd_prefix .. "Proxy"` → dispatch on the subcommand arg to `cliproxy.status/start/stop/restart/login`. Provide completion for the subcommands.
 - [ ] **Step 5: Commit** `#131 M1: :ParleyProxy command`
 
-### Task 3.3: end-to-end dispatch integration (the Done-when proof)
+### Task 3.4: end-to-end dispatch integration (the Done-when proof)
 
 **Files:** Test `tests/integration/cliproxy_dispatch_spec.lua`.
 
-- [ ] **Step 1: Failing test** — configure a cliproxy agent whose endpoint points at a free port; no proxy running; the discovered "binary" is `fake_cliproxy --mode healthy`. Drive a dispatch (or call `D.query` for the cliproxy provider) and assert: config.yaml was rendered (with the secret in `api-keys`, `0600`), the fake was spawned, became healthy, and the query proceeded. Then a second dispatch **reuses** (no second spawn). Then `:ParleyProxy stop`; the next dispatch **re-spawns** (auto-revive — spec §"stop is transient").
+- [ ] **Step 1: Failing test** — configure a cliproxy agent whose endpoint points at a free port; no proxy running; the discovered "binary" is `fake_cliproxy --mode healthy`. Drive a dispatch (or call `D.query` for the cliproxy provider) and assert: config.yaml was rendered (with the secret in `api-keys`, `0600`), the fake was spawned, became healthy, and the query proceeded. Then a second dispatch **reuses** (no second spawn). Then `:ParleyProxy stop`; the next dispatch **re-spawns** (auto-revive — spec §"stop is transient"). Plus the **abort case** from Task 3.2 (failure → spinner stopped + WARN), proving the no-hang invariant end-to-end.
 - [ ] **Step 2: Run** → FAIL. **Step 3:** fix wiring until green. **Step 4: Run** → PASS.
-- [ ] **Step 5: Commit** `#131 M1: e2e dispatch integration (render→spawn→reuse→revive)`
+- [ ] **Step 5: Commit** `#131 M1: e2e dispatch integration (render→spawn→reuse→revive + abort no-hang)`
 
-### Task 3.4: docs + README + atlas
+### Task 3.5: docs + README + atlas
 
 - [ ] Add a `cliproxy = { manage = true, ... }` example to `README.md` (provider section ~line 141) and the config docstring in `lua/parley/config.lua`. State the one manual step (`:ParleyProxy login`) and that it's opt-in/off-by-default.
 - [ ] Add `atlas/providers/cliproxy-managed.md` (the lifecycle + config-render flow) and link it from `atlas/index.md` (AGENTS.md §8).
 - [ ] **Commit** `#131 M1: docs + atlas for managed cliproxy`
 
-### Task 3.5: close M1
+### Task 3.6: close M1
 
 - [ ] `make test` green (unit + integration) on macOS; run the same on a Linux box/CI (spec platform scope).
 - [ ] `sdlc milestone-close --issue 131 --milestone M1 ...` (boundary review auto-dispatches; fix Critical/Important before crossing). Tick the M1 row.
@@ -455,5 +500,5 @@ ARCH-DRY: reuses the dispatcher's existing `pre_query` path (dispatcher.lua:387)
 
 - **Pure** (`cliproxy_config`): `tests/unit/cliproxy_config_spec.lua`, no mocks (ARCH-PURE boundary visible from outside).
 - **IO** (`cliproxy`): `tests/integration/cliproxy_lifecycle_spec.lua` + `tests/fixtures/fake_cliproxy.lua` — a real subprocess speaking the identity route, exercising reuse/spawn/foreign/timeout/crash/unauth. No function-call mocks for the proxy.
-- **Wiring**: `tests/unit/providers_pre_query_spec.lua` (no-op vs delegate) + `tests/integration/cliproxy_dispatch_spec.lua` (the Done-when e2e).
+- **Wiring**: `tests/unit/dispatcher_query_spec.lua` (abort channel: pre_query `on_error` → `on_abort`, query not run) + `tests/unit/providers_pre_query_spec.lua` (no-op vs delegate) + `tests/integration/cliproxy_dispatch_spec.lua` (the Done-when e2e **including the abort case**: ensure_running failure → spinner stopped + WARN, the no-hang proof).
 - Run: `make test-unit`, `make test-spec SPEC=<key>`, `make test` (full).

--- a/workshop/plans/000131-managed-cliproxy-plan.md
+++ b/workshop/plans/000131-managed-cliproxy-plan.md
@@ -55,14 +55,19 @@
   - **Injected into:** called from `cliproxyapi.pre_query`. The pure `render`/`encode`/`parse_endpoint` are injected here (this is the only place IO meets the pure core).
   - **Future extensions:** M2 `auto_download` slots into `discover_binary`'s fall-through.
 
-- **Cliproxy.health_probe(host, port, secret, cb)** — `curl` GET to the cliproxy **identity route**, classifies: `healthy` (200, cliproxy-shaped) / `unauthenticated` (401 → login needed) / `foreign` (200 but not cliproxy-shaped) / `down` (connection refused). The identity route is confirmed during the M1 gating task (candidates `/v1/models`, `/health`).
-  - **Injected into:** `ensure_running`, `status`.
+- **Cliproxy.health_probe(host, port, secret, cb)** — `curl` GET to **`/v1/models` WITH the client bearer** (identity route confirmed in Task 2.0; there is no `/health`). Classification (from the gating run):
+  - **200 + body `{"...","object":"list"}`, `data` non-empty** → `healthy` (up, client-authed, upstream logged in).
+  - **200 + `object:"list"` but `data: []`** → `needs_login` (up + client-authed, but no upstream OAuth — the "run `:ParleyProxy login`" signal).
+  - **401** → `client_key_mismatch` (up, but the rendered `api-keys` ≠ the bearer parley sent — a wiring bug, not a login problem).
+  - **200 but body is NOT `object:"list"`-shaped** → `foreign` (something else holds the port).
+  - **connection refused / no answer** → `down`.
+  - **Injected into:** `ensure_running` (treats `healthy`/`needs_login` as "proceed", `foreign`/`client_key_mismatch` as `on_error`, `down` as "spawn"), `status`.
 
 - **Cliproxy.spawn(binary, config_path)** — `vim.uv.spawn` **detached** (`detached=true`, `uv.unref` the handle) so the daemon outlives nvim and is shared; records our PID so `stop` only kills a parley-spawned proxy.
 
-- **Cliproxy.discover_binary()** — `cliproxy.binary_path` → (M2 managed dir) → `cli-proxy-api` on PATH. Returns path or nil.
+- **Cliproxy.discover_binary()** — `cliproxy.binary_path` → (M2 managed dir) → PATH lookup trying **both** `cliproxyapi` (brew name, confirmed installed) **and** `cli-proxy-api` (release-tarball name). Returns path or nil.
 
-- **Cliproxy commands** — `:ParleyProxy status|start|stop|restart|login`, registered in `init.lua` under `M.config.cmd_prefix`. `login` shells out to `cli-proxy-api login [--no-browser]`; `status` reports binary source, health/auth state, host:port, auth-dir, rendered-config path, and config-drift.
+- **Cliproxy commands** — `:ParleyProxy status|start|stop|restart|login`, registered in `init.lua` under `M.config.cmd_prefix`. `login <provider>` shells out to `cliproxyapi -<provider>-login [-no-browser]` (per-provider flags — `claude`, `codex`, `codex-device`, `google`→`-login`, `kimi`, `xai`, `antigravity`; NOT a `login` subcommand — confirmed in Task 2.0); `status` reports binary source, health/auth state (incl. `needs_login`), host:port, auth-dir, rendered-config path, and config-drift.
 
 - **cliproxyapi.pre_query** — adapter hook `pre_query(on_success, on_error)` delegating to `require("parley.cliproxy").ensure_running(on_success, on_error)`. ARCH-DRY: reuses the dispatcher's existing `pre_query` mechanism (dispatcher.lua:387) — copilot already proves the pattern. No-op (`on_success()`) when `manage` is off. The `on_error` is the new **abort channel** (below).
 
@@ -335,15 +340,14 @@ end
 
 `## Chunk 2` — `lua/parley/cliproxy.lua`, `tests/fixtures/fake_cliproxy.lua`, `tests/integration/cliproxy_lifecycle_spec.lua`.
 
-### Task 2.0: Gating task — prove JSON-as-YAML boots a real proxy (GO/NO-GO)
+### Task 2.0: Gating task — prove JSON-as-YAML boots a real proxy (GO/NO-GO) — ✅ DONE 2026-06-12
 
-**Manual, before writing lifecycle code. Spec §Emission makes this a hard gate.**
-
-- [ ] **Step 1:** Install a real binary locally (`brew install cliproxyapi` or download a pinned release tarball for this machine). Record the version + identity route in `## Log`.
-- [ ] **Step 2:** In a scratch nvim, build a minimal config via `cliproxy_config.render` + `encode`, write it to a temp `.yaml`, and run `cli-proxy-api --config <tmp>`.
-- [ ] **Step 3:** Confirm it boots and answers an HTTP probe. **Decide the identity route** (`/health` vs `/v1/models`) and record it. Also confirm `auth-dir` `~` handling: the cliproxy docs say `auth-dir` "supports `~` for home directory", so `render` writes it **literally** (no `vim.fn.expand`) — verify the booted proxy resolves `~` itself; record the result.
-- [ ] **Step 4: Confirm what a 401 on the identity route actually means** (plan-quality INFO). The rendered `api-keys` is the *client→proxy* token; a 401 might mean the probe sent a wrong/absent client key, **not** that upstream OAuth is missing. Probe with and without the bearer, with and without a completed `login`, and record which status/body distinguishes "up but client-unauthenticated" from "up but no upstream OAuth". `status`'s auth-state reporting (Task 2.5) is built on this recorded fact, not a guess.
-- [ ] **GO:** proceed. **NO-GO** (parser rejects JSON): add a nested+list YAML emitter as Task 1.4 (its own sub-task — *not* a flat emitter; spec says flat is non-viable), then continue. Log the decision either way.
+**Completed — recorded in `## Log`. Result: GO.** Booted `cliproxyapi` v7.1.60 on a throwaway port against a parley-rendered JSON-as-`.yaml` config; it boots and serves cleanly — **no fallback YAML emitter needed.** Confirmed facts now baked into the tasks below:
+- Identity route **`/v1/models`** (no `/health`); probe **with** the bearer.
+- 401 = client-key drift; 200+`data:[]` = `needs_login`; 200+models = healthy; refused = down; 200 non-list = foreign.
+- Binary **`cliproxyapi`** (also try `cli-proxy-api`); config flag **`-config`**; login = per-provider flags (`-claude-login`, …), `-no-browser`.
+- `api-keys` plural; `auth-dir` accepts `~` literally.
+- (Doc note) boot fetches a management-panel asset; recommend `remote-management.disable-control-panel: true` in the user's `config` passthrough.
 
 ### Task 2.1: `discover_binary`
 
@@ -351,23 +355,29 @@ end
 
 - [ ] **Step 1: Failing test** — given an explicit `binary_path` that exists, returns it; given a bogus path + nothing on PATH, returns nil. (Use a temp file as a fake binary; set `M.config.cliproxy.binary_path`.)
 - [ ] **Step 2: Run** `make test-spec SPEC=providers/cliproxy-managed` → FAIL.
-- [ ] **Step 3: Implement** `discover_binary()`: check `cfg.binary_path` (fs exists + executable), else `vim.fn.exepath("cli-proxy-api")`, else nil. (M2 inserts the managed dir between the two.)
+- [ ] **Step 3: Implement** `discover_binary()`: check `cfg.binary_path` (fs exists + executable), else `vim.fn.exepath("cliproxyapi")` then `vim.fn.exepath("cli-proxy-api")` (brew name first, then the release-tarball name), else nil. (M2 inserts the managed dir between `binary_path` and PATH.)
 - [ ] **Step 4: Run** → PASS. **Step 5: Commit** `#131 M1: cliproxy.discover_binary`
 
 ### Task 2.2: `health_probe` + identity classification
 
 **Files:** Modify `lua/parley/cliproxy.lua`; new `tests/fixtures/fake_cliproxy.lua`; Test the lifecycle spec.
 
-- [ ] **Step 1: Build the fake** — `tests/fixtures/fake_cliproxy.lua`: a `vim.uv` TCP server (run via `nvim -l`) that, by a `--mode` arg, answers the identity route with 200-cliproxy-shape / 200-foreign / 401 / never / exits immediately. It binds the port from `--port` and the identity route decided in Task 2.0.
-- [ ] **Step 2: Failing test** — start `fake_cliproxy --mode healthy --port <p>`; assert `health_probe` classifies `healthy`. Repeat for `foreign`→`foreign`, `unauth`→`unauthenticated`, nothing-listening→`down`.
+- [ ] **Step 1: Build the fake** — `tests/fixtures/fake_cliproxy.lua`: a `vim.uv` TCP server (run via `nvim -l`) answering **`GET /v1/models`** per a `--mode` arg (and `--port`):
+  - `healthy` → 200 `{"object":"list","data":[{"id":"claude-x"}]}`
+  - `needs_login` → 200 `{"object":"list","data":[]}`
+  - `client_key_mismatch` → 401
+  - `foreign` → 200 `{"hello":"i am not cliproxy"}`
+  - `slow` → accept the connection, never respond (never-healthy)
+  - `crash` → exit immediately on startup (spawn-fail)
+- [ ] **Step 2: Failing test** — start `fake_cliproxy --mode <m> --port <p>`; assert `health_probe(host,port,"testkey")` classifies: `healthy`→`healthy`, `needs_login`→`needs_login`, `client_key_mismatch`→`client_key_mismatch`, `foreign`→`foreign`, nothing-listening→`down`.
 - [ ] **Step 3: Run** → FAIL.
-- [ ] **Step 4: Implement** `health_probe(host, port, secret, cb)`: `curl -s -o - -w "%{http_code}"` (or `vim.uv`) GET to the identity route with the bearer; classify by status + body shape. Async, calls `cb(state)`.
-- [ ] **Step 5: Run** → PASS. **Commit** `#131 M1: cliproxy.health_probe + fake_cliproxy (identity classification)`
+- [ ] **Step 4: Implement** `health_probe(host, port, secret, cb)`: `curl -s -w "\n%{http_code}" -H "Authorization: Bearer <secret>" http://host:port/v1/models` with a short `--max-time`; classify by status + whether the body decodes to an `object=="list"` table and whether `data` is non-empty (per Task 2.0). Async, calls `cb(state)`.
+- [ ] **Step 5: Run** → PASS. **Commit** `#131 M1: cliproxy.health_probe + fake_cliproxy (/v1/models identity classification)`
 
 ### Task 2.3: `spawn` (detached) + PID tracking
 
 - [ ] **Step 1: Failing test** — spawn `fake_cliproxy --mode healthy`; assert the process starts, a PID is recorded, and a subsequent `health_probe` goes `healthy`. Assert the recorded PID is parley-owned (so `stop` is scoped).
-- [ ] **Step 2–4:** Implement `spawn(binary, config_path)` via `vim.uv.spawn` with `detached=true`, `uv.unref(handle)`, capture `pid` into module state. Return the handle/pid.
+- [ ] **Step 2–4:** Implement `spawn(binary, config_path)` via `vim.uv.spawn` with args `{ "-config", config_path }` (single-dash, confirmed Task 2.0), `detached=true`, `uv.unref(handle)`, capture `pid` into module state. Return the handle/pid.
 - [ ] **Step 5: Commit** `#131 M1: cliproxy.spawn (detached, PID-tracked)`
 
 ### Task 2.4: `ensure_running` — reuse / spawn / failure modes
@@ -378,9 +388,10 @@ This wires the pure core to IO. Cover **every** spec failure mode.
   - reuse-if-healthy: a `healthy` fake already listening → `ensure_running` calls `callback`, **does not** spawn (assert PID unchanged / no new process).
   - cold start: nothing listening + a `healthy`-mode fake as the discovered binary → spawns, polls healthy, calls `callback`.
   - foreign port: a `foreign` fake listening → `on_error` with "non-cliproxy process", no spawn.
+  - client_key_mismatch: a `client_key_mismatch` (401) fake → `on_error` naming the api-keys/secret drift (a wiring bug, not login).
+  - needs_login: a `needs_login` fake → **proceeds** (`callback`) — the proxy is up + client-authed; a missing upstream login surfaces as the request's own error, not a dispatch block. (`status` reports `needs_login`.)
   - never-healthy: discovered binary is the `slow` fake → bounded ~5s wait → `on_error("timed out")`, dispatch not blocked past the bound.
   - spawn-fail: discovered binary is the `crash` fake → `on_error("exited")`.
-  - unauthenticated: a `unauth` fake → `on_error` mentioning `:ParleyProxy login` (login not done).
 - [ ] **Step 2: Run** → FAIL.
 Also implement `M.is_managed()` → reads `require("parley").config.cliproxy` and returns `cfg ~= nil and cfg.manage == true` (the gate the `pre_query` seam in Task 3.1 calls). Add a one-line test (inject/stub the parley config).
 
@@ -389,13 +400,13 @@ Also implement `M.is_managed()` → reads `require("parley").config.cliproxy` an
   2. `host, port = cliproxy_config.parse_endpoint(D.providers.cliproxyapi.endpoint)`.
   3. `secret = vault.get_secret(require("parley.providers").get_secret_name("cliproxyapi"))` — derive the secret name via the codebase's single source (providers.lua:1282), don't hardcode the literal (ARCH-DRY).
   4. `cfg, overrides = cliproxy_config.render{...}`; if `#overrides>0` log a warning naming them; write `encode(cfg)` to `stdpath('data')/parley/cliproxy/config.yaml` at `0600`.
-  5. `health_probe` → `healthy`: `callback()`. `foreign`: `on_error`. `unauthenticated`: `on_error` (login). `down`: `discover_binary` (nil → `on_error` naming `brew install`/`auto_download`) → `spawn` → poll `health_probe` every ~250ms up to ~5s → healthy `callback()` / else `on_error("timed out")`. Crash mid-poll → `on_error("exited")`.
+  5. `health_probe` → `healthy`/`needs_login`: `callback()` (proceed). `client_key_mismatch`/`foreign`: `on_error`. `down`: `discover_binary` (nil → `on_error` naming `brew install cliproxyapi`/`auto_download`) → `spawn` → poll `health_probe` every ~250ms up to ~5s → any 200 (`healthy`/`needs_login`) `callback()` / else `on_error("timed out")`. Process exits mid-poll → `on_error("exited")`.
 - [ ] **Step 4: Run** → all PASS.
 - [ ] **Step 5: Commit** `#131 M1: cliproxy.ensure_running (reuse/spawn + all failure modes)`
 
 ### Task 2.5: commands — `status|start|stop|restart|login`
 
-- [ ] **Step 1: Failing tests** — `status()` returns a table with binary source, health/auth state, host:port, auth-dir, config path, and a `config_drift` bool (rendered ≠ running). `stop()` only kills a parley-spawned PID (a reused/foreign daemon is left alone). `restart()` = stop-if-ours + ensure. `login()` builds the `cli-proxy-api login` argv.
+- [ ] **Step 1: Failing tests** — `status()` returns a table with binary source, health/auth state (incl. `needs_login`), host:port, auth-dir, config path, and a `config_drift` bool (rendered ≠ running). `stop()` only kills a parley-spawned PID (a reused/foreign daemon is left alone). `restart()` = stop-if-ours + ensure. `login(provider)` builds the `cliproxyapi -<provider>-login [-no-browser]` argv (map `claude|codex|codex-device|google|kimi|xai|antigravity` → the flag; `google`→`-login`); default/unknown provider → list the valid ones.
 - [ ] **Step 2–4:** Implement. Keep each a thin wrapper; `status` composes `discover_binary` + `health_probe` + a config-drift check. **Drift compare:** decode both the on-disk YAML and a fresh `render`, then `vim.deep_equal` the tables — do NOT string-compare the encoded JSON (Lua table iteration order is unspecified, so `encode` key order isn't stable → string compare false-positives "restart needed").
 - [ ] **Step 5: Commit** `#131 M1: cliproxy commands (status/start/stop/restart/login)`
 

--- a/workshop/plans/000131-managed-cliproxy-plan.md
+++ b/workshop/plans/000131-managed-cliproxy-plan.md
@@ -245,9 +245,11 @@ describe("render", function()
         assert.same({ "host", "port" }, overrides)
     end)
 
-    it("emits an empty api-keys list when no secret is present", function()
+    it("omits api-keys entirely when no secret is present", function()
+        -- NB: do NOT emit an empty table — vim.json.encode({}) is `{}` (object),
+        -- not `[]` (array), so cliproxy would see a malformed api-keys. Omit it.
         local cfg = cc.render({ host = "h", port = 8317, config = {} })
-        assert.same({}, cfg["api-keys"])
+        assert.is_nil(cfg["api-keys"])
     end)
 end)
 ```
@@ -278,9 +280,9 @@ function M.render(opts)
         cfg["auth-dir"] = opts.auth_dir
     end
     if opts.secret ~= nil and opts.secret ~= "" then
-        cfg["api-keys"] = { opts.secret }
+        cfg["api-keys"] = { opts.secret }  -- non-empty → encodes as a JSON array
     else
-        cfg["api-keys"] = {}
+        cfg["api-keys"] = nil  -- omit, not {} (empty table → JSON object, malformed)
     end
     return cfg, overrides
 end
@@ -300,6 +302,7 @@ describe("encode", function()
     it("emits JSON that round-trips and keeps api-keys a list", function()
         local cfg = cc.render({ host = "127.0.0.1", port = 8317, secret = "s", config = {} })
         local str = cc.encode(cfg)
+        assert.is_truthy(str:find('"api-keys":%s*%["s"%]'))  -- wire format: a JSON array, not {}
         local back = vim.json.decode(str)
         assert.equals(8317, back.port)
         assert.same({ "s" }, back["api-keys"])  -- list, not object
@@ -393,7 +396,7 @@ Also implement `M.is_managed()` → reads `require("parley").config.cliproxy` an
 ### Task 2.5: commands — `status|start|stop|restart|login`
 
 - [ ] **Step 1: Failing tests** — `status()` returns a table with binary source, health/auth state, host:port, auth-dir, config path, and a `config_drift` bool (rendered ≠ running). `stop()` only kills a parley-spawned PID (a reused/foreign daemon is left alone). `restart()` = stop-if-ours + ensure. `login()` builds the `cli-proxy-api login` argv.
-- [ ] **Step 2–4:** Implement. Keep each a thin wrapper; `status` composes `discover_binary` + `health_probe` + a config-drift check (compare on-disk rendered file to a fresh `render`).
+- [ ] **Step 2–4:** Implement. Keep each a thin wrapper; `status` composes `discover_binary` + `health_probe` + a config-drift check. **Drift compare:** decode both the on-disk YAML and a fresh `render`, then `vim.deep_equal` the tables — do NOT string-compare the encoded JSON (Lua table iteration order is unspecified, so `encode` key order isn't stable → string compare false-positives "restart needed").
 - [ ] **Step 5: Commit** `#131 M1: cliproxy commands (status/start/stop/restart/login)`
 
 > **Chunk 2 review:** the process-level fake + `ensure_running` failure-mode matrix is the riskiest surface — sanity-review before wiring.


### PR DESCRIPTION
- #131: close — status done, actual 11.81h
- #131 M3: close — fix test-isolation contamination + FIX-THEN-SHIP findings
- #131 M3: auth-failure → guided login (config-driven, no name inference)
- topic-gen: also drop the synthetic (leading-user-turn) system prompt
- topic-gen: drop the persona system prompt from topic generation
- #131 side-quest: default oauth-model-alias so the spawned proxy serves Claude
- #131 side-quest: :ParleyProxy stop reaps leftover proxies by port
- #131 M2: close — address FIX-THEN-SHIP boundary review (no Critical)
- #131 M2: docs + atlas + log for auto_download
- #131 M2: auto_download — fetch + checksum-verify + extract; :ParleyProxy update
- #131 M2: cliproxy_config asset resolution (platform/asset_name/parse_checksums)
- #131 M1: record live e2e validation (operator, fresh nvim spawn path)
- #131 side-quest: ship managed cliproxy on by default
- #131 M1: close — address FIX-THEN-SHIP boundary review (no Critical)
- #131 M1: log Chunk 2/3 completion + full-suite-green evidence
- #131 M1: docs + atlas for managed cliproxyapi
- #131 M1: :ParleyProxy command (status/start/stop/restart/login)
- #131 M1: on_abort teardown at all 4 D.query callers + e2e
- #131 M1: D.query abort channel + cliproxyapi.pre_query hook
- #131 M1: cliproxy lifecycle — spawn, ensure_running, commands
- #131 M1: cliproxy IO seam — discover_binary + health_probe + fake
- #131 M1: Task 2.0 gating GO — validated against real cliproxyapi
- #131 M1: cliproxy_config pure core (parse_endpoint/render/encode)
- #131: plan — fold plan-quality INFO nits (empty api-keys wire, drift deep-compare)
- #131: plan — abort coverage across all 4 D.query callers + block teardown
- #131: plan — fix no-hang gap (pre_query abort channel)
- #131: plan — managed cliproxyapi (M1 spine + M2 outline)
- #131: claim — estimate 16h, status → working
- #131: spec — clarify stop is transient (auto-revive on next use)
- #131: spec — manage cliproxyapi lifecycle + config