### PR TITLE
#140: configurable read-tool roots beyond cwd

### DIFF
--- a/atlas/providers/tool_use.md
+++ b/atlas/providers/tool_use.md
@@ -60,7 +60,7 @@ Tool blocks in the transcript:
 
 ## Safety
 
-- **cwd-scope**: dispatcher checks both `path` and `file_path` fields against working directory. `chat_history_search` deliberately accepts neither, so it can search chat roots that live outside cwd (global iCloud dir, super-repo siblings).
+- **cwd-scope**: dispatcher (`resolve_path_in_cwd`) checks both `path` and `file_path` fields against the working directory, symlink-resolved (`fs_realpath`), so a symlink whose real path escapes is rejected. Read tools (`kind == "read"`) may additionally reach any root in the global `tool_read_roots` config — entries are absolute (`/x`), home (`~/workspace`, `~` expanded), or relative-to-cwd (`../`); write tools (`edit_file`/`write_file`) stay cwd-confined regardless (#140). Default `tool_read_roots = {}` → cwd-only; a rejection names the knob. `chat_history_search` deliberately accepts neither path field, so it can search chat roots that live outside cwd (global iCloud dir, super-repo siblings).
 - **Iteration cap**: `max_tool_iterations` (default 10) — writes synthetic `📎: (iteration limit reached)` when hit
 - **Cancellation**: `cmd_stop` triggers `repair_unmatched_tool_blocks` — writes `📎: (cancelled by user)` for any 🔧: without matching 📎:
 - **Backup**: `write_file` creates numbered `.parley-backup.N` on every write

--- a/lua/parley/config.lua
+++ b/lua/parley/config.lua
@@ -394,6 +394,11 @@ local config = {
 	chat_tool_use_prefix = "🔧:",
 	-- tool result prefix (parley's response to a tool_use, or synthetic cancel/cap marker)
 	chat_tool_result_prefix = "📎:",
+	-- #140: extra roots READ tools (read_file/ls/find/grep/ack) may reach beyond
+	-- cwd. Each entry: absolute (`/x`), home (`~/workspace`, ~ expanded), or
+	-- relative to cwd (`../`). Empty = cwd-only (the default sandbox). Write tools
+	-- (edit_file/write_file) stay cwd-confined regardless of this setting.
+	tool_read_roots = {},
 	-- The banner shown at the top of each chat file.
 	chat_template = require("parley.defaults").short_chat_template,
 	-- if you want more real estate in your chat files and don't need the helper text

--- a/lua/parley/skill_invoke.lua
+++ b/lua/parley/skill_invoke.lua
@@ -215,7 +215,8 @@ function M.invoke(buf, manifest, args, opts)
                             end
                         end
                     end
-                    results[i] = tools_dispatcher.execute_call(call, tools_registry, { cwd = cwd })
+                    results[i] = tools_dispatcher.execute_call(call, tools_registry,
+                        { cwd = cwd, read_roots = require("parley.config").tool_read_roots }) -- #140
                     if call.name == "propose_edits" then
                         if results[i].is_error then
                             table.insert(errors, results[i].content)

--- a/lua/parley/tool_loop.lua
+++ b/lua/parley/tool_loop.lua
@@ -244,6 +244,8 @@ function M.process_response(bufnr, raw_response, agent_info, live_model, exchang
     local exec_opts = {
         cwd = agent_info.cwd or vim.fn.getcwd(),
         max_bytes = agent_info.tool_result_max_bytes or 102400,
+        -- #140: extra read-tool roots (global config); write tools ignore it.
+        read_roots = require("parley.config").tool_read_roots,
     }
 
     for _, call in ipairs(tool_calls) do

--- a/lua/parley/tools/dispatcher.lua
+++ b/lua/parley/tools/dispatcher.lua
@@ -26,26 +26,6 @@ local M = {}
 -- Path resolution
 --------------------------------------------------------------------------------
 
---- Resolve a possibly-relative path against cwd, normalize, resolve
---- symlinks via fs_realpath, and reject anything whose real path
---- escapes cwd.
----
---- Handles the three cases the tool loop needs:
----
----   1. Existing file inside cwd → returns canonical realpath
----   2. Existing file outside cwd (or symlink resolving outside) → rejected
----   3. NEW file (doesn't exist yet) inside cwd → returns
----      `realpath(parent) .. "/" .. basename`. This is what
----      write_file needs when creating a fresh file: the file
----      itself doesn't exist, but its parent dir does, and that
----      parent must be inside cwd.
----
---- Returns `abs_path` on success, or `(nil, err_msg)` on rejection.
----
---- @param path string
---- @param cwd string
---- @return string|nil abs_path
---- @return string|nil err_msg
 -- Resolve a configured read root to a canonical absolute path. Roots may be
 -- absolute (`/x`), home-relative (`~/x`, `~` expanded), or relative to cwd
 -- (`../`, `sub/dir`). Returns the realpath, the normalized path if it does not
@@ -62,9 +42,31 @@ local function resolve_root(root, cwd)
     return vim.loop.fs_realpath(abs) or abs
 end
 
+--- Resolve a possibly-relative path against cwd, normalize, resolve
+--- symlinks via fs_realpath, and reject anything whose real path
+--- escapes cwd (and every configured read root).
+---
+--- Handles the three cases the tool loop needs:
+---
+---   1. Existing file inside cwd → returns canonical realpath
+---   2. Existing file outside cwd (or symlink resolving outside) → rejected
+---   3. NEW file (doesn't exist yet) inside cwd → returns
+---      `realpath(parent) .. "/" .. basename`. This is what
+---      write_file needs when creating a fresh file: the file
+---      itself doesn't exist, but its parent dir does, and that
+---      parent must be inside cwd.
+---
 --- `allowed_roots` (read tools only, #140): extra roots a path may resolve
 --- under, in addition to cwd. Each is resolved + symlink-canonicalized, so a
 --- symlink escaping every root is still rejected. nil/empty → cwd-only.
+---
+--- Returns `abs_path` on success, or `(nil, err_msg)` on rejection.
+---
+--- @param path string
+--- @param cwd string
+--- @param allowed_roots string[]|nil  extra read roots (absolute/~/relative-to-cwd)
+--- @return string|nil abs_path
+--- @return string|nil err_msg
 function M.resolve_path_in_cwd(path, cwd, allowed_roots)
     if type(path) ~= "string" or path == "" then
         return nil, "path must be a non-empty string"
@@ -194,9 +196,11 @@ function M.execute_call(call, tools_registry, opts)
     local path_fields = { "path", "file_path" }
     for _, field in ipairs(path_fields) do
         if opts.cwd and call.input and type(call.input[field]) == "string" then
-            -- #140: read tools (def.kind == "read") may also reach any
-            -- configured `tool_read_roots`; write tools get nil → cwd-only.
-            local roots = (def.kind == "read") and (opts.read_roots or {}) or nil
+            -- #140: read tools may also reach any configured `tool_read_roots`;
+            -- write tools get nil → cwd-only. Gate on `~= "write"` (the canonical
+            -- read-tool predicate `@readonly` uses): `kind` defaults to read when
+            -- absent, so `== "read"` would wrongly confine an absent-kind tool.
+            local roots = (def.kind ~= "write") and (opts.read_roots or {}) or nil
             local abs, scope_err = M.resolve_path_in_cwd(call.input[field], opts.cwd, roots)
             if not abs then
                 return {

--- a/lua/parley/tools/dispatcher.lua
+++ b/lua/parley/tools/dispatcher.lua
@@ -46,7 +46,26 @@ local M = {}
 --- @param cwd string
 --- @return string|nil abs_path
 --- @return string|nil err_msg
-function M.resolve_path_in_cwd(path, cwd)
+-- Resolve a configured read root to a canonical absolute path. Roots may be
+-- absolute (`/x`), home-relative (`~/x`, `~` expanded), or relative to cwd
+-- (`../`, `sub/dir`). Returns the realpath, the normalized path if it does not
+-- resolve, or nil for an invalid root. (#140)
+local function resolve_root(root, cwd)
+    if type(root) ~= "string" or root == "" then
+        return nil
+    end
+    if root:sub(1, 1) == "~" then
+        root = vim.fn.expand(root)
+    end
+    local abs = root:sub(1, 1) == "/" and vim.fs.normalize(root)
+        or vim.fs.normalize(cwd .. "/" .. root)
+    return vim.loop.fs_realpath(abs) or abs
+end
+
+--- `allowed_roots` (read tools only, #140): extra roots a path may resolve
+--- under, in addition to cwd. Each is resolved + symlink-canonicalized, so a
+--- symlink escaping every root is still rejected. nil/empty → cwd-only.
+function M.resolve_path_in_cwd(path, cwd, allowed_roots)
     if type(path) ~= "string" or path == "" then
         return nil, "path must be a non-empty string"
     end
@@ -77,14 +96,28 @@ function M.resolve_path_in_cwd(path, cwd)
     -- absolute paths (handles symlinked /tmp → /private/tmp on macOS).
     local real_cwd = vim.loop.fs_realpath(cwd) or vim.fs.normalize(cwd)
 
-    -- A path is inside cwd iff it equals cwd OR starts with cwd + "/".
-    -- String comparison is safe because both sides are canonical
-    -- absolute paths produced by fs_realpath.
-    if real_path ~= real_cwd and real_path:sub(1, #real_cwd + 1) ~= real_cwd .. "/" then
-        return nil, "path outside working directory: " .. path
+    -- Allowed base dirs: cwd, plus any configured read roots (#140). A path is
+    -- inside a base iff it equals the base OR starts with base + "/". String
+    -- comparison is safe because both sides are canonical fs_realpath outputs.
+    local bases = { real_cwd }
+    for _, root in ipairs(allowed_roots or {}) do
+        local r = resolve_root(root, cwd)
+        if r then
+            table.insert(bases, r)
+        end
     end
 
-    return real_path
+    for _, base in ipairs(bases) do
+        if real_path == base or real_path:sub(1, #base + 1) == base .. "/" then
+            return real_path
+        end
+    end
+
+    if allowed_roots then
+        return nil, "path outside working directory and configured read roots: "
+            .. path .. " (add a root to parley `tool_read_roots` to allow it)"
+    end
+    return nil, "path outside working directory: " .. path
 end
 
 --------------------------------------------------------------------------------
@@ -148,8 +181,9 @@ function M.execute_call(call, tools_registry, opts)
     end
 
     -- SHARED PRELUDE: cwd-scope check for any tool whose input has a
-    -- `path` string field. Applies uniformly to read and write tools
-    -- (M5 adds write-specific additional guards on top of this).
+    -- `path` string field. Read tools additionally honor configured
+    -- `tool_read_roots` (#140); write tools stay cwd-confined.
+    -- (M5 adds write-specific additional guards on top of this.)
     --
     -- `opts.cwd` is optional — the tool_loop passes it explicitly so
     -- the dispatcher does not need to know about vim.fn.getcwd() from
@@ -160,7 +194,10 @@ function M.execute_call(call, tools_registry, opts)
     local path_fields = { "path", "file_path" }
     for _, field in ipairs(path_fields) do
         if opts.cwd and call.input and type(call.input[field]) == "string" then
-            local abs, scope_err = M.resolve_path_in_cwd(call.input[field], opts.cwd)
+            -- #140: read tools (def.kind == "read") may also reach any
+            -- configured `tool_read_roots`; write tools get nil → cwd-only.
+            local roots = (def.kind == "read") and (opts.read_roots or {}) or nil
+            local abs, scope_err = M.resolve_path_in_cwd(call.input[field], opts.cwd, roots)
             if not abs then
                 return {
                     id = call.id,

--- a/tests/unit/tools_dispatcher_spec.lua
+++ b/tests/unit/tools_dispatcher_spec.lua
@@ -132,6 +132,69 @@ describe("resolve_path_in_cwd", function()
     end)
 end)
 
+describe("resolve_path_in_cwd allowed_roots (#140)", function()
+    local cwd, root
+    before_each(function()
+        local n = math.random(0, 0xFFFFFF)
+        cwd = tmp_base .. "/cwd140-" .. n
+        root = tmp_base .. "/root140-" .. n -- a sibling dir to allow
+        vim.fn.mkdir(cwd, "p")
+        vim.fn.mkdir(root, "p")
+    end)
+
+    it("accepts a file inside an absolute allowed root", function()
+        local target = root .. "/readme.md"
+        vim.fn.writefile({ "hi" }, target)
+        local abs, err = dispatcher.resolve_path_in_cwd(target, cwd, { root })
+        assert.is_nil(err)
+        assert.equals(canonical(target), abs)
+    end)
+
+    it("accepts a path reached via a relative-to-cwd root (../sibling)", function()
+        local target = root .. "/readme.md"
+        vim.fn.writefile({ "hi" }, target)
+        local rel_root = "../" .. vim.fs.basename(root)
+        local abs, err = dispatcher.resolve_path_in_cwd(target, cwd, { rel_root })
+        assert.is_nil(err)
+        assert.equals(canonical(target), abs)
+    end)
+
+    it("rejects a path outside cwd and all configured roots, naming the knob", function()
+        local outside = tmp_base .. "/elsewhere140-" .. math.random(0, 0xFFFFFF) .. ".txt"
+        vim.fn.writefile({ "no" }, outside)
+        local abs, err = dispatcher.resolve_path_in_cwd(outside, cwd, { root })
+        assert.is_nil(abs)
+        assert.matches("configured read roots", err)
+        assert.matches("tool_read_roots", err)
+    end)
+
+    it("accepts a symlink in cwd whose real path is inside an allowed root", function()
+        local target = root .. "/real.md"
+        vim.fn.writefile({ "x" }, target)
+        vim.loop.fs_symlink(target, cwd .. "/link.md")
+        local abs, err = dispatcher.resolve_path_in_cwd("link.md", cwd, { root })
+        assert.is_nil(err)
+        assert.equals(canonical(target), abs)
+    end)
+
+    it("rejects a symlink whose real path escapes cwd and all roots", function()
+        local outside = tmp_base .. "/secret140-" .. math.random(0, 0xFFFFFF) .. ".txt"
+        vim.fn.writefile({ "secret" }, outside)
+        vim.loop.fs_symlink(outside, cwd .. "/escape.md")
+        local abs, err = dispatcher.resolve_path_in_cwd("escape.md", cwd, { root })
+        assert.is_nil(abs)
+        assert.matches("configured read roots", err)
+    end)
+
+    it("empty roots list scopes to cwd but still reports the read-roots hint", function()
+        local outside = tmp_base .. "/x140-" .. math.random(0, 0xFFFFFF) .. ".txt"
+        vim.fn.writefile({ "no" }, outside)
+        local abs, err = dispatcher.resolve_path_in_cwd(outside, cwd, {})
+        assert.is_nil(abs)
+        assert.matches("tool_read_roots", err)
+    end)
+end)
+
 describe("truncate", function()
     it("returns content unchanged when under the byte cap", function()
         assert.equals("hello", dispatcher.truncate("hello", 100))
@@ -263,5 +326,35 @@ describe("execute_call", function()
         )
         assert.equals("toolu_07", result.id)
         assert.is_true(result.is_error)
+    end)
+
+    it("read tools reach configured read_roots; write tools stay cwd-confined (#140)", function()
+        local n = math.random(0, 0xFFFFFF)
+        local cwd = tmp_base .. "/gate-cwd-" .. n
+        local root = tmp_base .. "/gate-root-" .. n
+        vim.fn.mkdir(cwd, "p")
+        vim.fn.mkdir(root, "p")
+        local target = root .. "/doc.md"
+        vim.fn.writefile({ "x" }, target)
+
+        local echo_path = function(input)
+            return { content = "ran: " .. (input.file_path or ""), is_error = false }
+        end
+        registry.register({ name = "rd", kind = "read", description = "r",
+            input_schema = { type = "object" }, handler = echo_path })
+        registry.register({ name = "wr", kind = "write", description = "w",
+            input_schema = { type = "object" }, handler = echo_path })
+
+        local opts = { cwd = cwd, read_roots = { root } }
+        -- READ tool: the configured root is honored → handler runs on the file.
+        local rd = dispatcher.execute_call(
+            { id = "g1", name = "rd", input = { file_path = target } }, registry, opts)
+        assert.matches("ran: ", rd.content)
+        assert.equals(false, rd.is_error)
+        -- WRITE tool: same path + same roots, but writes ignore read_roots → rejected.
+        local wr = dispatcher.execute_call(
+            { id = "g2", name = "wr", input = { file_path = target } }, registry, opts)
+        assert.is_true(wr.is_error)
+        assert.matches("outside working directory", wr.content)
     end)
 end)

--- a/tests/unit/tools_dispatcher_spec.lua
+++ b/tests/unit/tools_dispatcher_spec.lua
@@ -356,5 +356,32 @@ describe("execute_call", function()
             { id = "g2", name = "wr", input = { file_path = target } }, registry, opts)
         assert.is_true(wr.is_error)
         assert.matches("outside working directory", wr.content)
+        -- Prove the write path took the nil-roots branch (not the read message).
+        assert.is_nil(wr.content:match("configured read roots"))
+    end)
+
+    it("a tool with ABSENT kind is treated as read (kind defaults to read) (#140)", function()
+        local n = math.random(0, 0xFFFFFF)
+        local cwd = tmp_base .. "/nokind-cwd-" .. n
+        local root = tmp_base .. "/nokind-root-" .. n
+        vim.fn.mkdir(cwd, "p")
+        vim.fn.mkdir(root, "p")
+        local target = root .. "/doc.md"
+        vim.fn.writefile({ "x" }, target)
+        -- No `kind` field → defaults to read → must honor configured roots
+        -- (gate is `~= "write"`, matching @readonly's contract).
+        registry.register({
+            name = "nokind",
+            description = "n",
+            input_schema = { type = "object" },
+            handler = function(input)
+                return { content = "ran: " .. (input.file_path or ""), is_error = false }
+            end,
+        })
+        local res = dispatcher.execute_call(
+            { id = "g3", name = "nokind", input = { file_path = target } },
+            registry, { cwd = cwd, read_roots = { root } })
+        assert.matches("ran: ", res.content)
+        assert.equals(false, res.is_error)
     end)
 end)

--- a/workshop/issues/000140-file-read-tool-failed.md
+++ b/workshop/issues/000140-file-read-tool-failed.md
@@ -1,10 +1,12 @@
 ---
 id: 000140
-status: working
+status: done
 deps: []
 created: 2026-06-25
 updated: 2026-06-25
 started: 2026-06-25T21:54:02-07:00
+estimate_hours: 1.5
+actual_hours: 1.5
 ---
 
 # file read tool failed
@@ -12,16 +14,56 @@ file read failed for an nvim with cwd in brain, to read ../ariadne/README.md. wh
 
 ## Done when
 
--
+- A read tool (`read_file`/`ls`/`find`/`grep`/`ack`) can read a file under any
+  configured root (e.g. `../`, `~/workspace`) even when it resolves outside cwd.
+- Write tools (`edit_file`/`write_file`) stay cwd-confined regardless of config.
+- Default config (`tool_read_roots = {}`) preserves today's cwd-only behavior.
+- The rejection error names the `tool_read_roots` knob so the limit is discoverable.
 
 ## Spec
 
+**Diagnosis.** All file tools route through one guard,
+`dispatcher.execute_call` → `resolve_path_in_cwd(path, cwd)`
+(`lua/parley/tools/dispatcher.lua`), which normalizes, `fs_realpath`-resolves
+symlinks, and rejects any path not equal to / under `cwd` →
+`"path outside working directory"`. From a `brain` cwd, `../ariadne/README.md`
+resolves to a sibling outside cwd → rejected. Deliberate sandbox, hardcoded to
+cwd-only.
+
+**Design** (decisions confirmed: reads-only, global config):
+- New global config `tool_read_roots = {}` — list of extra read roots: absolute,
+  `~`-expanded, or relative-to-cwd (`../`). Opt-in; empty = current behavior.
+- `resolve_path_in_cwd(path, cwd, allowed_roots)` gains `allowed_roots`; a path
+  passes if it resolves under cwd **or** any root (each `fs_realpath`'d, so
+  symlink escapes still caught). Rejection names `tool_read_roots`.
+- `execute_call` passes the roots **only for `def.kind == "read"`** tools; write
+  tools get `nil` → unchanged cwd-confinement.
+- `tool_loop.lua` + `skill_invoke.lua` thread `read_roots = config.tool_read_roots`
+  into `exec_opts`. The dispatcher stays the single path-safety guard.
 
 ## Plan
 
-- [ ]
+- [x] `resolve_path_in_cwd` + `resolve_root` helper: accept `allowed_roots`, pass if under cwd or any root.
+- [x] `execute_call`: gate roots on `def.kind == "read"`.
+- [x] Config `tool_read_roots = {}`; thread via `tool_loop` + `skill_invoke`.
+- [x] Tests (`tools_dispatcher_spec`): root forms, symlink escape, read-vs-write gate.
+- [x] Atlas (`providers/tool_use.md`): document the knob + read-only scope.
+- [x] Verify: full `make test`.
+
+## Revisions
+
+### 2026-06-25 — boundary review (FIX-THEN-SHIP) addressed
+- ARCH-DRY: the read-vs-write gate used `def.kind == "read"`, but `kind` defaults
+  to read when absent and `@readonly` uses `~= "write"` — two predicates for "is a
+  read tool." Switched the gate to `def.kind ~= "write"` (the canonical one) so an
+  absent-kind read tool reaches configured roots; added a test for it (32/32 now).
+- Moved the `resolve_path_in_cwd` EmmyLua doc block below `resolve_root` so its
+  `@param`/`@return` attach correctly, and added `@param allowed_roots`.
+- Tightened the write-rejection test to assert it does NOT carry the read-roots
+  message (proves the nil-roots branch).
 
 ## Log
 
 ### 2026-06-25
+- 2026-06-25: closed — tools_dispatcher_spec 31/31 (7 new #140: absolute + relative-to-cwd roots, symlink escaping cwd+roots rejected, symlink INTO an allowed root accepted, read-vs-write gate); full make test green (exit 0, incl. parley_harness_golden 7/7); luacheck clean. Diagnosis confirmed: resolve_path_in_cwd is the single cwd-scope guard; reads-only allowlist with edit_file/write_file staying cwd-confined per the confirmed design (def.kind gate). Atlas: providers/tool_use.md cwd-scope bullet updated. Actual labeled — active-time found no window.; review verdict: FIX-THEN-SHIP
 


### PR DESCRIPTION
- #140: close — FIX-THEN-SHIP (align read-tool gate with @readonly contract)
- #140: configurable read-tool roots beyond cwd