### PR TITLE
issue-sync: update issues

### DIFF
--- a/atlas/discovery/registry.md
+++ b/atlas/discovery/registry.md
@@ -21,7 +21,7 @@ index later — same output shape, swappable producer).
 | `matcher.lua` | tagged-union predicate over `(path, fm)` | PURE |
 | `descriptor.lua` | `TypeDescriptor` shape + `validate` | PURE |
 | `base.lua` | `build(config)` → base descriptor list (pure fn of live config) | PURE |
-| `registry.lua` | `Registry` — `of/get/names/query/spec_to_command/render` | PURE |
+| `registry.lua` | `Registry` — `of/get/names/query/spec_to_command/render_command/render` | PURE |
 | `merge.lua` | `expand_locate` + `dedupe_compose` — the pure base∪local merge | PURE |
 | `local_types.lua` | grep novel `type:` minus base → `local` descriptors | INTEGRATION (rg) |
 | `init.lua` | `RegistryBuilder` — `build(ctx)` / `current()`; live-config via `setup(parley)` | INTEGRATION |
@@ -53,12 +53,19 @@ repo roots. `plan` has no config key (parley doesn't auto-create
 `workshop/plans/`) — literal `workshop/plans/*.md`.
 
 ## The two consumers
-- `query(type, term) → DiscoverySpec` then `spec_to_command(spec) → string`:
-  the **deterministic-shell, thin-model** seam. The model only ever picks a
-  noun + a term; the registry compiles the actual `rg` pipeline. Only a
+- `query(type, term) → DiscoverySpec` → `spec_to_command(spec) → structured
+  command` → `render_command(cmd) → string`: the **deterministic-shell,
+  thin-model** seam. The model only ever picks a noun + a term; the registry
+  compiles the search. `spec_to_command` is a **pure structured compiler** —
+  `split_glob` turns each `locate` glob into a positional search DIR + a RELATIVE
+  `-g` name pattern, yielding `{search_dirs, name_globs, frontmatter,
+  content_term}`; `render_command` renders the shellescaped `rg` pipeline.
+  This split is the **I-B root-cause fix** (#116 M2): on the *built* registry the
+  locate globs are absolute (repo-prefixed), so the old `rg … -g '<abs>' .`
+  matched nothing — a positional absolute dir + a relative `-g` matches. Only a
   `frontmatter`-kind matcher adds a frontmatter filter; otherwise the `locate`
-  glob discriminates. "Decide the search" (pure) is split from "run the search"
-  (IO, consumer-side / M2).
+  glob discriminates. "Decide/compile the search" (pure) is split from "run it"
+  (IO, consumer-side / #115).
 - `render() → string`: the noun-vocabulary text — one sorted bullet per type
   (label, blurb, a derived find-hint). This is the repo-aware vocabulary parley's
   **chat context** (P1) surfaces; its format is a contract guarded by
@@ -89,11 +96,32 @@ types" when rg is absent. This module is the single swap point for a future
 `datatype`-binary-maintained index: same descriptor-list output, different
 producer.
 
-## Scope (M1 only)
-M1 is the registry **core** (this doc). Deferred:
-- **M2** — finders source their home root folder from the registry (the
-  existing per-type finders; `<C-g>m` stays the type-blind escape hatch).
-- **M3** — embedded descriptor format + human-driven new-instance scaffolding.
+## Issue home from cue (M2)
+The `issue` noun is **ariadne-owned**, so parley sources its home folder from
+ariadne's model rather than hardcoding it (the heart of #116 — parley defers to
+ariadne for ariadne's nouns). `ariadne/construct/vocabulary/issue.cue` carries a
+concrete `discovery: {home, glob}` block; `weave compile` exports it (via
+`vocabulary export`, a passthrough of `cue export`) into the gitignored
+`construct/generated/vocabulary/issue.json`. `issue_vocabulary.home()` reads the
+relative `discovery.home` (nil pre-weave / fresh clone — pcall-guarded). At
+`setup`, `issues.resolve_issues_dir(opts.issues_dir, home(), default)` seeds
+`config.issues_dir` — **precedence: explicit user override > cue home > built-in
+default** — so all five `config.issues_dir` readers (`get_issues_dir`,
+`get_issues_repo_root`, the super-repo finder `issue_finder.lua:133`, the status
+autocmd, and base.lua's issue descriptor) derive from the one cue source with no
+per-reader rerouting. `issues_dir` stays relative (it is in setup's
+`skip_prepare`). chat/note/vision stay parley-native — their config keys are
+parley's own concept, not ariadne's, so routing them through the registry would
+be a circular no-op.
+
+## Scope
+- **M1** — the registry **core** (this doc).
+- **M2 (done)** — `issue` home sourced from cue (above) + the I-B structured-argv
+  fix (built-registry `query()` now compiles a *matching* command). chat/note/
+  vision stay parley-native; the faceted picker UI is split to #115.
+- **M3** — issue creation via `sdlc issue new` **delegation** (retire parley's
+  hand-rolled `render_issue_template`); ariadne#145 unifies the creation template
+  onto the cue model.
 
 ## Related
 - [Repo Mode](../infra/repo_mode.md) — the root-union the merge reuses.

--- a/atlas/issues/issue-management.md
+++ b/atlas/issues/issue-management.md
@@ -9,15 +9,18 @@ IDs are sequential integers (e.g., `000066`, `000067`). Sub-ticket IDs must NOT 
 
 Status values, categories, and lifecycle transitions are loaded at runtime from
 `construct/generated/vocabulary/issue.json`, which is generated from ariadne's
-`construct/vocabulary/issue.cue`. Parley uses that model for issue creation,
-status completion, picker active filtering, status sorting, and status cycling.
+`construct/vocabulary/issue.cue`. Parley uses that model for status completion,
+picker active filtering, status sorting, and status cycling — and (M2 #116) for
+the issue **home**: `config.issues_dir` is seeded at setup from the cue
+`discovery.home` (precedence: explicit user override > cue home > built-in
+default), so every reader derives from the one cue source.
 
 ## Commands
-- `:ParleyIssueNew` (`<C-y>c`): create issue with auto-incremented ID. The title prompt is prefixed with the destination repo — `[<repo>] Issue title: ` — where `<repo>` is the basename of the git root `issues_dir` resolves against (the editor's cwd root), so issues aren't created in the wrong repo (#142)
+- `:ParleyIssueNew` (`<C-y>c`): **delegates to `sdlc issue new`** (M3 #116) — the canonical creator (id allocation + the cue/sdlc-owned template + broadcast to origin/main per ariadne#82) — then opens the created file. The title prompt is prefixed with the destination repo — `[<repo>] Issue title: ` — where `<repo>` is the basename of the git root `issues_dir` resolves against (the editor's cwd root), so issues aren't created in the wrong repo (#142)
 - `:ParleyIssueFinder` (`<C-y>f`): float picker with status badges and view mode cycling — default `all` (done items in `workshop/issues/` visible), `<C-a>` cycles `all → active → all+history` so the first press hides done items (#152)
 - `:ParleyIssueNext` (`<C-y>x`): open next runnable issue (oldest open with all deps done)
 - `:ParleyIssueStatus` (`<C-y>s`): cycle frontmatter status using the first lifecycle transition for the current status in generated vocabulary order
-- `:ParleyIssueDecompose` (`<C-y>i`): create child issue from plan line, add to parent deps, and write a markdown link `[issue NNNNNN](./NNNNNN-slug.md)` into the parent's plan line; the new child file gets a `Parent: [issue PPPPPP](./PPPPPP-...md)` backlink under its title
+- `:ParleyIssueDecompose` (`<C-y>i`): create child issue from plan line, add to parent deps, and write a markdown link `[issue NNNNNN](./NNNNNN-slug.md)` into the parent's plan line; the new child file gets a `Parent: [issue PPPPPP](./PPPPPP-...md)` backlink under its title. (M3 #116: decompose **retains** parley's `render_issue_template` — its semantics, parent.deps += child + the parent plan-line link + the backlink, are incompatible with `sdlc issue new`'s shape, so unlike `:ParleyIssueNew` it is not delegated.)
 - `:ParleyIssueGoto` (`<C-y>g`): follow a markdown link `[...](./NNNNNN-*.md)` under the cursor to the linked issue; if there is no link under the cursor, jump to the current issue's parent (derived from `deps`). Use `<C-o>` to return.
 
 ## Parent/Child Links

--- a/lua/parley/discovery/registry.lua
+++ b/lua/parley/discovery/registry.lua
@@ -112,36 +112,87 @@ function Registry:render()
     return table.concat(lines, "\n")
 end
 
-local function glob_flags(roots)
-    local parts = {}
-    for _, g in ipairs(roots) do
-        table.insert(parts, "-g " .. vim.fn.shellescape(g))
+-- Split a locate glob into (search_dir, name_glob): the leading wildcard-free
+-- directory prefix becomes an rg positional search PATH; the remainder is the
+-- RELATIVE `-g` filename pattern. This is the I-B root-cause fix (#116 M2): on the
+-- BUILT registry the locate globs are absolute (repo-prefixed), so the old
+-- `rg … -g '<abs>' .` matched nothing (an absolute `-g` glob never matches the
+-- relative paths rg walks under `.`). Passing the dir as a positional path makes
+-- rg search there, and a relative `-g` matches names at/under it. Pure.
+--   "/abs/workshop/issues/*.md" → ("/abs/workshop/issues", "*.md")
+--   "**/*.md"                   → (".", "**/*.md")
+--   "workshop/issues/*.md"      → ("workshop/issues", "*.md")
+--- @param glob string
+--- @return string search_dir
+--- @return string|nil name_glob  nil when the glob has no wildcard (a literal path)
+local function split_glob(glob)
+    local wc = glob:find("[%*%?%[]") -- first wildcard byte, or nil
+    if not wc then
+        return glob, nil -- literal path: search it directly, no -g filter
     end
-    return table.concat(parts, " ")
+    -- last '/' at or before the first wildcard → the dir/pattern boundary
+    local boundary = glob:sub(1, wc - 1):find("/[^/]*$")
+    if not boundary then
+        return ".", glob -- wildcard in the first segment → search cwd
+    end
+    return glob:sub(1, boundary - 1), glob:sub(boundary + 1)
 end
 
---- Compile a DiscoverySpec to an rg pipeline string (PURE — does not run it).
---- Roots become rg `--glob` filters; a frontmatter filter lists matching files
---- first, then greps their content. Execution is the consumer's (M2) job.
---- All interpolated values (globs, frontmatter pattern, content term) are
---- `shellescape`d so a value containing a quote can't break/inject the command.
+--- Compile a DiscoverySpec into a STRUCTURED command (PURE — does not run it):
+--- `{ search_dirs = {dir…}, name_globs = {relative glob…}, frontmatter, content_term }`.
+--- `search_dirs` are rg positional paths (absolute-safe); `name_globs` are RELATIVE
+--- `-g` filters (deduped). render_command turns this into the rg string; execution
+--- (vim.fn.system) is the consumer's job. Keeping the compiler structured is the
+--- ARCH-PURE seam — pure compiler, thin shellescape renderer.
 --- @param spec table DiscoverySpec
---- @return string
+--- @return table command
 function M.spec_to_command(spec)
-    local globs = glob_flags(spec.roots)
-    local fm = spec.frontmatter
-    local term = spec.content_term
+    local dirs, globs, seen = {}, {}, {}
+    for _, root in ipairs(spec.roots) do
+        local dir, name = split_glob(root)
+        table.insert(dirs, dir)
+        if name and not seen[name] then
+            seen[name] = true
+            table.insert(globs, name)
+        end
+    end
+    return {
+        search_dirs = dirs,
+        name_globs = globs,
+        frontmatter = spec.frontmatter,
+        content_term = spec.content_term,
+    }
+end
+
+--- Render a structured command (from spec_to_command) into an rg pipeline string,
+--- `shellescape`ing every interpolated value (so a value with a quote can't
+--- break/inject the command). `name_globs` become `-g` filters; `search_dirs`
+--- are positional paths; a frontmatter filter lists matching files first, then
+--- greps their content. PURE — vim.fn.system runs the result (consumer side).
+--- @param cmd table structured command from spec_to_command
+--- @return string
+function M.render_command(cmd)
+    local parts = {}
+    for _, g in ipairs(cmd.name_globs) do
+        table.insert(parts, "-g " .. vim.fn.shellescape(g))
+    end
+    for _, d in ipairs(cmd.search_dirs) do
+        table.insert(parts, vim.fn.shellescape(d))
+    end
+    local scope = table.concat(parts, " ")
+    local fm = cmd.frontmatter
+    local term = cmd.content_term
     if fm then
-        local list = "rg -l " .. vim.fn.shellescape("^" .. fm.field .. ": " .. fm.value) .. " " .. globs .. " ."
+        local list = "rg -l " .. vim.fn.shellescape("^" .. fm.field .. ": " .. fm.value) .. " " .. scope
         if term then
             return list .. " | xargs -r rg -il " .. vim.fn.shellescape(term)
         end
         return list
     end
     if term then
-        return "rg -il " .. vim.fn.shellescape(term) .. " " .. globs .. " ."
+        return "rg -il " .. vim.fn.shellescape(term) .. " " .. scope
     end
-    return "rg --files " .. globs .. " ."
+    return "rg --files " .. scope
 end
 
 return M

--- a/lua/parley/discovery/registry.lua
+++ b/lua/parley/discovery/registry.lua
@@ -144,6 +144,11 @@ end
 --- `-g` filters (deduped). render_command turns this into the rg string; execution
 --- (vim.fn.system) is the consumer's job. Keeping the compiler structured is the
 --- ARCH-PURE seam — pure compiler, thin shellescape renderer.
+--- INVARIANT: all roots in a spec share one trailing glob (per-type uniform
+--- extension — `*.md`, or vision's `*.yaml`). name_globs/search_dirs are flattened
+--- into two independent lists, which rg unions (every `-g` across every path); a
+--- *heterogeneous-extension* spec would therefore over-match. If a future
+--- descriptor mixes extensions, pair each (dir, glob) per root instead (#116 M2 review).
 --- @param spec table DiscoverySpec
 --- @return table command
 function M.spec_to_command(spec)

--- a/lua/parley/init.lua
+++ b/lua/parley/init.lua
@@ -538,6 +538,20 @@ M.setup = function(opts)
 		M.config[k] = v
 	end
 
+	-- #116 M2: seed issues_dir from the cue `discovery.home` (ariadne's issue.cue,
+	-- exported to construct/generated/vocabulary/issue.json) when the user did NOT
+	-- override it, so every config.issues_dir reader (get_issues_dir,
+	-- get_issues_repo_root, the super-repo finder, the status autocmd, base.lua's
+	-- issue descriptor) derives from the one cue source. Precedence: explicit user
+	-- override > cue home > built-in default. home() returns nil in a fresh clone /
+	-- pre-weave, so this is a no-op there (stays on the built-in default). Relative
+	-- stays relative — issues_dir is in skip_prepare, never absolutized here.
+	M.config.issues_dir = require("parley.issues").resolve_issues_dir(
+		opts.issues_dir,
+		require("parley.issue_vocabulary").home(),
+		M.config.issues_dir
+	)
+
 	-- Detect parley-enabled repo via marker file and set up repo-local directories
 	-- Skip if user explicitly set chat_dir in opts (e.g. tests)
 	local function apply_repo_local()

--- a/lua/parley/issue_vocabulary.lua
+++ b/lua/parley/issue_vocabulary.lua
@@ -171,4 +171,26 @@ M.reset_for_tests = function()
     default_model = nil
 end
 
+-- #116 M2: the repo-RELATIVE home folder for issue instances, sourced from the
+-- cue `discovery` block (construct/vocabulary/issue.cue → exported issue.json).
+-- PURE over `model` when given; with no arg it pcall-loads the default and
+-- returns nil when the generated vocabulary is missing/unreadable (fresh clone /
+-- pre-weave) — callers fall back to their own config default. Config-decoupled by
+-- design (the default fallback lives at the seed site, init.lua). Never absolute:
+-- consumers join to their repo root.
+M.home = function(model)
+    if model == nil then
+        local ok, m = pcall(M.default)
+        if not ok then
+            return nil
+        end
+        model = m
+    end
+    local discovery = type(model) == "table" and model.raw and model.raw.discovery
+    if type(discovery) == "table" and type(discovery.home) == "string" and discovery.home ~= "" then
+        return discovery.home
+    end
+    return nil
+end
+
 return M

--- a/lua/parley/issues.lua
+++ b/lua/parley/issues.lua
@@ -502,20 +502,6 @@ M.get_issues_repo_root = function()
     return root
 end
 
--- Resolve the history directory (repo-local, relative to git root)
-M.get_history_dir = function()
-    local history_dir = _parley.config.history_dir or "history"
-    if history_dir:sub(1, 1) == "/" then
-        return history_dir
-    end
-
-    local git_root = _parley.helpers.find_git_root(vim.fn.getcwd())
-    if git_root == "" then
-        git_root = vim.fn.getcwd()
-    end
-    return git_root .. "/" .. history_dir
-end
-
 -- Scan a directory for max issue ID (4-digit prefix pattern)
 local function scan_max_id(dir)
     local max_id = 0

--- a/lua/parley/issues.lua
+++ b/lua/parley/issues.lua
@@ -334,6 +334,55 @@ M.resolve_issues_dir = function(user_override, cue_home, builtin_default)
     return user_override or cue_home or builtin_default
 end
 
+-- #116 M3: extract the created issue path from `sdlc issue new` output. sdlc
+-- writes the bare dest path to stdout (cmd/sdlc/issue.go:319); "Created <path>"
+-- + sync warnings go to stderr — those all carry spaces, so the path is the one
+-- line that is ENTIRELY a non-whitespace `*.md` token. Robust to stdout/stderr
+-- interleaving (we match the token, not a position). PURE. nil if no such line.
+M.parse_issue_new_output = function(output)
+    local found = nil
+    for line in (output or ""):gmatch("[^\n]+") do
+        local trimmed = trim(line)
+        if trimmed:match("^%S+%.md$") then
+            found = trimmed
+        end
+    end
+    return found
+end
+
+-- #116 M3: create a new issue by delegating to `sdlc issue new` — the canonical
+-- creator (allocates the id, writes the canonical template, broadcasts to
+-- origin/main per ariadne#82). Returns (path, nil) | (nil, err). `runner` is
+-- injectable for tests (default = vim.fn.system list-form + v:shell_error); REAL
+-- sdlc creates+pushes an issue, so tests MUST inject a fake runner. Thin IO over
+-- the pure parse_issue_new_output. runner(argv) -> (output, exit_code).
+M.run_sdlc_issue_new = function(title, opts, runner)
+    opts = opts or {}
+    local argv = { "sdlc", "issue", "new", title }
+    if opts.deps and #opts.deps > 0 then
+        table.insert(argv, "--deps")
+        table.insert(argv, table.concat(opts.deps, ",")) -- StringSlice: comma-separated
+    end
+    if opts.slug and opts.slug ~= "" then
+        table.insert(argv, "--slug")
+        table.insert(argv, opts.slug)
+    end
+    runner = runner or function(a)
+        -- list-form: no shell, so the title can't inject or need quoting
+        local out = vim.fn.system(a)
+        return out, vim.v.shell_error
+    end
+    local output, code = runner(argv)
+    if code ~= 0 then
+        return nil, "sdlc issue new failed (exit " .. tostring(code) .. "): " .. trim(output or "")
+    end
+    local path = M.parse_issue_new_output(output)
+    if not path then
+        return nil, "sdlc issue new succeeded but no created path in output: " .. trim(output or "")
+    end
+    return path, nil
+end
+
 --------------------------------------------------------------------------------
 -- IO functions (require vim/parley runtime)
 --------------------------------------------------------------------------------

--- a/lua/parley/issues.lua
+++ b/lua/parley/issues.lua
@@ -6,7 +6,7 @@
 --
 -- Pure functions (no vim deps): parse_frontmatter, next_runnable,
 -- cycle_status_value, topo_sort, parse_deps_value, slugify
--- IO functions (require vim): setup, get_issues_dir, create_issue,
+-- IO functions (require vim): setup, get_issues_dir, run_sdlc_issue_new,
 -- scan_issues, write_frontmatter, cmd_*
 
 local chat_parser = require("parley.chat_parser")
@@ -586,6 +586,14 @@ updated: {{date}}
 ### {{date}}
 ]]
 
+-- #116 M3: retained ONLY for the child-decomposition flow (cmd_issue_decompose).
+-- The primary `cmd_issue_new` path delegates to `sdlc issue new` (the canonical,
+-- cue/sdlc-owned template). The child flow can't cleanly delegate: it sets the
+-- decomposition dep direction (parent.deps += child — the opposite of
+-- `sdlc issue new --deps`), mutates the parent buffer (deps + plan-line link),
+-- and adds a child→parent backlink — semantics `sdlc issue new` doesn't model.
+-- Fully retiring this template means folding those into a sdlc-delegated child
+-- flow (a separate refactor); ariadne#145 unifies the template onto cue.
 M.render_issue_template = function(values)
     values = values or {}
     local default_status = vocab():category("open")[1] or "open"
@@ -594,35 +602,6 @@ M.render_issue_template = function(values)
         :gsub("{{status}}", values.status or default_status)
         :gsub("{{title}}", function() return values.title or "" end)
         :gsub("{{date}}", values.date or "")
-end
-
--- Create a new issue file and open it
-M.create_issue = function(title)
-    local issues_dir = M.get_issues_dir()
-    if not issues_dir then
-        _parley.logger.warning("issues_dir is not configured")
-        return nil
-    end
-
-    vim.fn.mkdir(issues_dir, "p")
-    local id = M.next_issue_id(issues_dir)
-    local slug = M.slugify(title)
-    local filename = id .. "-" .. slug .. ".md"
-    local filepath = issues_dir .. "/" .. filename
-
-    local date = os.date("%Y-%m-%d")
-    local content = M.render_issue_template({
-        id = id,
-        title = title,
-        date = date,
-    })
-    local lines = vim.split(content, "\n", { plain = true })
-
-    vim.fn.writefile(lines, filepath)
-
-    -- Open in current window
-    vim.cmd("edit " .. vim.fn.fnameescape(filepath))
-    return filepath
 end
 
 -- Update frontmatter status in the current buffer
@@ -689,10 +668,16 @@ M.cmd_issue_new = function()
         if not title or trim(title) == "" then
             return
         end
-        local filepath = M.create_issue(title)
-        if filepath then
-            _parley.logger.info("Created issue: " .. vim.fn.fnamemodify(filepath, ":t"))
+        -- #116 M3: delegate to `sdlc issue new` — the canonical creator (id
+        -- allocation, the cue/sdlc-owned template, broadcast to origin/main) —
+        -- instead of parley's own hand-rolled template. Then open the created file.
+        local path, err = M.run_sdlc_issue_new(title)
+        if not path then
+            _parley.logger.error("Issue creation failed: " .. tostring(err))
+            return
         end
+        vim.cmd("edit " .. vim.fn.fnameescape(vim.fn.fnamemodify(path, ":p")))
+        _parley.logger.info("Created issue: " .. vim.fn.fnamemodify(path, ":t"))
     end)
 end
 

--- a/lua/parley/issues.lua
+++ b/lua/parley/issues.lua
@@ -325,6 +325,15 @@ M.repo_label = function(git_root)
     return stripped:match("([^/]+)$") or stripped
 end
 
+-- #116 M2: resolve the effective issues_dir at setup time. Precedence:
+-- explicit user override > cue `discovery.home` > built-in default. PURE — the
+-- setup site supplies the three inputs and seeds config.issues_dir with the
+-- result, so every reader (get_issues_dir, get_issues_repo_root, the super-repo
+-- finder, the status autocmd, base.lua's issue descriptor) derives from one value.
+M.resolve_issues_dir = function(user_override, cue_home, builtin_default)
+    return user_override or cue_home or builtin_default
+end
+
 --------------------------------------------------------------------------------
 -- IO functions (require vim/parley runtime)
 --------------------------------------------------------------------------------

--- a/lua/parley/issues.lua
+++ b/lua/parley/issues.lua
@@ -358,10 +358,11 @@ end
 
 -- #116 M3: create a new issue by delegating to `sdlc issue new` — the canonical
 -- creator (allocates the id, writes the canonical template, broadcasts to
--- origin/main per ariadne#82). Returns (path, nil) | (nil, err). `runner` is
--- injectable for tests (default = vim.fn.system list-form + v:shell_error); REAL
--- sdlc creates+pushes an issue, so tests MUST inject a fake runner. Thin IO over
--- the pure parse_issue_new_output. runner(argv) -> (output, exit_code).
+-- origin/main per ariadne#82). ASYNC: calls `on_done(path|nil, err|nil)` when sdlc
+-- finishes (so callers can show an animated spinner — sdlc is slow: build + push).
+-- `runner(spawn_argv, on_complete)` is injectable for tests (default uses jobstart;
+-- REAL sdlc creates+pushes, so tests MUST inject a fake). Thin IO over the pure
+-- parse_issue_new_output. on_complete(output, exit_code).
 
 -- #116 M3: choose how to spawn `sdlc`. If it's a resolvable executable, spawn the
 -- argv directly (no shell, no quoting). Otherwise `sdlc` is a shell function/alias
@@ -380,7 +381,7 @@ M.build_spawn_argv = function(argv, is_exec, shell)
     return { shell or "sh", "-i", "-c", table.concat(escaped, " ") }
 end
 
-M.run_sdlc_issue_new = function(title, opts, runner)
+M.run_sdlc_issue_new = function(title, opts, on_done, runner)
     opts = opts or {}
     local argv = { "sdlc", "issue", "new" }
     -- #116 M3 (I1 fix): anchor creation at the git root, not nvim's cwd. sdlc's
@@ -407,23 +408,48 @@ M.run_sdlc_issue_new = function(title, opts, runner)
     -- positional arg, not mistaken for a flag by cobra/pflag.
     table.insert(argv, "--")
     table.insert(argv, title)
-    runner = runner or function(a)
-        -- sdlc may be a PATH binary OR a shell function/alias; pick the spawn form
-        -- accordingly (build_spawn_argv). The parser tolerates any rc prompt/precmd
-        -- noise an interactive shell emits — it extracts the .md path, ignores rest.
+    -- ASYNC (so a progress spinner can animate — a blocking vim.fn.system freezes
+    -- the UI). runner(spawn_argv, on_complete) invokes on_complete(output, code);
+    -- the default uses jobstart (build_spawn_argv handles binary-vs-function). The
+    -- parser tolerates any rc prompt/precmd noise an interactive shell emits.
+    runner = runner or function(a, on_complete)
         local is_exec = vim.fn.executable(a[1]) == 1
         local spawn = M.build_spawn_argv(a, is_exec, vim.env.SHELL or vim.o.shell or "sh")
-        return vim.fn.system(spawn), vim.v.shell_error
+        local out = {}
+        local function collect(_, data)
+            if data then
+                vim.list_extend(out, data)
+            end
+        end
+        local jid = vim.fn.jobstart(spawn, {
+            stdout_buffered = true,
+            stderr_buffered = true,
+            on_stdout = collect,
+            on_stderr = collect,
+            on_exit = function(_, code)
+                vim.schedule(function()
+                    on_complete(table.concat(out, "\n"), code)
+                end)
+            end,
+        })
+        if jid <= 0 then
+            vim.schedule(function()
+                on_complete("could not start sdlc (jobstart=" .. tostring(jid) .. ")", 127)
+            end)
+        end
     end
-    local output, code = runner(argv)
-    if code ~= 0 then
-        return nil, "sdlc issue new failed (exit " .. tostring(code) .. "): " .. trim(output or "")
-    end
-    local path = M.parse_issue_new_output(output)
-    if not path then
-        return nil, "sdlc issue new succeeded but no created path in output: " .. trim(output or "")
-    end
-    return path, nil
+    runner(argv, function(output, code)
+        if code ~= 0 then
+            on_done(nil, "sdlc issue new failed (exit " .. tostring(code) .. "): " .. trim(output or ""))
+            return
+        end
+        local path = M.parse_issue_new_output(output)
+        if not path then
+            on_done(nil, "sdlc issue new succeeded but no created path in output: " .. trim(output or ""))
+            return
+        end
+        on_done(path, nil)
+    end)
 end
 
 --------------------------------------------------------------------------------
@@ -711,6 +737,34 @@ end
 -- Commands
 --------------------------------------------------------------------------------
 
+-- An animated command-bar (echo-area) spinner for a pending async op. Reuses the
+-- single-source braille frames (`progress.SPINNER`/`frame`); the timer + echo are
+-- the IO. Returns `{ stop = fn }`. The create path is async (jobstart), so this
+-- animates while sdlc builds + creates + pushes — a blocking call could not.
+M.start_cmdline_spinner = function(message)
+    local progress = require("parley.progress")
+    local tick = 0
+    local timer = vim.uv.new_timer()
+    local function paint()
+        vim.api.nvim_echo({ { " " .. progress.frame(tick) .. " " .. message, "ModeMsg" } }, false, {})
+        tick = tick + 1
+    end
+    paint()
+    timer:start(120, 120, vim.schedule_wrap(paint))
+    return {
+        stop = function()
+            if timer then
+                pcall(function()
+                    timer:stop()
+                    timer:close()
+                end)
+                timer = nil
+            end
+            vim.api.nvim_echo({ { "" } }, false, {}) -- clear the spinner line
+        end,
+    }
+end
+
 M.cmd_issue_new = function()
     -- #142: show the destination repo so issues don't land in the wrong one
     -- (issues_dir resolves against the editor's cwd git root).
@@ -722,18 +776,21 @@ M.cmd_issue_new = function()
         -- #116 M3: delegate to `sdlc issue new` — the canonical creator (id
         -- allocation, the cue/sdlc-owned template, broadcast to origin/main) —
         -- instead of parley's own hand-rolled template. Forward the git-root-
-        -- anchored dirs so creation lands where #142's prompt label promises
-        -- (not relative to nvim's cwd). Then open the created file.
-        local path, err = M.run_sdlc_issue_new(title, {
+        -- anchored dirs so creation lands where #142's prompt label promises.
+        -- Async + a command-bar spinner: sdlc is slow (build + create + push).
+        local spinner = M.start_cmdline_spinner("Creating issue via sdlc…")
+        M.run_sdlc_issue_new(title, {
             issues_dir = M.get_issues_dir(),
             history_dir = M.get_history_dir(),
-        })
-        if not path then
-            _parley.logger.error("Issue creation failed: " .. tostring(err))
-            return
-        end
-        vim.cmd("edit " .. vim.fn.fnameescape(vim.fn.fnamemodify(path, ":p")))
-        _parley.logger.info("Created issue: " .. vim.fn.fnamemodify(path, ":t"))
+        }, function(path, err)
+            spinner.stop()
+            if not path then
+                _parley.logger.error("Issue creation failed: " .. tostring(err))
+                return
+            end
+            vim.cmd("edit " .. vim.fn.fnameescape(vim.fn.fnamemodify(path, ":p")))
+            _parley.logger.info("Created issue: " .. vim.fn.fnamemodify(path, ":t"))
+        end)
     end)
 end
 

--- a/lua/parley/issues.lua
+++ b/lua/parley/issues.lua
@@ -341,9 +341,15 @@ end
 -- interleaving (we match the token, not a position). PURE. nil if no such line.
 M.parse_issue_new_output = function(output)
     local found = nil
-    for line in (output or ""):gmatch("[^\n]+") do
+    for line in (output or ""):gmatch("[^\r\n]+") do
         local trimmed = trim(line)
-        if trimmed:match("^%S+%.md$") then
+        -- The bare dest path (stdout) is a line ending in `.md` that is NOT sdlc's
+        -- "Created <path>" stderr decoration (cok prints "[ok] Created <path>",
+        -- possibly colored). Excluding any line CONTAINING "Created" — rather than
+        -- requiring a whitespace-free token — so an ABSOLUTE path under a directory
+        -- with spaces is still extracted (now reachable: M3 forwards an absolute
+        -- --issues-dir). Plain stdout path carries no color/decoration. (#116 M3 review)
+        if trimmed:match("%.md$") and not trimmed:find("Created", 1, true) then
             found = trimmed
         end
     end
@@ -358,7 +364,19 @@ end
 -- the pure parse_issue_new_output. runner(argv) -> (output, exit_code).
 M.run_sdlc_issue_new = function(title, opts, runner)
     opts = opts or {}
-    local argv = { "sdlc", "issue", "new", title }
+    local argv = { "sdlc", "issue", "new" }
+    -- #116 M3 (I1 fix): anchor creation at the git root, not nvim's cwd. sdlc's
+    -- --issues-dir/--history-dir default RELATIVE ("workshop/...") to its process
+    -- cwd; forwarding the resolved absolute dirs makes both the create location
+    -- AND NextID's scan cwd-independent (preserves the #142 location contract).
+    if opts.issues_dir and opts.issues_dir ~= "" then
+        table.insert(argv, "--issues-dir")
+        table.insert(argv, opts.issues_dir)
+    end
+    if opts.history_dir and opts.history_dir ~= "" then
+        table.insert(argv, "--history-dir")
+        table.insert(argv, opts.history_dir)
+    end
     if opts.deps and #opts.deps > 0 then
         table.insert(argv, "--deps")
         table.insert(argv, table.concat(opts.deps, ",")) -- StringSlice: comma-separated
@@ -367,6 +385,10 @@ M.run_sdlc_issue_new = function(title, opts, runner)
         table.insert(argv, "--slug")
         table.insert(argv, opts.slug)
     end
+    -- `--` terminates flag parsing so a title beginning with `-` is taken as the
+    -- positional arg, not mistaken for a flag by cobra/pflag.
+    table.insert(argv, "--")
+    table.insert(argv, title)
     runner = runner or function(a)
         -- list-form: no shell, so the title can't inject or need quoting
         local out = vim.fn.system(a)
@@ -387,26 +409,34 @@ end
 -- IO functions (require vim/parley runtime)
 --------------------------------------------------------------------------------
 
--- Resolve issues_dir: relative path against git repo root
-M.get_issues_dir = function()
-    local issues_dir = _parley.config.issues_dir
-    if not issues_dir or issues_dir == "" then
+-- Resolve a repo-local dir (issues / history) against the git repo root:
+-- absolute as-is; relative → git_root .. "/" .. dir (cwd's git root, cwd fallback
+-- when not in a repo). ONE resolver so issues + history anchor identically
+-- (ARCH-DRY) and creation is cwd-independent (#116 M3 — see get_history_dir).
+local function resolve_against_git_root(dir)
+    if not dir or dir == "" then
         return nil
     end
-
-    -- If already absolute, use as-is
-    if issues_dir:sub(1, 1) == "/" then
-        return issues_dir
+    if dir:sub(1, 1) == "/" then
+        return dir -- already absolute
     end
-
-    -- Resolve relative to git root
     local git_root = _parley.helpers.find_git_root(vim.fn.getcwd())
     if git_root == "" then
-        -- Fallback to cwd if not in a git repo
-        git_root = vim.fn.getcwd()
+        git_root = vim.fn.getcwd() -- fallback if not in a git repo
     end
+    return git_root .. "/" .. dir
+end
 
-    return git_root .. "/" .. issues_dir
+-- Resolve issues_dir against the git repo root.
+M.get_issues_dir = function()
+    return resolve_against_git_root(_parley.config.issues_dir)
+end
+
+-- Resolve history_dir against the git repo root. #116 M3: forwarded to
+-- `sdlc issue new --history-dir` so its NextID scan covers the right archive and
+-- creation stays git-root-anchored regardless of nvim's cwd (#142 contract).
+M.get_history_dir = function()
+    return resolve_against_git_root(_parley.config.history_dir)
 end
 
 -- Resolve the git repo root issues are created in — the same root get_issues_dir
@@ -670,8 +700,13 @@ M.cmd_issue_new = function()
         end
         -- #116 M3: delegate to `sdlc issue new` — the canonical creator (id
         -- allocation, the cue/sdlc-owned template, broadcast to origin/main) —
-        -- instead of parley's own hand-rolled template. Then open the created file.
-        local path, err = M.run_sdlc_issue_new(title)
+        -- instead of parley's own hand-rolled template. Forward the git-root-
+        -- anchored dirs so creation lands where #142's prompt label promises
+        -- (not relative to nvim's cwd). Then open the created file.
+        local path, err = M.run_sdlc_issue_new(title, {
+            issues_dir = M.get_issues_dir(),
+            history_dir = M.get_history_dir(),
+        })
         if not path then
             _parley.logger.error("Issue creation failed: " .. tostring(err))
             return

--- a/lua/parley/issues.lua
+++ b/lua/parley/issues.lua
@@ -362,6 +362,24 @@ end
 -- injectable for tests (default = vim.fn.system list-form + v:shell_error); REAL
 -- sdlc creates+pushes an issue, so tests MUST inject a fake runner. Thin IO over
 -- the pure parse_issue_new_output. runner(argv) -> (output, exit_code).
+
+-- #116 M3: choose how to spawn `sdlc`. If it's a resolvable executable, spawn the
+-- argv directly (no shell, no quoting). Otherwise `sdlc` is a shell function/alias
+-- (commonly the build-in-owner wrapper) that nvim's non-interactive child shells
+-- can't see — wrap it in the user's INTERACTIVE shell so the rc-defined function
+-- loads. PURE given `is_exec` + `shell`; the spawn itself stays in the runner.
+-- (Fixes the live "E475: 'sdlc' is not executable" — list-form against a function.)
+M.build_spawn_argv = function(argv, is_exec, shell)
+    if is_exec then
+        return argv -- real binary: spawn directly, no shell, no quoting
+    end
+    local escaped = {}
+    for _, word in ipairs(argv) do
+        escaped[#escaped + 1] = vim.fn.shellescape(word)
+    end
+    return { shell or "sh", "-i", "-c", table.concat(escaped, " ") }
+end
+
 M.run_sdlc_issue_new = function(title, opts, runner)
     opts = opts or {}
     local argv = { "sdlc", "issue", "new" }
@@ -390,9 +408,12 @@ M.run_sdlc_issue_new = function(title, opts, runner)
     table.insert(argv, "--")
     table.insert(argv, title)
     runner = runner or function(a)
-        -- list-form: no shell, so the title can't inject or need quoting
-        local out = vim.fn.system(a)
-        return out, vim.v.shell_error
+        -- sdlc may be a PATH binary OR a shell function/alias; pick the spawn form
+        -- accordingly (build_spawn_argv). The parser tolerates any rc prompt/precmd
+        -- noise an interactive shell emits — it extracts the .md path, ignores rest.
+        local is_exec = vim.fn.executable(a[1]) == 1
+        local spawn = M.build_spawn_argv(a, is_exec, vim.env.SHELL or vim.o.shell or "sh")
+        return vim.fn.system(spawn), vim.v.shell_error
     end
     local output, code = runner(argv)
     if code ~= 0 then

--- a/tests/integration/discovery_builder_spec.lua
+++ b/tests/integration/discovery_builder_spec.lua
@@ -176,28 +176,36 @@ describe("discovery.build — render() of the built registry (I1 regression)", f
     end)
 end)
 
-describe("discovery.build — spec_to_command on a built registry (I-B / M2 seam)", function()
-    -- Documents the CURRENT behavior: on the BUILT registry the roots are
-    -- absolute (repo-prefixed), so spec_to_command emits `rg ... -g '<abs>' .`.
-    -- An absolute `-g` glob against search-path `.` won't match — reconciling
-    -- glob-vs-search-root is the M2 execution model (see plan ## Revisions /
-    -- M2 sketch). This test pins the gap so M2 changes it consciously, rather
-    -- than inheriting a silently-empty search.
+describe("discovery.build — spec_to_command on a built registry (I-B FIXED, M2.4)", function()
+    -- On the BUILT registry the locate globs are absolute (repo-prefixed). The
+    -- I-B root-cause fix (#116 M2): spec_to_command splits each glob into a
+    -- positional search DIR (absolute, here `<root>/workshop/issues`) + a RELATIVE
+    -- `-g` name pattern (`*.md`). So the rendered command actually matches files
+    -- under the absolute home — where the old `rg … -g '<abs>' .` returned empty.
     local root = vim.fn.tempname() .. "-parley-builder-cmd"
+    local issues_dir = root .. "/" .. config.issues_dir
 
     before_each(function()
-        vim.fn.mkdir(root, "p")
+        vim.fn.mkdir(issues_dir, "p")
+        vim.fn.writefile({ "# 000001 a todo item", "status: open" }, issues_dir .. "/000001-todo.md")
+        vim.fn.writefile({ "# 000002 something else" }, issues_dir .. "/000002-other.md")
     end)
     after_each(function()
         vim.fn.delete(root, "rf")
     end)
 
-    it("compiles an absolute-glob command from the built issue spec", function()
+    it("splits the built issue spec into a positional abs dir + relative glob", function()
         local reg = builder.build({ repo_root = root })
         local cmd = registry.spec_to_command(reg:query("issue", "todo"))
-        assert.are.equal(
-            "rg -il 'todo' -g '" .. root .. "/" .. config.issues_dir .. "/*.md' .",
-            cmd
-        )
+        assert.are.same({ issues_dir }, cmd.search_dirs)
+        assert.are.same({ "*.md" }, cmd.name_globs)
+    end)
+
+    it("the rendered command actually matches files under the absolute home", function()
+        local reg = builder.build({ repo_root = root })
+        local cmd_str = registry.render_command(registry.spec_to_command(reg:query("issue", "todo")))
+        local out = vim.fn.system(cmd_str)
+        -- was a silently-empty search pre-fix; now lists the matching issue file.
+        assert.is_truthy(out:find("000001%-todo%.md"), "rg should list the matching issue; got:\n" .. out)
     end)
 end)

--- a/tests/unit/discovery_registry_spec.lua
+++ b/tests/unit/discovery_registry_spec.lua
@@ -67,36 +67,47 @@ describe("registry.query → DiscoverySpec", function()
     end)
 end)
 
-describe("registry.spec_to_command", function()
-    it("compiles a frontmatter spec to an rg-filter-then-content pipeline", function()
-        local spec = reg():query("pensive", "duality")
-        local cmd = registry.spec_to_command(spec)
+describe("registry.spec_to_command + render_command", function()
+    -- spec_to_command compiles to a STRUCTURED command (search_dirs as rg
+    -- positional paths, RELATIVE name_globs); render_command renders the
+    -- shellescaped rg pipeline. The split is the I-B root-cause fix (#116 M2):
+    -- an absolute home works as a positional path while the -g pattern stays
+    -- relative — see the built-registry integration test in discovery_builder_spec.
+    it("splits a locate glob into a positional dir + relative name glob", function()
+        local cmd = registry.spec_to_command(reg():query("issue", "async"))
+        assert.are.same({ config.issues_dir }, cmd.search_dirs)
+        assert.are.same({ "*.md" }, cmd.name_globs)
+        assert.equals("async", cmd.content_term)
+        assert.is_nil(cmd.frontmatter)
+    end)
+
+    it("renders a frontmatter spec to an rg-filter-then-content pipeline", function()
+        local cmd = registry.spec_to_command(reg():query("pensive", "duality"))
         assert.are.equal(
-            "rg -l '^type: pensive' -g '**/*.md' . | xargs -r rg -il 'duality'",
-            cmd
+            "rg -l '^type: pensive' -g '**/*.md' '.' | xargs -r rg -il 'duality'",
+            registry.render_command(cmd)
         )
     end)
 
-    it("compiles a no-frontmatter spec to a plain content search", function()
-        -- issue: `any` matcher, single repo-relative glob → deterministic command.
-        local spec = reg():query("issue", "async")
-        local cmd = registry.spec_to_command(spec)
+    it("renders a no-frontmatter spec to a plain content search (dir as path)", function()
+        local cmd = registry.spec_to_command(reg():query("issue", "async"))
         assert.are.equal(
-            "rg -il 'async' -g '" .. config.issues_dir .. "/*.md' .",
-            cmd
+            "rg -il 'async' -g '*.md' " .. vim.fn.shellescape(config.issues_dir),
+            registry.render_command(cmd)
         )
     end)
 
-    it("compiles a frontmatter spec with no term to a file-list command", function()
-        local spec = reg():query("pensive")
-        local cmd = registry.spec_to_command(spec)
-        assert.are.equal("rg -l '^type: pensive' -g '**/*.md' .", cmd)
+    it("renders a frontmatter spec with no term to a file-list command", function()
+        local cmd = registry.spec_to_command(reg():query("pensive"))
+        assert.are.equal("rg -l '^type: pensive' -g '**/*.md' '.'", registry.render_command(cmd))
     end)
 
-    it("compiles a no-frontmatter spec with no term to --files", function()
-        local spec = reg():query("issue")
-        local cmd = registry.spec_to_command(spec)
-        assert.are.equal("rg --files -g '" .. config.issues_dir .. "/*.md' .", cmd)
+    it("renders a no-frontmatter spec with no term to --files", function()
+        local cmd = registry.spec_to_command(reg():query("issue"))
+        assert.are.equal(
+            "rg --files -g '*.md' " .. vim.fn.shellescape(config.issues_dir),
+            registry.render_command(cmd)
+        )
     end)
 end)
 

--- a/tests/unit/issue_vocabulary_spec.lua
+++ b/tests/unit/issue_vocabulary_spec.lua
@@ -87,4 +87,32 @@ describe("issue_vocabulary", function()
             assert.is_true(completed[status] or model:is_terminal(status))
         end
     end)
+
+    -- #116 M2: issue home sourced from the cue `discovery` block (relative).
+    local function vocab_with_discovery(home)
+        local v = sample_vocab()
+        v.discovery = { home = home, glob = "*.md" }
+        return v
+    end
+
+    it("home() returns the exact relative discovery.home from the cue model", function()
+        assert.equals("workshop/issues", vocab.home(vocab.from_table(vocab_with_discovery("workshop/issues"))))
+    end)
+
+    it("home() returns nil when discovery is absent", function()
+        assert.is_nil(vocab.home(vocab.from_table(sample_vocab())))
+    end)
+
+    it("home() returns nil for an empty discovery.home", function()
+        assert.is_nil(vocab.home(vocab.from_table(vocab_with_discovery(""))))
+    end)
+
+    it("home() returns nil (not raise) when the generated vocab can't load", function()
+        local orig = vocab.default
+        vocab.default = function() error("no generated vocab (fresh clone / pre-weave)") end
+        local ok, result = pcall(vocab.home)
+        vocab.default = orig
+        assert.is_true(ok) -- the raising loader was caught, not propagated
+        assert.is_nil(result)
+    end)
 end)

--- a/tests/unit/issues_spec.lua
+++ b/tests/unit/issues_spec.lua
@@ -145,6 +145,22 @@ describe("run_sdlc_issue_new", function()
     end)
 end)
 
+describe("build_spawn_argv (#116 M3 — sdlc as PATH binary vs shell function)", function()
+    it("spawns the argv directly when sdlc is a resolvable executable", function()
+        local argv = { "sdlc", "issue", "new", "--", "t" }
+        assert.are.same(argv, issues.build_spawn_argv(argv, true, "/bin/zsh"))
+    end)
+
+    it("wraps in an interactive shell when sdlc is a function/alias (the live E475 fix)", function()
+        local out = issues.build_spawn_argv({ "sdlc", "issue", "new", "--", "my title" }, false, "/bin/zsh")
+        assert.are.same("/bin/zsh", out[1])
+        assert.are.same("-i", out[2])
+        assert.are.same("-c", out[3])
+        assert.is_truthy(out[4]:find("'sdlc' 'issue' 'new'", 1, true)) -- each word shellescaped
+        assert.is_truthy(out[4]:find("'my title'", 1, true)) -- title quoted intact (space preserved)
+    end)
+end)
+
 --------------------------------------------------------------------------------
 -- slugify
 --------------------------------------------------------------------------------

--- a/tests/unit/issues_spec.lua
+++ b/tests/unit/issues_spec.lua
@@ -33,6 +33,24 @@ local function fake_issue_vocab(statuses)
 end
 
 --------------------------------------------------------------------------------
+-- resolve_issues_dir (#116 M2 — seed precedence: user override > cue > default)
+--------------------------------------------------------------------------------
+
+describe("resolve_issues_dir", function()
+    it("uses the explicit user override when present (wins over cue)", function()
+        assert.equals("my/issues", issues.resolve_issues_dir("my/issues", "workshop/issues", "workshop/issues"))
+    end)
+
+    it("uses the cue home when the user did not override", function()
+        assert.equals("workshop/issues", issues.resolve_issues_dir(nil, "workshop/issues", "fallback/dir"))
+    end)
+
+    it("falls back to the built-in default when neither override nor cue", function()
+        assert.equals("fallback/dir", issues.resolve_issues_dir(nil, nil, "fallback/dir"))
+    end)
+end)
+
+--------------------------------------------------------------------------------
 -- slugify
 --------------------------------------------------------------------------------
 

--- a/tests/unit/issues_spec.lua
+++ b/tests/unit/issues_spec.lua
@@ -91,25 +91,33 @@ end)
 --------------------------------------------------------------------------------
 
 describe("run_sdlc_issue_new", function()
+    -- async runner: receives (argv, on_complete) and calls on_complete(output, code)
     local function fake(output, code, cap)
-        return function(argv)
+        return function(argv, on_complete)
             if cap then cap.argv = argv end
-            return output, code
+            on_complete(output, code)
         end
     end
+    -- drive the async call (the fake calls back inline → stays synchronous) + capture
+    local function run(title, opts, runner)
+        local r = {}
+        issues.run_sdlc_issue_new(title, opts, function(path, err)
+            r.path, r.err = path, err
+        end, runner)
+        return r
+    end
 
-    it("returns the created path on success; argv = sdlc issue new <title>", function()
+    it("calls back with the created path on success; argv = sdlc issue new <title>", function()
         local cap = {}
-        local path, err = issues.run_sdlc_issue_new("My Title", {}, fake("workshop/issues/000160-my-title.md\n", 0, cap))
-        assert.is_nil(err)
-        assert.equals("workshop/issues/000160-my-title.md", path)
+        local r = run("My Title", {}, fake("workshop/issues/000160-my-title.md\n", 0, cap))
+        assert.is_nil(r.err)
+        assert.equals("workshop/issues/000160-my-title.md", r.path)
         assert.are.same({ "sdlc", "issue", "new", "--", "My Title" }, cap.argv)
     end)
 
     it("forwards absolute --issues-dir/--history-dir (git-root-anchored, #116 M3 I1)", function()
         local cap = {}
-        issues.run_sdlc_issue_new("t",
-            { issues_dir = "/r/workshop/issues", history_dir = "/r/workshop/history" },
+        run("t", { issues_dir = "/r/workshop/issues", history_dir = "/r/workshop/history" },
             fake("/r/workshop/issues/000001-t.md\n", 0, cap))
         assert.are.same(
             { "sdlc", "issue", "new", "--issues-dir", "/r/workshop/issues",
@@ -119,20 +127,20 @@ describe("run_sdlc_issue_new", function()
 
     it("appends -- so a title starting with '-' is positional, not a flag", function()
         local cap = {}
-        issues.run_sdlc_issue_new("-n weird title", {}, fake("workshop/issues/000001-n-weird-title.md\n", 0, cap))
+        run("-n weird title", {}, fake("workshop/issues/000001-n-weird-title.md\n", 0, cap))
         assert.are.same({ "sdlc", "issue", "new", "--", "-n weird title" }, cap.argv)
     end)
 
-    it("surfaces a non-zero exit as an error", function()
-        local path, err = issues.run_sdlc_issue_new("t", {}, fake("title is required\n", 1))
-        assert.is_nil(path)
-        assert.is_truthy(err and err:find("exit 1", 1, true))
+    it("calls back with an error on a non-zero exit", function()
+        local r = run("t", {}, fake("title is required\n", 1))
+        assert.is_nil(r.path)
+        assert.is_truthy(r.err and r.err:find("exit 1", 1, true))
     end)
 
     it("errors when sdlc succeeds but prints no parseable path", function()
-        local path, err = issues.run_sdlc_issue_new("t", {}, fake("nothing useful\n", 0))
-        assert.is_nil(path)
-        assert.is_truthy(err and err:find("no created path", 1, true))
+        local r = run("t", {}, fake("nothing useful\n", 0))
+        assert.is_nil(r.path)
+        assert.is_truthy(r.err and r.err:find("no created path", 1, true))
     end)
 
     -- NB: opts.deps is a forward API for an eventual child-flow migration; the
@@ -140,7 +148,7 @@ describe("run_sdlc_issue_new", function()
     -- is the opposite of --deps — parent.deps += child). Don't wire decompose here.
     it("passes --deps (comma-joined) when opts.deps is set", function()
         local cap = {}
-        issues.run_sdlc_issue_new("child task", { deps = { "000116" } }, fake("workshop/issues/000161-child.md\n", 0, cap))
+        run("child task", { deps = { "000116" } }, fake("workshop/issues/000161-child.md\n", 0, cap))
         assert.are.same({ "sdlc", "issue", "new", "--deps", "000116", "--", "child task" }, cap.argv)
     end)
 end)

--- a/tests/unit/issues_spec.lua
+++ b/tests/unit/issues_spec.lua
@@ -51,6 +51,72 @@ describe("resolve_issues_dir", function()
 end)
 
 --------------------------------------------------------------------------------
+-- parse_issue_new_output (#116 M3 — extract the created path from sdlc output)
+--------------------------------------------------------------------------------
+
+describe("parse_issue_new_output", function()
+    it("returns the bare created path (sdlc writes it to stdout, last line)", function()
+        assert.equals("workshop/issues/000160-foo.md",
+            issues.parse_issue_new_output("workshop/issues/000160-foo.md\n"))
+    end)
+
+    it("extracts the bare path from merged stdout+stderr (Created line + sync warning)", function()
+        local merged = "Created workshop/issues/000160-foo.md\n"
+            .. "issue created but auto-sync to main did not complete: offline\n"
+            .. "workshop/issues/000160-foo.md\n"
+        assert.equals("workshop/issues/000160-foo.md", issues.parse_issue_new_output(merged))
+    end)
+
+    it("returns nil when only the spaced 'Created <path>' line is present", function()
+        assert.is_nil(issues.parse_issue_new_output("Created workshop/issues/000160-foo.md\n"))
+    end)
+
+    it("returns nil for empty or pathless output", function()
+        assert.is_nil(issues.parse_issue_new_output(""))
+        assert.is_nil(issues.parse_issue_new_output("some error\nno path here\n"))
+    end)
+end)
+
+--------------------------------------------------------------------------------
+-- run_sdlc_issue_new (#116 M3 — delegate creation to `sdlc issue new`)
+--------------------------------------------------------------------------------
+
+describe("run_sdlc_issue_new", function()
+    local function fake(output, code, cap)
+        return function(argv)
+            if cap then cap.argv = argv end
+            return output, code
+        end
+    end
+
+    it("returns the created path on success; argv = sdlc issue new <title>", function()
+        local cap = {}
+        local path, err = issues.run_sdlc_issue_new("My Title", {}, fake("workshop/issues/000160-my-title.md\n", 0, cap))
+        assert.is_nil(err)
+        assert.equals("workshop/issues/000160-my-title.md", path)
+        assert.are.same({ "sdlc", "issue", "new", "My Title" }, cap.argv)
+    end)
+
+    it("surfaces a non-zero exit as an error", function()
+        local path, err = issues.run_sdlc_issue_new("t", {}, fake("title is required\n", 1))
+        assert.is_nil(path)
+        assert.is_truthy(err and err:find("exit 1", 1, true))
+    end)
+
+    it("errors when sdlc succeeds but prints no parseable path", function()
+        local path, err = issues.run_sdlc_issue_new("t", {}, fake("nothing useful\n", 0))
+        assert.is_nil(path)
+        assert.is_truthy(err and err:find("no created path", 1, true))
+    end)
+
+    it("passes --deps (comma-joined) for the child-decomposition flow", function()
+        local cap = {}
+        issues.run_sdlc_issue_new("child task", { deps = { "000116" } }, fake("workshop/issues/000161-child.md\n", 0, cap))
+        assert.are.same({ "sdlc", "issue", "new", "child task", "--deps", "000116" }, cap.argv)
+    end)
+end)
+
+--------------------------------------------------------------------------------
 -- slugify
 --------------------------------------------------------------------------------
 

--- a/tests/unit/issues_spec.lua
+++ b/tests/unit/issues_spec.lua
@@ -67,6 +67,15 @@ describe("parse_issue_new_output", function()
         assert.equals("workshop/issues/000160-foo.md", issues.parse_issue_new_output(merged))
     end)
 
+    it("extracts an absolute path under a directory containing spaces (#116 M3 I1 consequence)", function()
+        -- M3 forwards an absolute --issues-dir, so dest can be an absolute path
+        -- whose dir contains spaces; the colored '[ok] Created <path>' line is
+        -- excluded by containing "Created", the bare stdout path is kept.
+        local merged = "  [ok] Created /Users/John Doe/r/workshop/issues/000001-foo.md\n"
+            .. "/Users/John Doe/r/workshop/issues/000001-foo.md\n"
+        assert.equals("/Users/John Doe/r/workshop/issues/000001-foo.md", issues.parse_issue_new_output(merged))
+    end)
+
     it("returns nil when only the spaced 'Created <path>' line is present", function()
         assert.is_nil(issues.parse_issue_new_output("Created workshop/issues/000160-foo.md\n"))
     end)
@@ -94,7 +103,24 @@ describe("run_sdlc_issue_new", function()
         local path, err = issues.run_sdlc_issue_new("My Title", {}, fake("workshop/issues/000160-my-title.md\n", 0, cap))
         assert.is_nil(err)
         assert.equals("workshop/issues/000160-my-title.md", path)
-        assert.are.same({ "sdlc", "issue", "new", "My Title" }, cap.argv)
+        assert.are.same({ "sdlc", "issue", "new", "--", "My Title" }, cap.argv)
+    end)
+
+    it("forwards absolute --issues-dir/--history-dir (git-root-anchored, #116 M3 I1)", function()
+        local cap = {}
+        issues.run_sdlc_issue_new("t",
+            { issues_dir = "/r/workshop/issues", history_dir = "/r/workshop/history" },
+            fake("/r/workshop/issues/000001-t.md\n", 0, cap))
+        assert.are.same(
+            { "sdlc", "issue", "new", "--issues-dir", "/r/workshop/issues",
+              "--history-dir", "/r/workshop/history", "--", "t" },
+            cap.argv)
+    end)
+
+    it("appends -- so a title starting with '-' is positional, not a flag", function()
+        local cap = {}
+        issues.run_sdlc_issue_new("-n weird title", {}, fake("workshop/issues/000001-n-weird-title.md\n", 0, cap))
+        assert.are.same({ "sdlc", "issue", "new", "--", "-n weird title" }, cap.argv)
     end)
 
     it("surfaces a non-zero exit as an error", function()
@@ -109,10 +135,13 @@ describe("run_sdlc_issue_new", function()
         assert.is_truthy(err and err:find("no created path", 1, true))
     end)
 
-    it("passes --deps (comma-joined) for the child-decomposition flow", function()
+    -- NB: opts.deps is a forward API for an eventual child-flow migration; the
+    -- current cmd_issue_decompose does NOT use this function (and its dep direction
+    -- is the opposite of --deps — parent.deps += child). Don't wire decompose here.
+    it("passes --deps (comma-joined) when opts.deps is set", function()
         local cap = {}
         issues.run_sdlc_issue_new("child task", { deps = { "000116" } }, fake("workshop/issues/000161-child.md\n", 0, cap))
-        assert.are.same({ "sdlc", "issue", "new", "child task", "--deps", "000116" }, cap.argv)
+        assert.are.same({ "sdlc", "issue", "new", "--deps", "000116", "--", "child task" }, cap.argv)
     end)
 end)
 

--- a/workshop/issues/000116-datatype-aware-navigation-and-creation-via-descriptor.md
+++ b/workshop/issues/000116-datatype-aware-navigation-and-creation-via-descriptor.md
@@ -4,7 +4,7 @@ status: working
 deps: [000114]
 created: 2026-04-30
 updated: 2026-06-11
-estimate_hours: 20
+estimate_hours: 2.8
 ---
 
 # datatype-aware navigation and creation via descriptor
@@ -55,6 +55,34 @@ Lean: (1) for static cases, with an escape to (3) when a type genuinely needs co
 ### Cross-repo
 
 Datatypes can reference instances across repos (e.g., `brain/data/project/charon-launch-push.md` references `charon#13`). Super-repo mode (#114) is the surface that makes this navigable from a single parley session. This issue assumes #114 lands or progresses in parallel; cross-repo navigation is not solved here.
+
+## Estimate
+
+Re-derived 2026-06-30 after the M2/M3 re-scope (typed picker → issue cue-sourcing;
+descriptor-scaffolder → `sdlc issue new` delegation). The original 20h was
+pre-v3.1 and inflated — M1's actual was 0.59h against an 8h guess. Design ×0.2
+(the plan doc pre-resolves decisions); impl at v3.1's 40% of the v2 ranges;
++15% design buffer (thorough plan).
+
+```estimate
+model: estimate-logic-v3.1
+familiarity: 1.0
+design-buffer: 0.15
+item: lua-neovim                design=0.8  impl=0.9
+item: cross-cutting-refactor    design=0.1  impl=0.15
+item: cross-repo-refactor-small design=0.05 impl=0.08
+item: scope-pivot               design=0.15 impl=0.1
+item: milestone-review          design=0.0  impl=0.3
+total: 2.8
+```
+
+> *Produced via `brain/data/life/42shots/velocity/estimate-logic-v3.1.md` against
+> `baseline-v3.1.md`. Method A only.* `lua-neovim` = the parley Lua across M1
+> (discovery registry, done) + M2 (issue cue-sourcing) + M3 (`sdlc issue new`
+> delegation); `cross-cutting-refactor` = the M2 I-B `spec_to_command`
+> structured-argv fix; `cross-repo-refactor-small` = the M2 ariadne `issue.cue`
+> `discovery` block; `scope-pivot` = this mid-flight re-scope; `milestone-review`
+> = the M2 + M3 boundary reviews.
 
 ## Plan
 

--- a/workshop/issues/000116-datatype-aware-navigation-and-creation-via-descriptor.md
+++ b/workshop/issues/000116-datatype-aware-navigation-and-creation-via-descriptor.md
@@ -92,7 +92,7 @@ checklist is folded into M1/M3 below.
 
 - [x] M1 — discovery registry core: base ∪ local composition, `query()` → DiscoverySpec, `render()` noun-vocabulary (the #128 `repo_discovery` unblock)
 - [x] M2 — finders source their home root folder from the registry (`<C-g>m` stays the type-blind escape hatch; the faceted picker is #115)
-- [ ] M3 — issue creation: delegate to `sdlc issue new` (retire parley's hand-rolled `render_issue_template`/`cmd_issue_new`); open the created file. (Descriptor-driven multi-type scaffolding DROPPED — see the 2026-06-30 revision. The deeper "issue structure sourced from cue" unification is ariadne#145, which #116 does NOT block on.)
+- [x] M3 — issue creation: `cmd_issue_new` (`<C-y>c`) delegates to `sdlc issue new` (git-root-anchored via `--issues-dir`/`--history-dir`); dead `create_issue` removed. `render_issue_template` is **retained** for the child-decompose flow — its `parent.deps += child` / parent-buffer-mutation semantics are incompatible with sdlc's `--deps` (which sets `child.deps = [parent]`), so that flow isn't delegated (see the 2026-06-30 M3.4 revision). Descriptor-driven multi-type scaffolding DROPPED; the cue-template unification is ariadne#145, which #116 does NOT block on.
 
 ## Revisions
 
@@ -156,10 +156,17 @@ model and *what* M2/M3 actually do, after auditing the cue→Go→weave pipeline
   **ariadne#145** to unify creation onto the cue model (independent; #116 does
   not block on it).
 - **M3 → delegation.** Parley delegates issue creation to `sdlc issue new`
-  (retire the duplicate `render_issue_template`/`cmd_issue_new`), then opens the
+  (the primary `cmd_issue_new` path; `create_issue` removed), then opens the
   created file. Collapses parley's copy into sdlc's single Go renderer;
   id-allocation stays in sdlc (the dependency on ariadne is not new — it's the
   same `weave`/substrate edge). NOT a generic descriptor-driven scaffolder.
+  - **M3.4 fallback (as-built):** `render_issue_template`/`ISSUE_TEMPLATE`/
+    `next_issue_id` are **RETAINED** for the child-decompose flow — its
+    `parent.deps += child` direction + parent-buffer mutation (plan-line link)
+    can't cleanly use `sdlc issue new --deps` (which sets `child.deps=[parent]`).
+    So retirement is partial: only the top-level path is delegated; full
+    retirement folds into a future sdlc-delegated decompose. ariadne#145 unifies
+    the template onto cue regardless.
 - **M2 → seam now, repo-source later.** M2 inserts the finder→registry seam
   (the finder stops hardcoding its dir; reads the registry's `locate`) + the
   I-B absolute-glob fix. Sourcing the issue `home` from the emitted `issue.json`
@@ -171,6 +178,8 @@ model and *what* M2/M3 actually do, after auditing the cue→Go→weave pipeline
 ## Log
 
 
+
+- 2026-06-30: closed M3 — M3.1-M3.4 TDD; issues_spec 95/0/0 (parse_issue_new_output + run_sdlc_issue_new), full suite green (make test exit 0), lint 0/0 (237 files). cmd_issue_new (<C-y>c) delegates to `sdlc issue new` (injectable runner; list-form vim.fn.system = no shell injection; robust path parse); dead create_issue removed; render_issue_template retained for the child-decomposition flow (incompatible with sdlc --deps direction + parent-buffer mutation — documented, ariadne#145 unifies). --no-actual: same cross-branch active-time window mis-resolution as M2; cumulative measured at final issue close. **Review-Verdict: FIX-THEN-SHIP → fixed.** The sdlc auto-dispatch ran this time AND an independent fresh-eyes subagent both flagged the same Important (I1): `cmd_issue_new` anchored creation at nvim's cwd, not the git root (regressing #142 — stray dir + colliding ID when run from a subdir). Root-cause fix: forward absolute `--issues-dir`/`--history-dir` (one git-root resolver `resolve_against_git_root`, ARCH-DRY) + a `--` flag-terminator (leading-dash titles) + hardened `parse_issue_new_output` for spaced absolute paths (a consequence of the now-absolute dest). Minors handled: deps/slug forward-API test de-trapped; blocking-push UX noted. issues_spec 98/0/0; full suite green (make test exit 0); lint 0/0.
 - 2026-06-30: closed M2 — M2.1-M2.4 TDD; full suite green (make test exit 0), lint 0/0 (237 files). E2E live: vocabulary export -> issue.json carries discovery.home=workshop/issues -> issue_vocabulary.home() returns it -> setup seeds config.issues_dir from cue (all 5 readers derive). I-B fixed: built-registry spec_to_command compiles a MATCHING command (real-rg integration test). --no-actual: active-time window base mis-resolved to M1-start (cross-branch M1 close via PR #95) => measured 5.38h is cumulative, not the M2 increment; issue-level actual measured correctly at final close. **Review-Verdict: SHIP** — fresh-eyes subagent review (sdlc auto-dispatch hit E2BIG "argument list too long" from a bloated PATH → recorded not-run; a manual fresh-context review of the #116-only diff substituted). No Critical/Important. 2 Minor: (1) `spec_to_command` flatten would cross-product a *heterogeneous-extension* spec — not reachable today, now documented as an invariant in the code; (2) `config.lua` keeps the `issues_dir` literal as the pre-weave bootstrap fallback — by design.
 ### 2026-04-30
 

--- a/workshop/issues/000116-datatype-aware-navigation-and-creation-via-descriptor.md
+++ b/workshop/issues/000116-datatype-aware-navigation-and-creation-via-descriptor.md
@@ -1,10 +1,11 @@
 ---
 id: 000116
-status: working
+status: done
 deps: [000114]
 created: 2026-04-30
-updated: 2026-06-11
+updated: 2026-06-30
 estimate_hours: 2.8
+actual_hours: 7.83
 ---
 
 # datatype-aware navigation and creation via descriptor
@@ -179,6 +180,8 @@ model and *what* M2/M3 actually do, after auditing the cue→Go→weave pipeline
 
 
 
+
+- 2026-06-30: closed — M1 discovery registry; M2 issue home from ariadne cue (discovery.home -> weave-emitted issue.json -> config.issues_dir seeded at setup, all 5 readers derive) + I-B spec_to_command structured-argv fix; M3 issue creation delegated to `sdlc issue new` (git-root-anchored via --issues-dir/--history-dir, async jobstart + command-bar spinner, shell-function resolved via interactive shell). Full suite green, lint 0/0/237; M2 SHIP, M3 FIX-THEN-SHIP->fixed; live-tested by operator. Re-scoped deferrals (operator-accepted, land it): generic faceted/any-datatype picker -> #115; embedded-descriptor format + multi-type scaffolding resolved as cue, ariadne#145 unifies the creation template onto cue; descriptor-in-type.md superseded by the cue approach. **Review-Verdict: FIX-THEN-SHIP → fixed.** The end-of-issue integration review flagged one Important (I1, ARCH-DRY): my M3 I1 fix added a `get_history_dir` via the shared `resolve_against_git_root`, but a pre-existing inline `get_history_dir` shadowed it (Lua last-assignment-wins) → dead dup + a divergence on empty config. Fixed: deleted the inline duplicate so `get_issues_dir` + `get_history_dir` both route through the one resolver (the ARCH-DRY claim now true); default-config behavior unchanged, nil guarded at every consumer. issues_spec 100/0/0, lint 0/0.
 - 2026-06-30: closed M3 — M3.1-M3.4 TDD; issues_spec 95/0/0 (parse_issue_new_output + run_sdlc_issue_new), full suite green (make test exit 0), lint 0/0 (237 files). cmd_issue_new (<C-y>c) delegates to `sdlc issue new` (injectable runner; list-form vim.fn.system = no shell injection; robust path parse); dead create_issue removed; render_issue_template retained for the child-decomposition flow (incompatible with sdlc --deps direction + parent-buffer mutation — documented, ariadne#145 unifies). --no-actual: same cross-branch active-time window mis-resolution as M2; cumulative measured at final issue close. **Review-Verdict: FIX-THEN-SHIP → fixed.** The sdlc auto-dispatch ran this time AND an independent fresh-eyes subagent both flagged the same Important (I1): `cmd_issue_new` anchored creation at nvim's cwd, not the git root (regressing #142 — stray dir + colliding ID when run from a subdir). Root-cause fix: forward absolute `--issues-dir`/`--history-dir` (one git-root resolver `resolve_against_git_root`, ARCH-DRY) + a `--` flag-terminator (leading-dash titles) + hardened `parse_issue_new_output` for spaced absolute paths (a consequence of the now-absolute dest). Minors handled: deps/slug forward-API test de-trapped; blocking-push UX noted. issues_spec 98/0/0; full suite green (make test exit 0); lint 0/0.
 - 2026-06-30: closed M2 — M2.1-M2.4 TDD; full suite green (make test exit 0), lint 0/0 (237 files). E2E live: vocabulary export -> issue.json carries discovery.home=workshop/issues -> issue_vocabulary.home() returns it -> setup seeds config.issues_dir from cue (all 5 readers derive). I-B fixed: built-registry spec_to_command compiles a MATCHING command (real-rg integration test). --no-actual: active-time window base mis-resolved to M1-start (cross-branch M1 close via PR #95) => measured 5.38h is cumulative, not the M2 increment; issue-level actual measured correctly at final close. **Review-Verdict: SHIP** — fresh-eyes subagent review (sdlc auto-dispatch hit E2BIG "argument list too long" from a bloated PATH → recorded not-run; a manual fresh-context review of the #116-only diff substituted). No Critical/Important. 2 Minor: (1) `spec_to_command` flatten would cross-product a *heterogeneous-extension* spec — not reachable today, now documented as an invariant in the code; (2) `config.lua` keeps the `issues_dir` literal as the pre-weave bootstrap fallback — by design.
 ### 2026-04-30

--- a/workshop/issues/000116-datatype-aware-navigation-and-creation-via-descriptor.md
+++ b/workshop/issues/000116-datatype-aware-navigation-and-creation-via-descriptor.md
@@ -64,7 +64,7 @@ checklist is folded into M1/M3 below.
 
 - [x] M1 — discovery registry core: base ∪ local composition, `query()` → DiscoverySpec, `render()` noun-vocabulary (the #128 `repo_discovery` unblock)
 - [ ] M2 — finders source their home root folder from the registry (`<C-g>m` stays the type-blind escape hatch; the faceted picker is #115)
-- [ ] M3 — embedded descriptor format + human-driven new-instance scaffolding; update `construct/datatype/type.md` so future prototypes ship a descriptor
+- [ ] M3 — issue creation: delegate to `sdlc issue new` (retire parley's hand-rolled `render_issue_template`/`cmd_issue_new`); open the created file. (Descriptor-driven multi-type scaffolding DROPPED — see the 2026-06-30 revision. The deeper "issue structure sourced from cue" unification is ariadne#145, which #116 does NOT block on.)
 
 ## Revisions
 
@@ -104,6 +104,41 @@ slice it borrows from a repo's agent substrate. Deltas to this issue:
 - **Write-side stays valid.** #116's scaffolding (template new-instance creation)
   is *human-driven manual* creation — consistent with the readonly-*agent*
   direction (the LLM is readonly; the human may scaffold via a template).
+
+### 2026-06-30 — transport settled (weave-emitted JSON); M3 → sdlc delegation; M2 → seam-now
+
+Reason: a design conversation settled *how* parley consumes ariadne's datatype
+model and *what* M2/M3 actually do, after auditing the cue→Go→weave pipeline.
+
+- **Transport = weave-emitted gitignored JSON — already in production.** Parley
+  is a proper weave derivative (`construct/deps` → `substrate ../ariadne`;
+  `make weave` runs ariadne's `weave compile`). `lua/parley/issue_vocabulary.lua`
+  already reads `construct/generated/vocabulary/issue.json` (weave-compiled,
+  gitignored, never committed) for issue status/lifecycle. So the descriptor
+  channel exists; we extend it, not build it. **No commit / vendor / runtime
+  shell-out** (resolves the descriptor-format open question — it's none of the
+  three 2026-04-30 candidates; cue authors, weave emits JSON, lua reads).
+- **Source of truth = cue**, for concepts parley unifies with ariadne (this is
+  parley's ariadne-support subsystem). **Issue-first** — the only well-modeled
+  cue noun. pensive/project deferred (pensive's cue is definitions-only →
+  exports `{}`; the rest have no cue).
+- **Finding:** `sdlc issue new` creation template is **hardcoded Go**
+  (`cmd/sdlc/internal/issue/scaffold.go:Render`), NOT cue-sourced; cue drives
+  only *validation* (`#Issue`) and *lifecycle/status* (`pkg/vocab`). Filed
+  **ariadne#145** to unify creation onto the cue model (independent; #116 does
+  not block on it).
+- **M3 → delegation.** Parley delegates issue creation to `sdlc issue new`
+  (retire the duplicate `render_issue_template`/`cmd_issue_new`), then opens the
+  created file. Collapses parley's copy into sdlc's single Go renderer;
+  id-allocation stays in sdlc (the dependency on ariadne is not new — it's the
+  same `weave`/substrate edge). NOT a generic descriptor-driven scaffolder.
+- **M2 → seam now, repo-source later.** M2 inserts the finder→registry seam
+  (the finder stops hardcoding its dir; reads the registry's `locate`) + the
+  I-B absolute-glob fix. Sourcing the issue `home` from the emitted `issue.json`
+  (a `discovery`/location field added on the ariadne side — ariadne#145's
+  optional scope) is then a **producer swap behind the M1 abstraction, no finder
+  change**. chat/note/vision stay parley-native (genuinely parley's own
+  concepts, not ariadne's).
 
 ## Log
 

--- a/workshop/issues/000116-datatype-aware-navigation-and-creation-via-descriptor.md
+++ b/workshop/issues/000116-datatype-aware-navigation-and-creation-via-descriptor.md
@@ -91,7 +91,7 @@ Decomposed into review-boundary milestones (task detail:
 checklist is folded into M1/M3 below.
 
 - [x] M1 — discovery registry core: base ∪ local composition, `query()` → DiscoverySpec, `render()` noun-vocabulary (the #128 `repo_discovery` unblock)
-- [ ] M2 — finders source their home root folder from the registry (`<C-g>m` stays the type-blind escape hatch; the faceted picker is #115)
+- [x] M2 — finders source their home root folder from the registry (`<C-g>m` stays the type-blind escape hatch; the faceted picker is #115)
 - [ ] M3 — issue creation: delegate to `sdlc issue new` (retire parley's hand-rolled `render_issue_template`/`cmd_issue_new`); open the created file. (Descriptor-driven multi-type scaffolding DROPPED — see the 2026-06-30 revision. The deeper "issue structure sourced from cue" unification is ariadne#145, which #116 does NOT block on.)
 
 ## Revisions
@@ -170,6 +170,8 @@ model and *what* M2/M3 actually do, after auditing the cue→Go→weave pipeline
 
 ## Log
 
+
+- 2026-06-30: closed M2 — M2.1-M2.4 TDD; full suite green (make test exit 0), lint 0/0 (237 files). E2E live: vocabulary export -> issue.json carries discovery.home=workshop/issues -> issue_vocabulary.home() returns it -> setup seeds config.issues_dir from cue (all 5 readers derive). I-B fixed: built-registry spec_to_command compiles a MATCHING command (real-rg integration test). --no-actual: active-time window base mis-resolved to M1-start (cross-branch M1 close via PR #95) => measured 5.38h is cumulative, not the M2 increment; issue-level actual measured correctly at final close. **Review-Verdict: SHIP** — fresh-eyes subagent review (sdlc auto-dispatch hit E2BIG "argument list too long" from a bloated PATH → recorded not-run; a manual fresh-context review of the #116-only diff substituted). No Critical/Important. 2 Minor: (1) `spec_to_command` flatten would cross-product a *heterogeneous-extension* spec — not reachable today, now documented as an invariant in the code; (2) `config.lua` keeps the `issues_dir` literal as the pre-weave bootstrap fallback — by design.
 ### 2026-04-30
 
 Issue filed off the duality pensive. See pensive for the framing context and the open questions that motivated this.

--- a/workshop/plans/000116-datatype-aware-navigation-and-creation-via-descriptor-close-review.md
+++ b/workshop/plans/000116-datatype-aware-navigation-and-creation-via-descriptor-close-review.md
@@ -1,0 +1,75 @@
+# Boundary Review — parley.nvim#116 (whole-issue close)
+
+| field | value |
+|-------|-------|
+| issue | 116 — datatype-aware navigation and creation via descriptor |
+| repo | parley.nvim |
+| issue file | workshop/issues/000116-datatype-aware-navigation-and-creation-via-descriptor.md |
+| boundary | whole-issue close |
+| milestone | — |
+| window | d88253495875b33126daac086c3c2ae41ec57fc0..HEAD |
+| command | sdlc close --issue 116 |
+| reviewer | claude |
+| timestamp | 2026-06-30T15:49:19-07:00 |
+| verdict | FIX-THEN-SHIP |
+
+## Review
+
+I have a complete picture. Tests for the four #116 specs pass cleanly (issues 100, vocab 10, registry 17, builder 11), lint is 0/0/237, the one failing suite test (`tools_builtin_find_spec`) is pre-existing parallel-execution flakiness in a file the window doesn't touch. One real defect surfaced: a duplicate `get_history_dir`.
+
+VERDICT: FIX-THEN-SHIP (confidence: high)
+
+```verdict
+verdict: FIX-THEN-SHIP
+confidence: high
+```
+
+The whole-issue close for #116 (M2 cue-sourced issue home + I-B structured-argv fix; M3 `sdlc issue new` delegation) is in good shape and the prior M3 I1 regression (cwd-anchoring) is genuinely fixed — creation now forwards git-root-anchored absolute `--issues-dir`/`--history-dir`, so the #142 location contract holds. The pure/IO split is exemplary, `create_issue` is cleanly removed with no orphaned callers, the four #116 specs are green and lint is clean. The one thing to fix before crossing: the M3 ARCH-DRY refactor added a new `resolve_against_git_root`-based `get_history_dir` but **left the pre-existing inline one in place**, so the new definition is dead code (shadowed) and the "one resolver" invariant the commit claims isn't actually achieved. Behavior is correct in the default config, so it's non-blocking — but it's a one-line cleanup that should land before "done."
+
+## 1. Strengths
+
+- **ARCH-PURE textbook split.** `parse_issue_new_output` (`issues.lua:342`), `build_spawn_argv` (`issues.lua:373`), `resolve_issues_dir` (`issues.lua:333`), and the `spec_to_command`→`render_command` pair (`registry.lua:154,179`) are all pure and unit-tested IO-free; `run_sdlc_issue_new` is thin IO over them with an **injectable runner** so tests never invoke real sdlc (`issues_spec.lua` `run_sdlc_issue_new` block). This is the pure-core/thin-shell shape the plan promised.
+- **I-B root-cause fix is real, not a patch.** `split_glob` (`registry.lua:128`) turns each absolute locate glob into a positional search DIR + relative `-g` pattern; the integration test actually executes the rendered command against a temp fixture and asserts it lists the file (`discovery_builder_spec.lua` "the rendered command actually matches files under the absolute home") — verifying the previously-silently-empty search now matches.
+- **I1 regression genuinely closed.** `cmd_issue_new` forwards `M.get_issues_dir()`/`M.get_history_dir()` as absolute dirs (`issues.lua:782-784`); `run_sdlc_issue_new` appends `--issues-dir`/`--history-dir` (`issues.lua:391-398`), and `--` terminates flag parsing (`issues.lua:409`) so leading-dash titles stay positional. Both fixes are unit-pinned (`issues_spec.lua` "forwards absolute …" / "appends -- …").
+- **Single-source seed.** `init.lua:549` seeds `config.issues_dir` once from the cue home with correct precedence (override > cue > default), so all five readers derive from one value rather than per-reader rerouting. The `home()` loader is pcall-guarded for fresh-clone/pre-weave (`issue_vocabulary.lua:181`), and I confirmed the generated `issue.json` actually carries `discovery.home: "workshop/issues"`.
+- **Clean, documented retention.** `render_issue_template`/`ISSUE_TEMPLATE`/`next_issue_id` correctly retained for `cmd_issue_decompose` (the only caller, `issues.lua:896`) with the incompatibility rationale spelled out (`issues.lua:666-673`).
+
+## 2. Critical findings
+
+None.
+
+## 3. Important findings
+
+**I1 — Duplicate `get_history_dir`: the new ARCH-DRY definition is dead code, the consolidation it claims isn't achieved. `issues.lua:485-487` (shadowed) vs `:506-517` (wins). (ARCH-DRY)**
+
+The window added a new `M.get_history_dir` that routes through the shared `resolve_against_git_root` (`issues.lua:485`, comment at `:459-462`: *"ONE resolver so issues + history anchor identically (ARCH-DRY)"*), but the pre-existing inline `M.get_history_dir` (`issues.lua:506-517`, present in the base at the same logical spot) was **not deleted**. Lua last-assignment-wins means the old inline version is what actually runs; the new one at `:485` never executes. So:
+- the new definition is **dead code**, and
+- the stated invariant is false in letter — `get_issues_dir` uses `resolve_against_git_root` while the *winning* `get_history_dir` does its own inline git-root join, so there are still two resolvers.
+
+Failure/risk scenario: behavior coincides today only because `config.history_dir` defaults to the relative `"workshop/history"` (`config.lua:524`), for which both implementations yield `git_root/workshop/history`. A future maintainer editing the visible new `:485` version (e.g. to change empty-config handling) will see no effect — a silent maintenance trap. They also diverge on empty config: new returns `nil`, old defaults to `"history"` → `git_root/history` (which would misdirect sdlc's NextID scan away from `workshop/history` and risk an ID collision with archived issues).
+
+Fix (root cause, ARCH-DRY): delete the old inline definition (`issues.lua:506-517`) and keep the `resolve_against_git_root` one. Safe — `nil` history is already guarded at every consumer (`next_issue_id` `:546`, `scan_issues` `:623`, and `cmd_issue_new`'s `if opts.history_dir and opts.history_dir ~= ""` `:395`). This restores the genuine single-resolver the comment claims.
+
+## 4. Minor findings
+
+- **`parse_issue_new_output` "Created"-substring discriminator is fragile.** `issues.lua:352` excludes any line *containing* `"Created"` to skip sdlc's stderr decoration. A repo whose absolute path legitimately contains `Created` (e.g. `/Users/x/Created/...`) would cause the bare-path stdout line to be wrongly excluded → `nil`. Root-cause-clean alternative: keep stdout/stderr **separate** in the jobstart runner (`issues.lua:419-423` merges them via one `collect`) and take the last `.md` line from stdout only — no content heuristic needed.
+- **`vim.uv` vs `vim.loop` inconsistency.** `start_cmdline_spinner` uses `vim.uv.new_timer()` (`issues.lua:747`) while the rest of the codebase — including the sibling `progress.lua:72` and `issues.lua`'s own scandir calls — uses `vim.loop`. `vim.uv` only exists on nvim ≥ 0.10; for consistency/portability use `vim.loop` (or `vim.uv or vim.loop`).
+- **Spinner duplicates the progress timer loop (ARCH-DRY-adjacent).** `start_cmdline_spinner` (`issues.lua:744`) re-implements the 120ms timer→tick→repaint loop that `progress.start` (`progress.lua:65-76`) already owns, reusing only `progress.frame`. The render targets genuinely differ (echo-area vs float window), so this is borderline-acceptable, but note it ships a second progress mechanism rather than extending the established one.
+- **`--deps`/`--slug` forward API has no production caller.** `run_sdlc_issue_new`'s `opts.deps`/`opts.slug` (`issues.lua:399-406`) are exercised only by tests; `cmd_issue_new` passes neither and the decompose flow wasn't migrated. Documented speculative generality — acceptable, but it ships unused.
+
+## 5. Test coverage notes
+
+- Pure seams are well covered: parser (merged-stream + spaced-absolute-path + error branches), argv forwarding (absolute dirs, `--`, `--deps`), `build_spawn_argv` (binary vs interactive-shell), `resolve_issues_dir` precedence, `home()` (relative string / absent / empty / raising-loader-caught), and the I-B structured split + real-rg integration.
+- **Gap:** the I1 fix's actual IO path (`cmd_issue_new` → real `vim.fn.system`/jobstart → cwd-relative resolution → `:p` open from a subdir) is entirely faked; the "creates under git root when cwd ≠ repo root" behavior rests on the argv-forwarding unit tests + the operator live-test logged in the issue. Real sdlc creates+pushes, so an automated e2e is impractical — acceptable, but the e2e that would have *originally* caught I1 still doesn't exist.
+- The duplicate `get_history_dir` (§3) is invisible to tests because both implementations coincide on the default config — a test asserting `get_history_dir()` resolves against git root would still pass against the wrong (old) function. No test change needed beyond removing the dup.
+
+## 6. Architectural notes for upcoming work
+
+- **ARCH-DRY: FLAG → §3.** Otherwise the diff single-sources well (issue creation → sdlc; issue home → cue seed; one `resolve_against_git_root` for issues). Removing the dead `get_history_dir` collapses the last duplicate resolver.
+- **ARCH-PURE: PASS.** Exemplary; the injectable-runner pattern is the right seam for the next sdlc-delegated flow (the eventual decompose migration).
+- **ARCH-PURPOSE: PASS (with tracked deferrals).** Shadow-sweep of issue-creation/home consumers: `cmd_issue_new` derives from sdlc ✓; `config.issues_dir` (all 5 readers) derives from cue ✓; `cmd_issue_decompose` still hand-maintains `ISSUE_TEMPLATE` ✗ — a genuinely separable secondary path, documented and tracked to ariadne#145, not the cheap-win evasion the principle targets. The original "descriptor in `type.md`" purpose was consciously superseded by the cue channel (better single source), documented in the issue revisions. The deferred faceted picker is #115. No undeclared scope creep; the re-scopes are all operator-accepted and logged.
+
+## 7. Plan revision recommendations
+
+- None required for accuracy — the plan and issue already reconcile the as-built scope (M3.4 fallback retaining `render_issue_template` is documented in both the `## Plan` row at `000116…md:96` and the 2026-06-30 plan revision; the M2/M3 re-scopes are in `## Revisions`). The Core-concepts/entity table (M1-era matcher kinds) still matches code.
+- Optional: when fixing §3, add a one-line note to the plan's M3 / Log that `get_history_dir` was consolidated onto `resolve_against_git_root` (the dead-dup removal) so the "ONE resolver" claim in `issues.lua:459-462` is true in fact, not just intent.

--- a/workshop/plans/000116-datatype-aware-navigation-and-creation-via-descriptor-m3-review.md
+++ b/workshop/plans/000116-datatype-aware-navigation-and-creation-via-descriptor-m3-review.md
@@ -1,0 +1,65 @@
+# Boundary Review — parley.nvim#116 (milestone M3)
+
+| field | value |
+|-------|-------|
+| issue | 116 — datatype-aware navigation and creation via descriptor |
+| repo | parley.nvim |
+| issue file | workshop/issues/000116-datatype-aware-navigation-and-creation-via-descriptor.md |
+| boundary | milestone M3 |
+| milestone | M3 |
+| window | a37a83236b25ccdfda58bf81fa5d27ad4981d873..HEAD |
+| command | sdlc milestone-close --issue 116 --milestone M3 |
+| reviewer | claude |
+| timestamp | 2026-06-30T12:37:56-07:00 |
+| verdict | FIX-THEN-SHIP |
+
+## Review
+
+Confirmed the regression. sdlc's `--issues-dir` defaults to the **relative** `"workshop/issues"`, and `dest := filepath.Join(f.IssuesDir, …)` + `os.WriteFile(dest)` writes **relative to sdlc's process cwd** (which `vim.fn.system` inherits from nvim's `getcwd()`). The old `create_issue` anchored creation at the **git root** (`get_issues_dir()` = `git_root .. "/" .. issues_dir`). So when nvim's cwd isn't the repo root, the new path diverges. I have everything I need.
+
+VERDICT: FIX-THEN-SHIP (confidence: high)
+
+The M3 delegation is cleanly executed and the boundary is non-blocking: the pure/IO split is exemplary (a pure `parse_issue_new_output` + a thin `run_sdlc_issue_new` over an injectable runner), the documented sdlc stdout/stderr stream split is accurate (verified against `cmd/sdlc/issue.go`), the parser's "match the bare `.md` token, not a stream position" design is genuinely robust (I confirmed `vim.fn.system` merges stderr in this runtime, so the parser *must* skip the spaced "Created …"/warning lines — and it does), `create_issue` was removed with no orphaned callers, full suite is green (`make test` exit 0, lint 0/0/237, issues_spec OK). The one thing to fix before `sdlc close`: `cmd_issue_new` now anchors issue creation at nvim's **cwd** instead of the **git root**, a silent regression of the #142 location contract when cwd ≠ repo root.
+
+## 1. Strengths
+
+- **ARCH-PURE textbook split.** `parse_issue_new_output` (`issues.lua:342`) is pure and tested IO-free; `run_sdlc_issue_new` (`issues.lua:359`) is thin IO over it with a default-vs-injectable runner so tests never invoke real sdlc (`issues_spec.lua:84-117`). This is exactly the pure-core/thin-shell shape the plan promised.
+- **Robust, well-reasoned parser.** Matching `^%S+%.md$` (the one space-free token) rather than "last line" is the right call — I verified empirically that `vim.fn.system` *merges* stderr here, so the "Created …" + sync-warning lines really do land in the captured output, and the parser correctly skips them regardless of pipe interleaving. The test at `issues_spec.lua:63-68` pins exactly this merged-stream case.
+- **Faithful delegation contract.** The stdout=bare-path / stderr=Created+warnings claim in the code comment (`issues.lua:337-341`) matches `cmd/sdlc/issue.go` verbatim (`fmt.Fprintln(stdout, dest)` vs `cok(stderr, …)`/`cwarn(stderr, …)`).
+- **Clean removal.** `create_issue` deleted with zero remaining call sites; `render_issue_template`/`ISSUE_TEMPLATE`/`next_issue_id` correctly retained (still used by `cmd_issue_decompose`) and the retention is documented with rationale (`issues.lua:589-596`).
+
+## 2. Critical findings
+
+None.
+
+## 3. Important findings
+
+**I1 — Issue creation now anchors at nvim's cwd, not the git root (regresses the #142 location contract). `issues.lua:674`, `:361` (ARCH-DRY / ARCH-PURPOSE)**
+
+`run_sdlc_issue_new` builds `{"sdlc","issue","new",title}` with no `--issues-dir`, so sdlc uses its relative default `"workshop/issues"` and writes `filepath.Join("workshop/issues", …)` **relative to its process cwd** = nvim's `getcwd()` (`cmd/sdlc/issue.go:217,265,288`). The deleted `create_issue` resolved via `get_issues_dir()` = `git_root .. "/" .. issues_dir` (`issues.lua:391-410`), i.e. git-root-anchored and cwd-independent.
+
+Failure scenario: nvim launched (or `autochdir`'d) in a subdir like `lua/parley/`. `:ParleyIssueNew` → sdlc creates a stray `lua/parley/workshop/issues/000001-foo.md` (and `NextID` scans that empty dir → **allocates a colliding ID**, e.g. `000001`), then parley's `fnamemodify(path, ":p")` (relative to the same cwd) opens that stray file. The #142 prompt label still shows the *git-root* repo basename via `get_issues_repo_root()` — so the label now lies about where the file lands. Common case (cwd = repo root) is unaffected; no crash or data loss, hence Important not Critical, but it silently misfiles + can collide IDs.
+
+Fix sketch (root cause): pass the already-resolved absolute dir so creation routes through the same resolution every other reader uses (ARCH-DRY) — `cmd_issue_new` computes `M.get_issues_dir()` and forwards it as `opts.issues_dir`; `run_sdlc_issue_new` appends `--issues-dir <abs>`. sdlc then prints an absolute `dest`, making the subsequent `:p` a no-op and the open/create locations identical and cwd-independent. Verify the #82 broadcast-to-main still behaves with an absolute issues-dir.
+
+## 4. Minor findings
+
+- **Leading-dash titles are parsed as flags.** A title like `"-n: refactor"` becomes a bare argv element starting with `-`; cobra/pflag treats it as a flag → spurious failure (the old non-shell path was immune). Cheap guard: append `"--"` before `title` in the argv (`issues.lua:361`). Combine with the I1 fix.
+- **`--deps`/`--slug` plumbing has no production caller.** `cmd_issue_new` calls `run_sdlc_issue_new(title)` with no opts, and the child-decompose flow was *not* migrated (took the documented M3.4 fallback), so `opts.deps`/`opts.slug` (`issues.lua:362-369`) are exercised only by tests. Mild speculative generality — acceptable as the documented forward API for the eventual child migration, but note it ships unused.
+- **`render_issue_template` retention vs the `## Plan` text.** The issue's M3 checkbox (`000116…md:95`) and plan (`plan.md:314`) say "retire `render_issue_template`", but it's retained for the child flow. The Log entry documents the partial retirement; the Plan line itself reads as fuller than reality (see §7).
+
+## 5. Test coverage notes
+
+- Pure parser + runner seam are well covered, including the merged-stream case and the three error branches (non-zero exit, unparseable output, success). Good — this covers the bug class the *parser* could ship.
+- **Gap:** the real IO integration (`cmd_issue_new` → actual `vim.fn.system` → cwd-relative resolution → `:p` open) is entirely faked, which is exactly why I1 (cwd anchoring + ID collision from a subdir) is untested and ships silently. A small integration test that runs `run_sdlc_issue_new` with a real fake-`sdlc` script on `$PATH` from a subdir cwd, asserting the created path resolves under the git root, would pin the fix. Not blocking, but it's the test that would have caught I1.
+
+## 6. Architectural notes for upcoming work
+
+- **ARCH-DRY: PASS, with tracked debt.** `cmd_issue_new` now single-sources to sdlc; the remaining `render_issue_template` for the child flow is documented and tracked (ariadne#145). Note the *new* DRY seam I1 exposes: issue-dir resolution now has two implementations — parley's `get_issues_dir()` (git-root) and sdlc's cwd-relative default — and the fix (forward `--issues-dir`) collapses them back to one.
+- **ARCH-PURE: PASS.** Exemplary; nothing to add.
+- **ARCH-PURPOSE: mostly PASS.** Shadow-sweep of issue-creation consumers: `cmd_issue_new` derives from sdlc ✓; `cmd_issue_decompose` still hand-maintains `ISSUE_TEMPLATE` ✗ (documented deferral, tracked). The deferred child flow is a genuine secondary path, not the cheap-win evasion the principle targets — acceptable. The I1 cwd-anchoring does nick the purpose ("delegate to the canonical creator" should mean issues land in the canonical location); fixing it completes the intent.
+
+## 7. Plan revision recommendations
+
+- **Issue file (`000116…md`), `## Revisions`:** add an entry noting M3 took the M3.4 **fallback** — `render_issue_template`/`ISSUE_TEMPLATE`/`next_issue_id` are *retained* for `cmd_issue_decompose`; only the top-level `cmd_issue_new`/`create_issue` path was retired. The M3 `## Plan` checkbox text ("retire … `render_issue_template`") otherwise overstates the delivered scope. (The Log already records this; the Plan line should be reconciled so the plan stops claiming full retirement.)
+- **Plan (`000116-discovery-registry-plan.md`), M3.3:** the task says only `:edit` the returned path; it omits the cwd-vs-git-root resolution decision that I1 surfaces. If I1 is fixed by forwarding `--issues-dir <abs>`, add a one-line note to M3.3 recording that creation is anchored at `get_issues_dir()` (git root), not sdlc's cwd default — so the contract is explicit rather than incidental.

--- a/workshop/plans/000116-discovery-registry-plan.md
+++ b/workshop/plans/000116-discovery-registry-plan.md
@@ -242,35 +242,46 @@ registry's issue descriptor consume it (`ARCH-DRY`).
 
 #### Task M2.2 — parley: `issue_vocabulary.home()` (cue-sourced, graceful fallback)
 - `lua/parley/issue_vocabulary.lua`: add `M.home()` → the **relative**
-  `discovery.home` from the loaded JSON (NOT repo-root-joined). Relative is the
-  consistent form: `config.issues_dir` is relative (`"workshop/issues"`,
-  `config.lua:520`), `get_issues_dir()` already does the git-root join itself
-  (`issues.lua:333-352`) and expects a relative input, and `base.lua` globs are
-  repo-relative by contract (RegistryBuilder prefixes the root). Joining anywhere
-  but `get_issues_dir()` would double-join or skip per-root expansion.
-- Fallback `config.issues_dir` (also relative) when `discovery.home` is absent.
-  The loader **raises** on a missing/unreadable file (`M.load()` → `error()`,
-  `issue_vocabulary.lua:147`), so wrap it in `pcall` — the fresh-clone/pre-weave
-  fallback must catch the raise, not just a `discovery == nil` field check.
-- Test: pin the **exact relative form** returned (`"workshop/issues"`, not merely
-  non-nil — so TDD forces the relative contract); missing field → fallback;
-  missing/unreadable file → fallback (the pcall path). (`ARCH-PURE`)
+  `discovery.home` from the loaded JSON (NOT joined), or **nil** when absent.
+  Relative is the consistent form: `config.issues_dir` is relative
+  (`"workshop/issues"`, `config.lua:520`), `get_issues_dir()` does its own git-root
+  join (`issues.lua:333-352`), and `base.lua` globs are repo-relative by contract.
+- The loader **raises** on a missing/unreadable file (`M.load()` → `error()`,
+  `issue_vocabulary.lua:147`), so wrap it in `pcall` and return **nil** (not raise)
+  in a fresh clone / pre-weave. Keep the module **config-decoupled** — no `config`
+  access here; the default fallback lives at the seed site (M2.3).
+- Test: cue JSON with `discovery.home` → returns the **exact relative string**
+  (`"workshop/issues"`, not merely non-nil — TDD forces the relative contract);
+  missing `discovery` field → nil; missing/unreadable file → nil (the pcall path).
+  (`ARCH-PURE`)
 
-#### Task M2.3 — parley: route the issue dir through the cue source
-- `lua/parley/issues.lua` `get_issues_dir()` (the single issue-dir accessor) →
-  source from `issue_vocabulary.home()`. The finder (`issue_finder.lua`) +
-  super-repo `expand_roots` already go through it; reroute that one accessor so they
-  pick up the repo-sourced dir. Keep `expand_roots` + `scan_issues`.
-- `base.lua`'s issue descriptor sources its `locate` home from the same cue home
-  in **relative** form, **injected via RegistryBuilder at the IO boundary**
-  (base.lua stays a pure function — receives the home as data). RegistryBuilder
-  then expands it across `[repo_root] + members` exactly like every other base
-  glob, so in **super-repo mode** the registry's issue view and the finder's
-  `expand_roots` (`issue_finder.lua:133`) view **converge** — both see siblings.
-  (`ARCH-PURPOSE`: one cue home, derived in *every* mode; `ARCH-DRY`, `ARCH-PURE`.)
-- **Test (registry side):** in super-repo mode the issue `locate` is expanded
-  across roots (relative-glob behavior preserved) — guards against an absolute
-  home silently collapsing the registry to the current repo only.
+#### Task M2.3 — seed `config.issues_dir` from the cue home at setup (root-cause, one source)
+
+**Plan-quality finding (high-confidence) corrected the original per-reader reroute.**
+`config.issues_dir` has **five** direct readers, not one:
+`get_issues_dir()` (`issues.lua:334`), `get_issues_repo_root()` (`issues.lua:358`),
+the **super-repo finder** `super_repo.expand_roots(config.issues_dir)`
+(`issue_finder.lua:133` — the motivating #114 consumer), the status-typeahead
+autocmd (`init.lua:872`), and `base.lua`'s issue descriptor (`base.lua:63`).
+Rerouting only `get_issues_dir()` leaves the super-repo finder + others on raw
+config → divergence (`ARCH-PURPOSE` failure), invisible today only because the
+default and the cue home are the same string.
+
+- **Fix (root cause, `ARCH-DRY`):** at setup, right after the opts→config merge
+  (`init.lua:537-538`), seed:
+  `if opts.issues_dir == nil then local h = require("parley.issue_vocabulary").home(); if h then M.config.issues_dir = h end end`.
+  Precedence **explicit user override > cue `discovery.home` > built-in default**.
+  All five readers then derive from the one seeded value — **no per-reader
+  rerouting, no base.lua injection** (base.lua reads the seeded `config.issues_dir`).
+- **Relative preserved:** `issues_dir` ∈ `repo_artifacts.dir_keys` → `skip_prepare`
+  (`init.lua:644-646`), so dir-prep never absolutizes it; the cue home is relative
+  and stays relative (base.lua's locate contract + `get_issues_dir`'s join rely on
+  this).
+- Tests: setup with cue home + no user override → `config.issues_dir == "<cue home>"`;
+  `opts.issues_dir` set → override wins; fresh clone (`home()` nil) → built-in
+  default. Plus a **registry super-repo** test: the issue `locate` expands across
+  `[repo_root] + members` (relative-glob behavior), guarding against a collapse to
+  the current repo.
 
 #### Task M2.4 — I-B root-cause fix (built-registry query correctness)
 - `spec_to_command` → return a **structured form** (search_dirs + filename_globs +
@@ -282,11 +293,11 @@ registry's issue descriptor consume it (`ARCH-DRY`).
   seam)" from pinning the broken absolute-glob output to asserting the corrected,
   *matching* command; add an integration test (built registry over a temp fixture →
   the executed command actually lists the fixture's files).
-- **Contract change — update the four string-output assertions** in
-  `tests/unit/discovery_registry_spec.lua:73,83,92,98` (they assert the current
-  `rg … -g <glob> .` string). Changing `spec_to_command` to a structured form
-  breaks them; `make test` surfaces them, but they're listed here so the contract
-  change is deliberate, not accidental.
+- **Contract change — update the four `assert.are.equal` string assertions** at
+  `tests/unit/discovery_registry_spec.lua:74-77, 84-87, 93, 99` (they assert the
+  current `rg … -g <glob> .` string). Changing `spec_to_command` to a structured
+  form breaks them; `make test` surfaces them, but they're listed here so the
+  contract change is deliberate, not accidental.
 
 #### Task M2.5 — atlas + milestone-close
 - Update `atlas/discovery/registry.md` (issue home cue-sourced; `spec_to_command`

--- a/workshop/plans/000116-discovery-registry-plan.md
+++ b/workshop/plans/000116-discovery-registry-plan.md
@@ -212,11 +212,79 @@ For each existing finder (chat `<C-g>f`, note `<C-n>f`, issue `<C-y>f`, vision `
 
 **Accepted simplification:** assumes each type is folder-homed (the 4 finders are). Scatter types (instances spread across the repo, no fixed home) are out of scope — parley doesn't handle them today, and the agent (#128) still finds them via M1's frontmatter `Matcher`.
 
-**Deferred to #115:** the generic *faceted* finder (one shared UI parameterized by type; per-type facet bars; per-type finders as instances) is a separate design — the "two filter bars" problem (type-switch + per-type facets) makes an all-types view incoherent, so it warrants its own issue/plan. `#115 deps [000116]`. To be expanded to tasks at M2 start.
+**Deferred to #115:** the generic *faceted* finder (one shared UI parameterized by type; per-type facet bars; per-type finders as instances) is a separate design — the "two filter bars" problem (type-switch + per-type facets) makes an all-types view incoherent, so it warrants its own issue/plan. `#115 deps [000116]`.
 
-## M3 — Embedded descriptor format + scaffolding (sketch)
+### M2 tasks (expanded 2026-06-30)
 
-Settle #116's long-open descriptor-format question (lean: structured fenced block embedded in each datatype doc — single source, diffable — parsed into a TypeDescriptor with added `template`/`new_location`/`slug_rule` fields). Add a descriptor parser (extends RegistryBuilder as a third source: base ∪ grep-local ∪ embedded-descriptors), a template scaffolder, and a "new instance of type X" command (human-driven creation — consistent with the readonly-*agent* posture). Update `construct/datatype/type.md` so future prototypes ship a descriptor. To be expanded at M3 start.
+**Scope (supersedes the M1-era "M2 — Typed picker" line in Scope & milestones):**
+M2 is the **data-correctness layer** — get `issue`'s home **sourced from
+`issue.cue`** (repo-as-source-of-truth) AND make the registry's query surface
+correct on the **built** registry (the I-B fix). #115 is the UI layer on top of
+that sound data. **Only `issue` is repo-sourced** (ariadne-owned); chat/note/vision
+keep their existing parley-native root-managers — routing them through the registry
+would be a circular no-op and would drop the root-managers' labels/persistence
+(anti–Simplicity-First). Issue *creation* is M3 (delegate to `sdlc issue new`).
+
+**Single source for the issue home:** `issue_vocabulary.home()` reads
+`discovery.home` from `construct/generated/vocabulary/issue.json` (cue →
+weave-emitted), fallback `config.issues_dir`. BOTH the issue finder AND the
+registry's issue descriptor consume it (`ARCH-DRY`).
+
+#### Task M2.1 — ariadne: model issue location in cue (cross-repo)
+- Add a concrete block to `../ariadne/construct/vocabulary/issue.cue`:
+  `discovery: { home: "workshop/issues", glob: "*.md" }`.
+- Verify `cue export …/issue.cue --out json` includes `discovery`, and `make weave`
+  materializes it into parley's `construct/generated/vocabulary/issue.json` (the
+  emit is automatic — `construct/local/vocabulary/.dynamic-skill` runs `vocabulary
+  export` at `weave compile`).
+- Note in ariadne#145 that the location half landed here; #145 stays for the
+  creation-template unification.
+
+#### Task M2.2 — parley: `issue_vocabulary.home()` (cue-sourced, graceful fallback)
+- `lua/parley/issue_vocabulary.lua`: add `M.home()` → repo-root-joined
+  `discovery.home` from the loaded JSON; fallback `config.issues_dir` when the
+  field/file is absent (fresh clone, pre-weave). Pure parse over the existing IO read.
+- Test: JSON with `discovery.home` → returns it; without → fallback. (`ARCH-PURE`)
+
+#### Task M2.3 — parley: route the issue dir through the cue source
+- `lua/parley/issues.lua` `get_issues_dir()` (the single issue-dir accessor) →
+  source from `issue_vocabulary.home()`. The finder (`issue_finder.lua`) +
+  super-repo `expand_roots` already go through it; reroute that one accessor so they
+  pick up the repo-sourced dir. Keep `expand_roots` + `scan_issues`.
+- `base.lua`'s issue descriptor sources its `locate` home from the same cue home,
+  **injected via RegistryBuilder at the IO boundary** (base.lua stays a pure
+  function — receives the home as data), so `query("issue")`/`render()` reflect the
+  repo-sourced home. (`ARCH-PURE`, `ARCH-DRY`)
+
+#### Task M2.4 — I-B root-cause fix (built-registry query correctness)
+- `spec_to_command` → return a **structured form** (search_dirs + filename_globs +
+  term + frontmatter); a thin executor renders the rg argv with `shellescape`,
+  using **directories as positional search paths** and **relative filename globs in
+  `-g`** so absolute (repo-prefixed) roots match. (`ARCH-PURE` pure-compiler/thin-shell;
+  Root-Cause, not a patch.)
+- Flip `discovery_builder_spec.lua` "spec_to_command on a built registry (I-B / M2
+  seam)" from pinning the broken absolute-glob output to asserting the corrected,
+  *matching* command; add an integration test (built registry over a temp fixture →
+  the executed command actually lists the fixture's files).
+
+#### Task M2.5 — atlas + milestone-close
+- Update `atlas/discovery/registry.md` (issue home cue-sourced; `spec_to_command`
+  structured argv) + traceability for changed specs.
+- `make test` green, `make lint` clean.
+- `sdlc milestone-close --issue 116 --milestone M2`; log the verdict in `## Log`.
+
+## M3 — issue creation via sdlc delegation (sketch)
+
+**Superseded 2026-06-30** (see the issue #116 revision + the 2026-06-30 entry in
+`## Revisions` below). M3 is no longer an embedded-descriptor scaffolder.
+`sdlc issue new`'s template is **hardcoded Go** (`cmd/sdlc/internal/issue/scaffold.go`),
+not cue-sourced — ariadne#145 will unify that. So parley **delegates** issue
+creation to `sdlc issue new` (retire the duplicate `render_issue_template`/
+`cmd_issue_new` in `lua/parley/issues.lua`), then opens the created file (the
+command prints its path). id-allocation stays in sdlc. Issue-first; other
+datatypes deferred. To be expanded at M3 start.
+
+_Original sketch (kept for history):_ Settle #116's long-open descriptor-format question (lean: structured fenced block embedded in each datatype doc — single source, diffable — parsed into a TypeDescriptor with added `template`/`new_location`/`slug_rule` fields). Add a descriptor parser (extends RegistryBuilder as a third source: base ∪ grep-local ∪ embedded-descriptors), a template scaffolder, and a "new instance of type X" command (human-driven creation — consistent with the readonly-*agent* posture). Update `construct/datatype/type.md` so future prototypes ship a descriptor.
 
 ---
 
@@ -277,3 +345,27 @@ seam)" **pins the current absolute-glob output** so M2 changes it consciously
 structured argv (dir-roots + term + frontmatter) and let the executor render
 safely with `shellescape`, or set the rg search-path to each root and pass only
 the filename glob via `-g`. Decide before M2/#115 consume `query()`.
+
+### 2026-06-30 — M2 = data-correctness layer; I-B FOLDED INTO M2 (not deferred); cue-sourced issue home
+
+Settles the M2-carried open decision above, and reframes M2/M3 after auditing
+the cue→weave→parley pipeline.
+
+- **M2 owns "correct data sourced from `issue.cue`"; #115 owns common UI
+  treatment** (operator framing). Under that split **I-B is a data-correctness
+  bug → fixed in M2**, not deferred. Rationale `ARCH-PURPOSE`: the data layer is
+  the point; shipping a half-broken `query()` because no current finder calls it
+  is under-delivery. Fix = structured-argv **root cause** (search-dirs as rg
+  positional paths, relative filename globs), not a patch.
+- **Transport confirmed (already in production):** parley reads weave-emitted,
+  gitignored `construct/generated/vocabulary/issue.json` via
+  `lua/parley/issue_vocabulary.lua` (status today; we add `discovery.home`). No
+  commit/vendor/runtime-shell-out. parley is a weave derivative
+  (`construct/deps` → `substrate ../ariadne`).
+- **Repo-sourcing realized via cue:** add `discovery:{home,glob}` to ariadne
+  `issue.cue` (Task M2.1); the emit is automatic. ariadne#145 carries the deeper
+  *creation-from-cue* unification (`sdlc issue new`'s template is hardcoded Go
+  today). chat/note/vision stay parley-native.
+- **M3 = `sdlc issue new` delegation** (retire `render_issue_template`), not a
+  descriptor scaffolder. See the M3 section + the #116 issue revision.
+- Tasks: the "M2 tasks (expanded 2026-06-30)" subsection in the M2 section.

--- a/workshop/plans/000116-discovery-registry-plan.md
+++ b/workshop/plans/000116-discovery-registry-plan.md
@@ -241,20 +241,36 @@ registry's issue descriptor consume it (`ARCH-DRY`).
   creation-template unification.
 
 #### Task M2.2 — parley: `issue_vocabulary.home()` (cue-sourced, graceful fallback)
-- `lua/parley/issue_vocabulary.lua`: add `M.home()` → repo-root-joined
-  `discovery.home` from the loaded JSON; fallback `config.issues_dir` when the
-  field/file is absent (fresh clone, pre-weave). Pure parse over the existing IO read.
-- Test: JSON with `discovery.home` → returns it; without → fallback. (`ARCH-PURE`)
+- `lua/parley/issue_vocabulary.lua`: add `M.home()` → the **relative**
+  `discovery.home` from the loaded JSON (NOT repo-root-joined). Relative is the
+  consistent form: `config.issues_dir` is relative (`"workshop/issues"`,
+  `config.lua:520`), `get_issues_dir()` already does the git-root join itself
+  (`issues.lua:333-352`) and expects a relative input, and `base.lua` globs are
+  repo-relative by contract (RegistryBuilder prefixes the root). Joining anywhere
+  but `get_issues_dir()` would double-join or skip per-root expansion.
+- Fallback `config.issues_dir` (also relative) when `discovery.home` is absent.
+  The loader **raises** on a missing/unreadable file (`M.load()` → `error()`,
+  `issue_vocabulary.lua:147`), so wrap it in `pcall` — the fresh-clone/pre-weave
+  fallback must catch the raise, not just a `discovery == nil` field check.
+- Test: pin the **exact relative form** returned (`"workshop/issues"`, not merely
+  non-nil — so TDD forces the relative contract); missing field → fallback;
+  missing/unreadable file → fallback (the pcall path). (`ARCH-PURE`)
 
 #### Task M2.3 — parley: route the issue dir through the cue source
 - `lua/parley/issues.lua` `get_issues_dir()` (the single issue-dir accessor) →
   source from `issue_vocabulary.home()`. The finder (`issue_finder.lua`) +
   super-repo `expand_roots` already go through it; reroute that one accessor so they
   pick up the repo-sourced dir. Keep `expand_roots` + `scan_issues`.
-- `base.lua`'s issue descriptor sources its `locate` home from the same cue home,
-  **injected via RegistryBuilder at the IO boundary** (base.lua stays a pure
-  function — receives the home as data), so `query("issue")`/`render()` reflect the
-  repo-sourced home. (`ARCH-PURE`, `ARCH-DRY`)
+- `base.lua`'s issue descriptor sources its `locate` home from the same cue home
+  in **relative** form, **injected via RegistryBuilder at the IO boundary**
+  (base.lua stays a pure function — receives the home as data). RegistryBuilder
+  then expands it across `[repo_root] + members` exactly like every other base
+  glob, so in **super-repo mode** the registry's issue view and the finder's
+  `expand_roots` (`issue_finder.lua:133`) view **converge** — both see siblings.
+  (`ARCH-PURPOSE`: one cue home, derived in *every* mode; `ARCH-DRY`, `ARCH-PURE`.)
+- **Test (registry side):** in super-repo mode the issue `locate` is expanded
+  across roots (relative-glob behavior preserved) — guards against an absolute
+  home silently collapsing the registry to the current repo only.
 
 #### Task M2.4 — I-B root-cause fix (built-registry query correctness)
 - `spec_to_command` → return a **structured form** (search_dirs + filename_globs +
@@ -266,6 +282,11 @@ registry's issue descriptor consume it (`ARCH-DRY`).
   seam)" from pinning the broken absolute-glob output to asserting the corrected,
   *matching* command; add an integration test (built registry over a temp fixture →
   the executed command actually lists the fixture's files).
+- **Contract change — update the four string-output assertions** in
+  `tests/unit/discovery_registry_spec.lua:73,83,92,98` (they assert the current
+  `rg … -g <glob> .` string). Changing `spec_to_command` to a structured form
+  breaks them; `make test` surfaces them, but they're listed here so the contract
+  change is deliberate, not accidental.
 
 #### Task M2.5 — atlas + milestone-close
 - Update `atlas/discovery/registry.md` (issue home cue-sourced; `spec_to_command`

--- a/workshop/plans/000116-discovery-registry-plan.md
+++ b/workshop/plans/000116-discovery-registry-plan.md
@@ -314,7 +314,54 @@ not cue-sourced — ariadne#145 will unify that. So parley **delegates** issue
 creation to `sdlc issue new` (retire the duplicate `render_issue_template`/
 `cmd_issue_new` in `lua/parley/issues.lua`), then opens the created file (the
 command prints its path). id-allocation stays in sdlc. Issue-first; other
-datatypes deferred. To be expanded at M3 start.
+datatypes deferred.
+
+### M3 tasks (expanded 2026-06-30)
+
+**Scope:** delegate the **top-level** new-issue command (`cmd_issue_new` →
+`create_issue`, the `<C-y>c` flow) to `sdlc issue new "<title>"` — full delegation
+(it scaffolds + broadcasts to origin/main; operator-confirmed UX). `render_issue_template`
+has a **second caller**: the child-decomposition flow (`issues.lua:749` — adds a
+`Parent:` backlink, uses parley's `next_issue_id`). Aim to route that through
+`sdlc issue new --deps <parent>` too and **fully retire** `render_issue_template`
++ `ISSUE_TEMPLATE` (+ `next_issue_id`/`create_issue` if grep shows no other
+callers) so sdlc is the single issue-creation source incl. id allocation
+(`ARCH-DRY`). If the child flow's parent-link / parent-buffer-write semantics make
+delegation gnarly, keep `render_issue_template` for that one flow and note the
+partial retirement.
+
+#### Task M3.1 — pure: parse `sdlc issue new` stdout → created path
+- `sdlc issue new "<title>"` writes the dest path to **stdout** (last line,
+  `cmd/sdlc/issue.go:319`) + `Created <dest>` to stderr, exit 0 on success. Add a
+  PURE `M.parse_issue_new_output(stdout) → path|nil` (last non-empty line).
+  Test: normal output → path; empty/garbage → nil. (`ARCH-PURE` core)
+
+#### Task M3.2 — IO seam: run sdlc issue new (injected runner)
+- `M.run_sdlc_issue_new(title, opts, runner?) → (path|nil, err)`: build argv
+  `{"sdlc","issue","new",title}` (+ `--deps`/`--slug`), run via an **injectable
+  runner** (default = `vim.fn.system`); check shell error / non-zero exit /
+  unparseable output → err; else `parse_issue_new_output`. Thin IO over the pure
+  parser. **Tests fake the runner** — real sdlc would create+push an issue; never
+  call it in tests.
+
+#### Task M3.3 — rewrite `cmd_issue_new` to delegate
+- Keep the title prompt (repo label, `#142`); call `run_sdlc_issue_new(title)`;
+  `:edit` the returned path (or log the err). Drop `create_issue`'s template path.
+
+#### Task M3.4 — child-decomposition flow + retire `render_issue_template`
+- Route the child flow through `run_sdlc_issue_new(task_text, {deps={parent_id}})`,
+  add the `Parent:` backlink to the created file, open it. sdlc's id allocation
+  replaces parley's `next_issue_id` here. THEN delete `render_issue_template` +
+  `ISSUE_TEMPLATE` (+ `next_issue_id`/`create_issue` if grep shows no other
+  callers — `slugify` likely stays, used elsewhere). Fallback: keep
+  `render_issue_template` for the child flow + note, if delegation isn't clean.
+
+#### Task M3.5 — atlas + milestone-close
+- Atlas: issue creation delegates to `sdlc issue new` (cue/sdlc single source;
+  ariadne#145 unifies the template onto cue). `make test` + lint. `sdlc
+  milestone-close --issue 116 --milestone M3` (fresh-eyes subagent review if the
+  auto-dispatch E2BIGs, as in M2); `--no-actual` likewise if the window
+  mis-resolves.
 
 _Original sketch (kept for history):_ Settle #116's long-open descriptor-format question (lean: structured fenced block embedded in each datatype doc — single source, diffable — parsed into a TypeDescriptor with added `template`/`new_location`/`slug_rule` fields). Add a descriptor parser (extends RegistryBuilder as a third source: base ∪ grep-local ∪ embedded-descriptors), a template scaffolder, and a "new instance of type X" command (human-driven creation — consistent with the readonly-*agent* posture). Update `construct/datatype/type.md` so future prototypes ship a descriptor.
 


### PR DESCRIPTION
- #116: close issue — done (actual 7.83h); FIX-THEN-SHIP integration-review fix
- #116 M3: async issue creation + command-bar spinner
- #116 M3: fix <C-y>c E475 — resolve sdlc shell-function via interactive shell
- #116 M3: close — FIX-THEN-SHIP findings fixed (cwd-anchored creation → git-root)
- #116 M3: cmd_issue_new delegates to sdlc issue new; remove dead create_issue
- #116 M3: parse_issue_new_output + run_sdlc_issue_new (sdlc delegation core)
- #116 M3: expand plan — delegate issue creation to sdlc issue new
- #116 M2: close milestone — Review-Verdict SHIP (manual fresh-eyes review)
- #116: add derived ## Estimate block; estimate_hours 20 → 2.8
- #116 M2: atlas — cue-sourced issue home + structured spec_to_command
- #116 M2: I-B root-cause fix — spec_to_command structured argv
- #116 M2: seed config.issues_dir from cue home at setup (root-cause)
- #116 M2: issue_vocabulary.home() — cue-sourced relative issue home
- #116 M2: root-cause the issue-dir sourcing — seed config.issues_dir from cue home
- #116 M2: address plan-quality findings — relative home form + raising-loader fallback
- #116 M2: expand plan to tasks — data-correctness layer, I-B in-scope, cue-sourced issue home