### PR TITLE
issues: #187 specify contextual markdown facets

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ Most-used defaults:
 **Global**
 - `<C-g>c` new chat - global hotkey
 - `<C-g>f` find chat - global hotkey
+- `<C-g>m` find Markdown files - directory facets in ordinary repo mode and
+  repository facets in super-repo mode; query text and facet choices persist
+  across finder reopenings within the current Neovim session
 
 **In Chat Buffer**
 - `<C-g>?` show key bindings
@@ -140,6 +143,7 @@ Most-used defaults:
 **Corresponding commands**
 - `:ParleyChatNew` create a new chat
 - `:ParleyChatFinder` chat finder
+- `:ParleyMarkdownFinder` Markdown finder with contextual directory/repository facets
 - `:ParleyChatRespond` answer current question
 - `:ParleyChatRespondAll` regenerate from start to cursor
 - `:ParleyStop` stop running generation

--- a/atlas/issues/issue-management.md
+++ b/atlas/issues/issue-management.md
@@ -20,11 +20,12 @@ default), so every reader derives from the one cue source.
 - `:ParleyIssueFinder` (`<C-y>f`): float picker with status badges and 2-state view cycling — `<Tab>` (natural key; `<C-a>` kept for back-compat) toggles between `issues` (all of `workshop/issues/`, done items visible — the default, sorted by the existing status/ID order) and `history` (archived items in `workshop/history/`, sorted by file modification time ascending so the newest archive row sits closest to the bottom-anchored prompt) (#158, superseding the tri-state all/active/all+history from #152). The complete prompt query is kept verbatim across that repaint and later Issue Finder invocations; clearing the prompt persists the empty query (#177). In super-repo mode, a completely labelled root set with at least two distinct repositories adds Chat Finder's existing `[ALL] [NONE]   [repo…]` facet bar. Repo choices share one persistent state across both views and invocations, and facet updates repaint in place without touching the query; newly discovered repos default on while temporarily absent choices are retained. Incomplete labels, a single unique repo, and ordinary single-root mode omit the bar and leave rows unfiltered. Persisted NONE still opens the empty picker so ALL remains reachable (#186).
 
 Facet discovery, persistent-state merging, immutable transitions, OR filtering,
-and picker-tag projection live in the pure `lua/parley/finder_facets.lua`
-model. Chat Finder and Issue Finder only supply item-specific facet keys and
-own their session/UI adapters; the registry-driven finder in #115 and Markdown
-Finder work in #187 consume the same policy rather than creating parallel state
-machines (`ARCH-DRY`, `ARCH-PURE`).
+picker-tag projection, and complete-labelled-root eligibility live in the pure
+`lua/parley/finder_facets.lua` model. Chat, Issue, and Markdown Finders supply
+their item-specific facet keys and own their session/UI adapters; Issue and
+Markdown also use the shared eligibility policy for contextual repository bars.
+Markdown's directory-versus-repository choice remains a picker concern rather
+than broadening issue-management policy (`ARCH-DRY`, `ARCH-PURE`).
 - `:ParleyIssueNext` (`<C-y>x`): open next runnable issue (oldest open with all deps done)
 - `:ParleyIssueStatus` (`<C-y>s`): cycle frontmatter status using the first lifecycle transition for the current status in generated vocabulary order
 - `:ParleyIssueDecompose` (`<C-y>i`): create child issue from plan line, add to parent deps, and write a markdown link `[issue NNNNNN](./NNNNNN-slug.md)` into the parent's plan line; the new child file gets a `Parent: [issue PPPPPP](./PPPPPP-...md)` backlink under its title. (M3 #116: decompose **retains** parley's `render_issue_template` — its semantics, parent.deps += child + the parent plan-line link + the backlink, are incompatible with `sdlc issue new`'s shape, so unlike `:ParleyIssueNew` it is not delegated.)

--- a/atlas/modes/super_repo.md
+++ b/atlas/modes/super_repo.md
@@ -54,8 +54,10 @@ rows. An eligible expansion with zero total rows therefore retains the bar, so
 a persisted NONE state is recoverable through ALL. Incomplete labels or fewer
 than two distinct labels suppress the bar. Duplicate complete labels are
 deduplicated and suppress it only when they collapse the universe below two;
-any mismatch between row labels and the eligible root set likewise leaves the
-aggregate unfiltered with no bar rather than applying a partial facet policy.
+repo facets are also suppressed when a successfully scanned row has no label
+or has a label outside the eligible root set. Eligible roots with no rows remain
+valid facets. Suppression leaves the aggregate unfiltered with no bar rather
+than applying a partial facet policy.
 
 ## Finder query persistence
 

--- a/atlas/modes/super_repo.md
+++ b/atlas/modes/super_repo.md
@@ -45,16 +45,29 @@ super-repo simply pushes each member's chat/note dir into `chat_roots` /
 `note_roots` with `label = <repo_name>`. Issue / vision / markdown finders
 were extended explicitly during M3-M5.
 
-## Sticky `{repo}` filter
+Markdown Finder obtains the active member roots from `super_repo.get_state()`
+when each picker invocation opens; it does not treat the cached config member
+list as the authority. In super-repo mode its tag bar is repo-only:
+`[ALL] [NONE] [repo…]`. Repository choices are derived from the member roots,
+sorted alphabetically, and include members that currently yield no Markdown
+rows. An eligible expansion with zero total rows therefore retains the bar, so
+a persisted NONE state is recoverable through ALL. Incomplete, invalid, or
+duplicate member labels — and any mismatch between row labels and the eligible
+root set — leave the aggregate unfiltered and omit the bar rather than applying
+a partial facet policy.
 
-Chat, note, vision, and markdown finders preserve `{repo}` filter fragments
+## Finder query persistence
+
+Chat, note, and vision finders preserve `{repo}` filter fragments
 across reopens via `lua/parley/finder_sticky.lua`. Both completed (`{charon}`)
 and in-progress (`{char`) prompt fragments are extracted on every keystroke,
 normalised to the completed form, and re-seeded as `initial_query` next time.
 Chat finder additionally preserves `[tag]` fragments. Issue Finder is the
-intentional exception: it preserves the complete opaque query, including plain
-text, so the same filter survives view-cycle repaint and later invocations
-(#177).
+first intentional exception; Markdown Finder now follows the same complete,
+opaque policy. Each stores the prompt verbatim in its own in-memory finder state
+on every change, including whitespace and clearing to the empty string, so the
+query survives facet repaint and later invocations without going through
+`finder_sticky` (#177, #187).
 
 Matching is also forgiving of in-progress brackets: `{char` matches the same
 items as `{charon}` would (prefix match against the haystack `{repo}` token),
@@ -89,11 +102,13 @@ filter for plain repo mode's primary note root.
   `parley.is_super_repo_active()`; persistence gate consults pushed-dirs.
 - `lua/parley/issues.lua` — `scan_issues` accepts `repo_name` +
   `history_dir_override` opts.
-- `lua/parley/issue_finder.lua`, `vision_finder.lua`, `markdown_finder.lua`
-  — multi-root aggregation when `super_repo_members` is non-empty.
+- `lua/parley/issue_finder.lua`, `vision_finder.lua` — multi-root aggregation
+  through `super_repo.expand_roots`.
+- `lua/parley/markdown_finder.lua` — per-invocation aggregation and contextual
+  facets from the active `super_repo.get_state()` member roots.
 - `lua/parley/finder_sticky.lua` — shared `{root}` / `[tag]` extraction and
-  initial-query formatter used by chat, note, vision, and markdown finders;
-  Issue Finder owns its distinct full-query persistence policy.
+  initial-query formatter used by chat, note, and vision finders; Issue Finder
+  and Markdown Finder own separate full-query persistence state.
 - `lua/parley/lualine.lua` — `format_mode`, `create_mode_component`, and
   the filetype-component auto-replace at setup time.
 - `lua/parley/keybinding_registry.lua` — `super_repo_toggle` entry.

--- a/atlas/modes/super_repo.md
+++ b/atlas/modes/super_repo.md
@@ -51,10 +51,11 @@ list as the authority. In super-repo mode its tag bar is repo-only:
 `[ALL] [NONE] [repo…]`. Repository choices are derived from the member roots,
 sorted alphabetically, and include members that currently yield no Markdown
 rows. An eligible expansion with zero total rows therefore retains the bar, so
-a persisted NONE state is recoverable through ALL. Incomplete, invalid, or
-duplicate member labels — and any mismatch between row labels and the eligible
-root set — leave the aggregate unfiltered and omit the bar rather than applying
-a partial facet policy.
+a persisted NONE state is recoverable through ALL. Incomplete labels or fewer
+than two distinct labels suppress the bar. Duplicate complete labels are
+deduplicated and suppress it only when they collapse the universe below two;
+any mismatch between row labels and the eligible root set likewise leaves the
+aggregate unfiltered with no bar rather than applying a partial facet policy.
 
 ## Finder query persistence
 

--- a/atlas/traceability.yaml
+++ b/atlas/traceability.yaml
@@ -267,6 +267,7 @@ atlas:
       - tests/unit/finder_facets_spec.lua
       - tests/unit/chat_finder_logic_spec.lua
       - tests/unit/issue_finder_spec.lua
+      - tests/unit/markdown_finder_spec.lua
       - tests/unit/float_picker_spec.lua
 
   notes/structure:
@@ -514,6 +515,7 @@ atlas:
       - lua/parley/chat_dirs.lua
       - lua/parley/chat_finder.lua
       - lua/parley/note_finder.lua
+      - lua/parley/markdown_finder.lua
       - lua/parley/float_picker.lua
       - lua/parley/init.lua
       - lua/parley/config.lua
@@ -527,6 +529,7 @@ atlas:
       - tests/unit/picker_items_spec.lua
       - tests/unit/chat_finder_logic_spec.lua
       - tests/unit/note_finder_logic_spec.lua
+      - tests/unit/markdown_finder_spec.lua
       - tests/unit/pure_functions_spec.lua
 
   ui/keybindings:

--- a/atlas/ui/pickers.md
+++ b/atlas/ui/pickers.md
@@ -9,7 +9,7 @@ Up/down arrow keys wrap around at list boundaries (top wraps to bottom, bottom w
 AND-matching across whitespace-split tokens. Token-prefix scoring, bounded edit-distance typo tolerance, subsequence fallback. `{root}` / `[tag]` query tokens scope to bracketed haystack labels of the same kind; in-progress forms (`{char`, `[bu`) work the same way as their completed counterparts.
 
 ## Sticky Query
-`lua/parley/finder_sticky.lua` extracts `{root}` (and `[tag]` for chat finder) fragments from the prompt on every keystroke and re-seeds them on the next reopen. Plain text is intentionally not preserved in chat, note, vision, and markdown finders. Issue Finder is the deliberate exception: it stores the complete opaque prompt query so plain text and structured filters survive both view-cycle repaint and later invocations (#177).
+`lua/parley/finder_sticky.lua` extracts `{root}` (and `[tag]` for chat finder) fragments from the prompt on every keystroke and re-seeds them on the next reopen. Plain text is intentionally not preserved in chat, note, and vision finders. Issue Finder and Markdown Finder instead store their complete opaque prompt query verbatim in separate in-memory state, so plain text, structured filters, whitespace, and clearing to the empty string survive repaint and later invocations (#177, #187).
 
 The chat finder additionally pre-seeds `{}` (the primary chat root, which in repo mode is the repo chat root) on the first open of a parley session in plain repo mode, so the default view is scoped to repo chats and global chats are filtered out. The pre-seed is a one-shot — once the user clears or modifies the filter, sticky-query takes over and the default is never re-applied. Skipped in super-repo mode (whose whole point is aggregating siblings, which a `{}` narrowing would defeat).
 
@@ -17,11 +17,26 @@ The chat finder additionally pre-seeds `{}` (the primary chat root, which in rep
 Pickers that opt in via `recall_key` remember the id of the last `<CR>`-confirmed item (in-memory only) and place the cursor there on the next open. `recall_id_fn` lets callers point at the stable identity field (defaults to `item.value`; e.g. `item.name` for agent_picker, `item.dir` for root_dir_picker). Stale recall (id no longer present in items) silently falls through to whatever `initial_index` resolves — typically the first item. Cancel/`<Esc>` does not update recall; only confirmation does. Storage lives on `float_picker._last_selection` keyed by the picker's `recall_key`.
 
 ## Tag Bar
-Optional filterable tag row between results and prompt. OR logic — file visible if any enabled tag matches. Caller owns state; picker fires toggle callbacks.
+Optional filterable row between results and prompt. The canonical pure model is
+`lua/parley/finder_facets.lua`: source/alphabetical discovery, contextual label
+eligibility, immutable persistent-state merge/toggle/set-all transitions, OR
+filtering, and picker-tag projection. Callers choose the facet domain, own its
+state, and translate the model into the common `[ALL] [NONE] [facet…]` bar;
+`float_picker` renders it and fires callbacks.
+
+Markdown Finder selects exactly one contextual domain. Ordinary mode shows
+source-ordered top-level directory facets (when at least two exist), while an
+eligible super-repo expansion shows alphabetically ordered repository facets
+derived from the active member roots. Directory and repository choices persist
+in separate state domains, so switching modes cannot reinterpret one as the
+other. A facet toggle repaints rows and the bar in place without rewriting the
+live prompt query; persisted NONE leaves the bar available even when no rows
+remain.
 
 ## Picker Types
 - **Agent** (`:ParleyAgent`): select active agent
 - **System Prompt** (`:ParleySystemPrompt`): select active system prompt
 - **Chat Finder** (`:ParleyChatFinder` / `<C-g>f`): browse chats by recency, tags, and roots; mtime-cached metadata; sticky filter fragments across reopens
 - **Note Finder** (`:ParleyNoteFinder` / `<C-n>f`): same mechanics as Chat Finder for notes; special folders bypass recency
+- **Markdown Finder** (`:ParleyMarkdownFinder` / `<C-g>m`): browse repository Markdown by recency with contextual directory/repository facets and verbatim query persistence
 - **Outline** (`:ParleySearchChat` / `:ParleyOutline`): jump to headings and turns

--- a/lua/parley/finder_facets.lua
+++ b/lua/parley/finder_facets.lua
@@ -8,23 +8,49 @@ local function copy_state(state)
 	return copied
 end
 
-M.discover = function(entries, facets_for_entry)
+M.discover = function(entries, facets_for_entry, ordering)
 	local seen = {}
+	local discovered = {}
+	local has_empty = false
 	for _, entry in ipairs(entries) do
 		for _, key in ipairs(facets_for_entry(entry)) do
-			seen[key] = true
+			if key == "" then
+				has_empty = true
+			elseif not seen[key] then
+				seen[key] = true
+				table.insert(discovered, key)
+			end
 		end
 	end
 
-	local discovered = {}
-	local has_empty = seen[""] == true
-	seen[""] = nil
-	for key in pairs(seen) do
-		table.insert(discovered, key)
+	if ordering ~= "source" then
+		table.sort(discovered)
 	end
-	table.sort(discovered)
 	if has_empty then
 		table.insert(discovered, "")
+	end
+	return discovered
+end
+
+M.eligible_labels = function(entries, active, label_for_entry)
+	if not active then
+		return nil
+	end
+
+	local labels = {}
+	for _, entry in ipairs(entries) do
+		local label = label_for_entry(entry)
+		if type(label) ~= "string" or label == "" then
+			return nil
+		end
+		table.insert(labels, label)
+	end
+
+	local discovered = M.discover(labels, function(label)
+		return { label }
+	end)
+	if #discovered < 2 then
+		return nil
 	end
 	return discovered
 end

--- a/lua/parley/init.lua
+++ b/lua/parley/init.lua
@@ -3159,7 +3159,9 @@ M._vision_finder = {
 }
 
 M._markdown_finder = {
-	sticky_query = nil, -- Preserved {repo} filter across invocations (super-repo mode)
+	query = nil,
+	directory_facet_state = nil,
+	repo_facet_state = nil,
 }
 
 -- Create a new note with given subject

--- a/lua/parley/issue_finder.lua
+++ b/lua/parley/issue_finder.lua
@@ -63,24 +63,6 @@ M.sort_for_view = function(view_mode, issues)
     return sorted
 end
 
-local function eligible_repo_facets(roots, is_super_repo)
-    if not is_super_repo then
-        return nil
-    end
-    for _, root in ipairs(roots) do
-        if type(root.repo_name) ~= "string" or root.repo_name == "" then
-            return nil
-        end
-    end
-    local discovered = finder_facets.discover(roots, function(root)
-        return { root.repo_name }
-    end)
-    if #discovered < 2 then
-        return nil
-    end
-    return discovered
-end
-
 --------------------------------------------------------------------------------
 -- Reopen helper
 --------------------------------------------------------------------------------
@@ -195,7 +177,9 @@ M.open = function(_options)
         _parley._issue_finder.opened = false
         return
     end
-    local repo_facets = eligible_repo_facets(roots, sr_issues ~= nil)
+    local repo_facets = finder_facets.eligible_labels(roots, sr_issues ~= nil, function(root)
+        return root.repo_name
+    end)
 
     -- View mode: 0=issues (default), 1=history. Clamp with % 2 so any stale
     -- in-memory value (e.g. a `2` left by the pre-#158 tri-state) self-heals.

--- a/lua/parley/markdown_finder.lua
+++ b/lua/parley/markdown_finder.lua
@@ -1,7 +1,7 @@
 -- Markdown file finder module for Parley
 -- Finds markdown files from repo root, including parley-managed directories
--- (chats, notes, issues, history, vision). The tag bar lets users filter by
--- top-level directory if they want to hide categories.
+-- (chats, notes, issues, history, vision). The contextual tag bar filters by
+-- top-level directory in ordinary mode and repository in super-repo mode.
 
 local M = {}
 local _parley
@@ -145,7 +145,7 @@ M.build_picker_data = function(opts)
 end
 
 --- Aggregate markdown entries across super-repo members.
---- Each entry is tagged by repo name and its display becomes "<repo>/<relative>".
+--- Each labelled entry is tagged by repo name and displayed as "{repo} <relative>".
 M._scan_members = function(members, max_depth)
 	local entries = {}
 	for _, m in ipairs(members or {}) do

--- a/lua/parley/markdown_finder.lua
+++ b/lua/parley/markdown_finder.lua
@@ -6,10 +6,6 @@
 local M = {}
 local _parley
 local finder_facets = require("parley.finder_facets")
-local finder_sticky = require("parley.finder_sticky")
-
--- Tag state persists across opens within a session
-local _tag_state = {} -- { [dir_name] = true/false }
 
 M.setup = function(parley)
 	_parley = parley
@@ -148,71 +144,27 @@ M.build_picker_data = function(opts)
 	}
 end
 
---- Build picker items and tag bar from entries, respecting tag_state.
---- @return table items, table|nil tag_bar_tags, table all_tags_ordered
-local function build_picker_data(entries)
-	-- Collect unique tags in order of first appearance (mtime-sorted)
-	local tag_order = {}
-	local tag_seen = {}
-	for _, entry in ipairs(entries) do
-		if not tag_seen[entry.tag] then
-			tag_seen[entry.tag] = true
-			table.insert(tag_order, entry.tag)
-		end
-	end
-
-	-- Check if any tag is disabled
-	local any_disabled = false
-	for _, tag in ipairs(tag_order) do
-		if _tag_state[tag] == false then
-			any_disabled = true
-			break
-		end
-	end
-
-	-- Build filtered items
-	local items = {}
-	for _, entry in ipairs(entries) do
-		local enabled = _tag_state[entry.tag] ~= false
-		if not any_disabled or enabled then
-			table.insert(items, {
-				display = entry.display,
-				search_text = entry.search_text,
-				value = entry.value,
-			})
-		end
-	end
-
-	-- Build tag bar tags
-	local tag_bar_tags = nil
-	if #tag_order > 1 then
-		tag_bar_tags = {}
-		for _, tag in ipairs(tag_order) do
-			table.insert(tag_bar_tags, {
-				label = tag,
-				enabled = _tag_state[tag] ~= false,
-			})
-		end
-	end
-
-	return items, tag_bar_tags
-end
-
 --- Aggregate markdown entries across super-repo members.
 --- Each entry is tagged by repo name and its display becomes "<repo>/<relative>".
 M._scan_members = function(members, max_depth)
 	local entries = {}
 	for _, m in ipairs(members or {}) do
-		local root_prefix = vim.fn.resolve(m.path):gsub("/+$", "") .. "/"
-		local sub_entries = scan_markdown_files(m.path, max_depth)
-		for _, e in ipairs(sub_entries) do
-			local relative = e.value:sub(1, #root_prefix) == root_prefix
-				and e.value:sub(#root_prefix + 1)
-				or vim.fn.fnamemodify(e.value, ":t")
-			e.display = "{" .. m.name .. "} " .. relative .. "  [" .. os.date("%Y-%m-%d", e.mtime) .. "]"
-			e.search_text = "{" .. m.name .. "} " .. (relative:gsub("[/%-_]", " "))
-			e.tag = m.name
-			table.insert(entries, e)
+		if type(m.path) == "string" and m.path ~= "" then
+			local root_prefix = vim.fn.resolve(m.path):gsub("/+$", "") .. "/"
+			local sub_entries = scan_markdown_files(m.path, max_depth)
+			for _, e in ipairs(sub_entries) do
+				local relative = e.value:sub(1, #root_prefix) == root_prefix
+					and e.value:sub(#root_prefix + 1)
+					or vim.fn.fnamemodify(e.value, ":t")
+				if type(m.name) == "string" and m.name ~= "" then
+					e.display = "{" .. m.name .. "} " .. relative .. "  [" .. os.date("%Y-%m-%d", e.mtime) .. "]"
+					e.search_text = "{" .. m.name .. "} " .. (relative:gsub("[/%-_]", " "))
+					e.tag = m.name
+				else
+					e.tag = nil
+				end
+				table.insert(entries, e)
+			end
 		end
 	end
 	table.sort(entries, function(a, b) return a.mtime > b.mtime end)
@@ -223,13 +175,14 @@ M.open = function()
 	local config = _parley.config
 	local max_depth = config.markdown_finder_max_depth or 4
 
-	-- Compute scan roots: super-repo members or single repo_root.
-	local sr_active = _parley.is_super_repo_active and _parley.is_super_repo_active()
-	local sr_members = config.super_repo_members or {}
+	local super_state = _parley.super_repo and _parley.super_repo.get_state()
+		or { active = false, members = {} }
+	local mode = super_state.active and "super_repo" or "ordinary"
+	local member_roots = super_state.members or {}
 
 	local entries
-	if sr_active and #sr_members > 0 then
-		entries = M._scan_members(sr_members, max_depth)
+	if mode == "super_repo" then
+		entries = M._scan_members(member_roots, max_depth)
 	else
 		local repo_root = config.repo_root
 		if not repo_root or repo_root == "" then
@@ -242,48 +195,72 @@ M.open = function()
 		entries = scan_markdown_files(repo_root, max_depth)
 	end
 
-	local items, tag_bar_tags = build_picker_data(entries)
+	local function compute_picker_data()
+		local result = M.build_picker_data({
+			mode = mode,
+			entries = entries,
+			member_roots = member_roots,
+			directory_state = _parley._markdown_finder.directory_facet_state,
+			repo_state = _parley._markdown_finder.repo_facet_state,
+		})
+		_parley._markdown_finder.directory_facet_state = result.directory_state
+		_parley._markdown_finder.repo_facet_state = result.repo_state
+		return result
+	end
+
+	local picker_data = compute_picker_data()
 
 	local source_win = vim.api.nvim_get_current_win()
 	local picker_ref = {}
 
 	local tag_bar = nil
-	if tag_bar_tags then
+	if picker_data.tags then
 		local function refresh_picker()
-			local new_items, new_tb_tags = build_picker_data(entries)
+			picker_data = compute_picker_data()
 			if picker_ref.update then
-				picker_ref.update(new_items, new_tb_tags)
+				picker_ref.update(picker_data.items, picker_data.tags)
 			end
 		end
-		local function set_all_tags(value)
-			for _, entry in ipairs(entries) do
-				_tag_state[entry.tag] = value
+		local function update_active_state(update)
+			if picker_data.facet_domain == "directory" then
+				_parley._markdown_finder.directory_facet_state = update(
+					_parley._markdown_finder.directory_facet_state
+				)
+			elseif picker_data.facet_domain == "repo" then
+				_parley._markdown_finder.repo_facet_state = update(
+					_parley._markdown_finder.repo_facet_state
+				)
 			end
 			refresh_picker()
 		end
 		tag_bar = {
-			tags = tag_bar_tags,
+			tags = picker_data.tags,
 			on_toggle = function(tag_label)
-				_tag_state[tag_label] = _tag_state[tag_label] == false
-				refresh_picker()
+				update_active_state(function(state)
+					return finder_facets.toggle(state, tag_label)
+				end)
 			end,
 			on_all = function()
-				set_all_tags(true)
+				update_active_state(function(state)
+					return finder_facets.set_all(state, true)
+				end)
 			end,
 			on_none = function()
-				set_all_tags(false)
+				update_active_state(function(state)
+					return finder_facets.set_all(state, false)
+				end)
 			end,
 		}
 	end
 
 	local picker = _parley.float_picker.open({
 		title = "Markdown Files",
-		items = items,
+		items = picker_data.items,
 		recall_key = "parley.markdown_finder",
 		anchor = "bottom",
-		initial_query = finder_sticky.format_initial_query(_parley._markdown_finder.sticky_query),
+		initial_query = _parley._markdown_finder.query,
 		on_query_change = function(query)
-			_parley._markdown_finder.sticky_query = finder_sticky.extract(query, { "root" })
+			_parley._markdown_finder.query = query
 		end,
 		tag_bar = tag_bar,
 		on_select = function(item)

--- a/lua/parley/markdown_finder.lua
+++ b/lua/parley/markdown_finder.lua
@@ -5,6 +5,7 @@
 
 local M = {}
 local _parley
+local finder_facets = require("parley.finder_facets")
 local finder_sticky = require("parley.finder_sticky")
 
 -- Tag state persists across opens within a session
@@ -74,6 +75,77 @@ local function scan_markdown_files(repo_root, max_depth)
 	end)
 
 	return entries
+end
+
+local function entry_facets(entry)
+	return { entry.tag }
+end
+
+local function render_entry(entry)
+	return {
+		display = entry.display,
+		search_text = entry.search_text,
+		value = entry.value,
+	}
+end
+
+local function repo_entries_match(entries, repo_facets)
+	local known = {}
+	for _, label in ipairs(repo_facets) do
+		known[label] = true
+	end
+	for _, entry in ipairs(entries) do
+		if type(entry.tag) ~= "string" or entry.tag == "" or not known[entry.tag] then
+			return false
+		end
+	end
+	return true
+end
+
+--- Build contextual picker data without reading runtime or module state.
+--- @param opts table plain mode, entries, member roots, and facet states
+--- @return table result with items, tags, facet domain, and copied states
+M.build_picker_data = function(opts)
+	opts = opts or {}
+	local entries = opts.entries or {}
+	local directory_state = finder_facets.merge_state(opts.directory_state, {})
+	local repo_state = finder_facets.merge_state(opts.repo_state, {})
+	local visible = entries
+	local tags
+	local facet_domain
+
+	if opts.mode == "ordinary" then
+		local directory_facets = finder_facets.discover(entries, entry_facets, "source")
+		if #directory_facets >= 2 then
+			facet_domain = "directory"
+			directory_state = finder_facets.merge_state(directory_state, directory_facets)
+			visible = finder_facets.filter(entries, directory_state, entry_facets)
+			tags = finder_facets.project(directory_facets, directory_state)
+		end
+	elseif opts.mode == "super_repo" then
+		local repo_facets = finder_facets.eligible_labels(opts.member_roots or {}, true, function(root)
+			return root.name
+		end)
+		if repo_facets and repo_entries_match(entries, repo_facets) then
+			facet_domain = "repo"
+			repo_state = finder_facets.merge_state(repo_state, repo_facets)
+			visible = finder_facets.filter(entries, repo_state, entry_facets)
+			tags = finder_facets.project(repo_facets, repo_state)
+		end
+	end
+
+	local items = {}
+	for _, entry in ipairs(visible) do
+		table.insert(items, render_entry(entry))
+	end
+
+	return {
+		items = items,
+		tags = tags,
+		facet_domain = facet_domain,
+		directory_state = directory_state,
+		repo_state = repo_state,
+	}
 end
 
 --- Build picker items and tag bar from entries, respecting tag_state.

--- a/tests/unit/finder_facets_spec.lua
+++ b/tests/unit/finder_facets_spec.lua
@@ -6,7 +6,7 @@ end
 
 describe("finder facets", function()
     describe("discover", function()
-        it("deduplicates and sorts non-empty keys before the untagged key", function()
+        it("defaults to alphabetical non-empty keys before the untagged key", function()
             local calls = 0
             local entries = {
                 { facets = { "beta", "alpha" } },
@@ -23,8 +23,51 @@ describe("finder facets", function()
             assert.equals(3, calls)
         end)
 
+        it("preserves first appearance in source order while keeping the untagged key last", function()
+            local entries = {
+                { facets = { "beta", "", "alpha" } },
+                { facets = { "gamma", "beta" } },
+            }
+
+            assert.same({ "beta", "alpha", "gamma", "" }, finder_facets.discover(entries, facets, "source"))
+        end)
+
         it("returns an empty list when no facets are discovered", function()
             assert.same({}, finder_facets.discover({ { facets = {} } }, facets))
+        end)
+    end)
+
+    describe("eligible_labels", function()
+        local function repo_name(root)
+            return root.repo_name
+        end
+
+        it("returns nil when the label domain is inactive", function()
+            assert.is_nil(finder_facets.eligible_labels({ { repo_name = "alpha" }, { repo_name = "beta" } }, false, repo_name))
+        end)
+
+        it("returns nil when any projected label is incomplete", function()
+            for _, invalid in ipairs({ false, "" }) do
+                local roots = { { repo_name = "alpha" }, { repo_name = invalid } }
+                assert.is_nil(finder_facets.eligible_labels(roots, true, repo_name))
+            end
+            assert.is_nil(finder_facets.eligible_labels({ { repo_name = "alpha" }, {} }, true, repo_name))
+        end)
+
+        it("returns nil with fewer than two distinct labels", function()
+            assert.is_nil(finder_facets.eligible_labels({ { repo_name = "alpha" }, { repo_name = "alpha" } }, true, repo_name))
+        end)
+
+        it("returns sorted distinct labels without mutating entries", function()
+            local roots = {
+                { repo_name = "beta", marker = 1 },
+                { repo_name = "alpha", marker = 2 },
+                { repo_name = "beta", marker = 3 },
+            }
+            local before = vim.deepcopy(roots)
+
+            assert.same({ "alpha", "beta" }, finder_facets.eligible_labels(roots, true, repo_name))
+            assert.same(before, roots)
         end)
     end)
 

--- a/tests/unit/markdown_finder_spec.lua
+++ b/tests/unit/markdown_finder_spec.lua
@@ -1,0 +1,165 @@
+local markdown_finder = require("parley.markdown_finder")
+
+local function entry(name, tag)
+	return {
+		display = name .. " display",
+		search_text = name .. " search",
+		value = "/repo/" .. name .. ".md",
+		tag = tag,
+	}
+end
+
+local function item(name)
+	return {
+		display = name .. " display",
+		search_text = name .. " search",
+		value = "/repo/" .. name .. ".md",
+	}
+end
+
+describe("markdown finder picker policy", function()
+	it("uses only source-ordered directory facets in ordinary mode", function()
+		local entries = {
+			entry("recent", "workshop"),
+			entry("older", "docs"),
+			entry("oldest", "workshop"),
+		}
+
+		local result = markdown_finder.build_picker_data({
+			mode = "ordinary",
+			entries = entries,
+			member_roots = { { name = "zeta" }, { name = "alpha" } },
+			directory_state = { workshop = false },
+			repo_state = { docs = false },
+		})
+
+		assert.equals("directory", result.facet_domain)
+		assert.same({
+			{ label = "workshop", enabled = false },
+			{ label = "docs", enabled = true },
+		}, result.tags)
+		assert.same({ item("older") }, result.items)
+		assert.same({ docs = false }, result.repo_state)
+	end)
+
+	it("uses only alphabetized repository facets in eligible super-repo mode", function()
+		local result = markdown_finder.build_picker_data({
+			mode = "super_repo",
+			entries = { entry("beta-note", "beta"), entry("alpha-note", "alpha") },
+			member_roots = { { name = "beta" }, { name = "alpha" } },
+			directory_state = { beta = false },
+			repo_state = { alpha = false },
+		})
+
+		assert.equals("repo", result.facet_domain)
+		assert.same({
+			{ label = "alpha", enabled = false },
+			{ label = "beta", enabled = true },
+		}, result.tags)
+		assert.same({ item("beta-note") }, result.items)
+		assert.same({ beta = false }, result.directory_state)
+	end)
+
+	it("keeps an eligible member with no rows in the repository facets", function()
+		local result = markdown_finder.build_picker_data({
+			mode = "super_repo",
+			entries = { entry("alpha-note", "alpha") },
+			member_roots = { { name = "alpha" }, { name = "empty" } },
+		})
+
+		assert.same({
+			{ label = "alpha", enabled = true },
+			{ label = "empty", enabled = true },
+		}, result.tags)
+	end)
+
+	it("retains the repository bar for an eligible zero-row input", function()
+		local result = markdown_finder.build_picker_data({
+			mode = "super_repo",
+			entries = {},
+			member_roots = { { name = "beta" }, { name = "alpha" } },
+		})
+
+		assert.equals("repo", result.facet_domain)
+		assert.same({}, result.items)
+		assert.same({
+			{ label = "alpha", enabled = true },
+			{ label = "beta", enabled = true },
+		}, result.tags)
+	end)
+
+	it("renders invalid super-repo expansions unfiltered without a bar", function()
+		local invalid_roots = {
+			{ { name = "alpha" }, {} },
+			{ { name = "alpha" }, { name = 2 } },
+			{ { name = "alpha" }, { name = "" } },
+			{ { name = "alpha" }, { name = "alpha" } },
+		}
+		local entries = { entry("alpha-note", "alpha"), entry("other-note", "other") }
+
+		for _, member_roots in ipairs(invalid_roots) do
+			local result = markdown_finder.build_picker_data({
+				mode = "super_repo",
+				entries = entries,
+				member_roots = member_roots,
+				directory_state = { alpha = false },
+				repo_state = { alpha = false, absent = true },
+			})
+
+			assert.is_nil(result.facet_domain)
+			assert.is_nil(result.tags)
+			assert.same({ item("alpha-note"), item("other-note") }, result.items)
+			assert.same({ alpha = false }, result.directory_state)
+			assert.same({ alpha = false, absent = true }, result.repo_state)
+		end
+	end)
+
+	it("renders repository identity mismatches unfiltered without a bar", function()
+		local entries = { entry("alpha-note", "alpha"), entry("outside-note", "outside") }
+
+		local result = markdown_finder.build_picker_data({
+			mode = "super_repo",
+			entries = entries,
+			member_roots = { { name = "alpha" }, { name = "beta" } },
+			repo_state = { outside = false },
+		})
+
+		assert.is_nil(result.facet_domain)
+		assert.is_nil(result.tags)
+		assert.same({ item("alpha-note"), item("outside-note") }, result.items)
+	end)
+
+	it("enables new repository facets and retains absent choices", function()
+		local result = markdown_finder.build_picker_data({
+			mode = "super_repo",
+			entries = { entry("alpha-note", "alpha"), entry("beta-note", "beta") },
+			member_roots = { { name = "alpha" }, { name = "beta" } },
+			repo_state = { alpha = false, absent = false },
+		})
+
+		assert.same({ alpha = false, beta = true, absent = false }, result.repo_state)
+		assert.same({
+			{ label = "alpha", enabled = false },
+			{ label = "beta", enabled = true },
+		}, result.tags)
+	end)
+
+	it("does not mutate inputs and returns fresh tables", function()
+		local opts = {
+			mode = "ordinary",
+			entries = { entry("recent", "workshop"), entry("older", "docs") },
+			member_roots = { { name = "alpha" }, { name = "beta" } },
+			directory_state = { workshop = false, absent = true },
+			repo_state = { alpha = false },
+		}
+		local before = vim.deepcopy(opts)
+
+		local result = markdown_finder.build_picker_data(opts)
+
+		assert.same(before, opts)
+		assert.is_not.equal(opts.entries, result.items)
+		assert.is_not.equal(opts.directory_state, result.directory_state)
+		assert.is_not.equal(opts.repo_state, result.repo_state)
+		assert.is_not.equal(opts.entries[2], result.items[1])
+	end)
+end)

--- a/tests/unit/markdown_finder_spec.lua
+++ b/tests/unit/markdown_finder_spec.lua
@@ -163,3 +163,194 @@ describe("markdown finder picker policy", function()
 		assert.is_not.equal(opts.entries[2], result.items[1])
 	end)
 end)
+
+describe("markdown finder entry point", function()
+	local base_dir
+	local ordinary_root
+	local fake
+	local runtime_state
+	local picker_calls
+	local picker_updates
+
+	local function write_markdown(path, timestamp)
+		vim.fn.mkdir(vim.fn.fnamemodify(path, ":h"), "p")
+		vim.fn.writefile({ "# note" }, path)
+		if timestamp then
+			vim.loop.fs_utime(path, timestamp, timestamp)
+		end
+	end
+
+	local function labels(tags)
+		local result = {}
+		for _, tag in ipairs(tags or {}) do
+			table.insert(result, tag.label)
+		end
+		return result
+	end
+
+	local function update_values(update)
+		local result = {}
+		for _, picker_item in ipairs(update.items) do
+			table.insert(result, picker_item.value)
+		end
+		return result
+	end
+
+	local function set_runtime(active, members)
+		runtime_state = { active = active, members = members or {} }
+	end
+
+	before_each(function()
+		base_dir = vim.fn.tempname() .. "-markdown-finder-entry"
+		ordinary_root = base_dir .. "/ordinary"
+		picker_calls = {}
+		picker_updates = {}
+		set_runtime(false)
+
+		fake = {
+			_markdown_finder = {
+				query = nil,
+				directory_facet_state = nil,
+				repo_facet_state = nil,
+			},
+			config = {
+				repo_root = ordinary_root,
+				markdown_finder_max_depth = 4,
+				-- Deliberately stale: runtime super-repo state must win.
+				super_repo_members = { { path = "/stale", name = "stale" } },
+			},
+			super_repo = {
+				get_state = function()
+					return vim.deepcopy(runtime_state)
+				end,
+			},
+			helpers = {
+				find_git_root = function() return ordinary_root end,
+			},
+			logger = { warning = function() end },
+			float_picker = {
+				open = function(opts)
+					table.insert(picker_calls, opts)
+					return {
+						update = function(...)
+							local args = { ... }
+							table.insert(picker_updates, {
+								items = args[1],
+								tags = args[2],
+								argument_count = select("#", ...),
+							})
+						end,
+					}
+				end,
+			},
+			open_buf = function() end,
+		}
+		markdown_finder.setup(fake)
+	end)
+
+	after_each(function()
+		markdown_finder.setup(require("parley"))
+		if base_dir then vim.fn.delete(base_dir, "rf") end
+	end)
+
+	it("opens an ordinary directory bar and repaints without changing the live query", function()
+		local now = os.time()
+		write_markdown(ordinary_root .. "/workshop/recent.md", now)
+		write_markdown(ordinary_root .. "/docs/older.md", now - 10)
+
+		markdown_finder.open()
+		local call = picker_calls[1]
+		assert.same({ "workshop", "docs" }, labels(call.tag_bar.tags))
+		call.on_query_change("  exact live query  ")
+		call.tag_bar.on_toggle("workshop")
+
+		assert.same({ vim.fn.resolve(ordinary_root .. "/docs/older.md") }, update_values(picker_updates[1]))
+		assert.equals(2, picker_updates[1].argument_count)
+		assert.equals("  exact live query  ", fake._markdown_finder.query)
+	end)
+
+	it("reopens with verbatim whitespace and a subsequently cleared query", function()
+		write_markdown(ordinary_root .. "/note.md")
+		markdown_finder.open()
+		picker_calls[1].on_query_change("   ")
+
+		markdown_finder.open()
+		assert.equals("   ", picker_calls[2].initial_query)
+		picker_calls[2].on_query_change("")
+
+		markdown_finder.open()
+		assert.equals("", picker_calls[3].initial_query)
+	end)
+
+	it("keeps directory and repository choices independent across runtime mode changes", function()
+		local now = os.time()
+		write_markdown(ordinary_root .. "/workshop/a.md", now)
+		write_markdown(ordinary_root .. "/docs/b.md", now - 10)
+		local alpha = base_dir .. "/alpha"
+		local beta = base_dir .. "/beta"
+		local gamma = base_dir .. "/gamma"
+		write_markdown(alpha .. "/a.md", now)
+		write_markdown(beta .. "/b.md", now - 10)
+		write_markdown(gamma .. "/g.md", now - 20)
+
+		markdown_finder.open()
+		picker_calls[1].tag_bar.on_toggle("workshop")
+		set_runtime(true, { { path = alpha, name = "alpha" }, { path = beta, name = "beta" } })
+		markdown_finder.open()
+		assert.same({ "alpha", "beta" }, labels(picker_calls[2].tag_bar.tags))
+		picker_calls[2].tag_bar.on_toggle("alpha")
+
+		set_runtime(false)
+		markdown_finder.open()
+		assert.is_false(fake._markdown_finder.directory_facet_state.workshop)
+		assert.is_true(fake._markdown_finder.directory_facet_state.docs)
+
+		set_runtime(true, { { path = beta, name = "beta" }, { path = gamma, name = "gamma" } })
+		markdown_finder.open()
+		assert.is_false(fake._markdown_finder.repo_facet_state.alpha)
+		assert.is_true(fake._markdown_finder.repo_facet_state.beta)
+		assert.is_true(fake._markdown_finder.repo_facet_state.gamma)
+	end)
+
+	it("reopens after NONE with the directory bar available for ALL restore", function()
+		write_markdown(ordinary_root .. "/workshop/a.md")
+		write_markdown(ordinary_root .. "/docs/b.md")
+		markdown_finder.open()
+		picker_calls[1].tag_bar.on_none()
+		assert.equals(0, #picker_updates[1].items)
+
+		markdown_finder.open()
+		assert.equals(0, #picker_calls[2].items)
+		assert.is_table(picker_calls[2].tag_bar)
+		picker_calls[2].tag_bar.on_all()
+		assert.equals(2, #picker_updates[2].items)
+	end)
+
+	it("scans invalidly labelled members and opens the aggregate without a bar", function()
+		local alpha = base_dir .. "/alpha"
+		local unlabelled = base_dir .. "/unlabelled"
+		write_markdown(alpha .. "/a.md")
+		write_markdown(unlabelled .. "/u.md")
+		set_runtime(true, {
+			{ path = alpha, name = "alpha" },
+			{ path = unlabelled },
+			{ path = "", name = "discard-path" },
+			{ path = 3, name = "discard-number" },
+		})
+
+		assert.has_no.errors(markdown_finder.open)
+		assert.equals(2, #picker_calls[1].items)
+		assert.is_nil(picker_calls[1].tag_bar)
+	end)
+
+	it("opens an eligible zero-row super expansion with a sorted repository bar", function()
+		set_runtime(true, {
+			{ path = base_dir .. "/zeta", name = "zeta" },
+			{ path = base_dir .. "/alpha", name = "alpha" },
+		})
+
+		markdown_finder.open()
+		assert.same({}, picker_calls[1].items)
+		assert.same({ "alpha", "zeta" }, labels(picker_calls[1].tag_bar.tags))
+	end)
+end)

--- a/tests/unit/markdown_finder_spec.lua
+++ b/tests/unit/markdown_finder_spec.lua
@@ -269,6 +269,45 @@ describe("markdown finder entry point", function()
 		assert.equals("  exact live query  ", fake._markdown_finder.query)
 	end)
 
+	it("preserves picker identity and restores the source window before opening a selection", function()
+		local selected = ordinary_root .. "/selected.md"
+		write_markdown(selected)
+		local source_win = vim.api.nvim_get_current_win()
+		local opened
+		fake.open_buf = function(value, listed)
+			opened = {
+				value = value,
+				listed = listed,
+				win = vim.api.nvim_get_current_win(),
+			}
+		end
+
+		markdown_finder.open()
+		local call = picker_calls[1]
+		assert.equals("parley.markdown_finder", call.recall_key)
+		assert.equals("bottom", call.anchor)
+
+		local other_buf = vim.api.nvim_create_buf(false, true)
+		local other_win = vim.api.nvim_open_win(other_buf, true, {
+			relative = "editor",
+			row = 1,
+			col = 1,
+			width = 20,
+			height = 2,
+			style = "minimal",
+		})
+		call.on_select(call.items[1])
+		local selected_win = vim.api.nvim_get_current_win()
+		vim.api.nvim_win_close(other_win, true)
+
+		assert.equals(source_win, selected_win)
+		assert.same({
+			value = vim.fn.resolve(selected),
+			listed = true,
+			win = source_win,
+		}, opened)
+	end)
+
 	it("reopens with verbatim whitespace and a subsequently cleared query", function()
 		write_markdown(ordinary_root .. "/note.md")
 		markdown_finder.open()

--- a/workshop/issues/000187-markdown-finder-in-repo-mode-should-present-repo-facet-search.md
+++ b/workshop/issues/000187-markdown-finder-in-repo-mode-should-present-repo-facet-search.md
@@ -22,16 +22,86 @@ This is similar to issue #186. search terms and filters (facet) should be persis
 
 ## Problem
 
+Markdown Finder uses one bespoke tag-bar implementation for two different
+meanings: top-level directories in ordinary repo mode and repository names in
+super-repo mode. The super-repo behavior currently emerges indirectly because
+member scanning overwrites each entry's directory tag with its repo name. The
+two modes also share module-local selection state, so directory and repository
+keys can collide or leak across mode changes, and there is no finder-level test
+that defends the intended super-repo UI.
+
+The picker also preserves only structured `{repo}` fragments today. Ordinary
+search text is lost when the finder is reopened, despite the desired workflow
+being to resume the same Markdown search and facet selection.
+
 ## Spec
+
+### Mode-specific facet bar
+
+- In ordinary repo mode, Markdown Finder keeps its existing top-level-directory
+  facet bar.
+- In super-repo mode, the same bar represents repositories exclusively and is
+  rendered as `[ALL] [NONE]   [repo…]`; top-level-directory facets are not mixed
+  into that bar.
+- Repository facets are derived from the configured super-repo member roots,
+  not only from the current Markdown result rows. A member with no matching
+  Markdown files therefore remains a stable facet choice.
+- The repo facet bar appears only for a valid multi-repo expansion: member
+  labels must be complete and there must be at least two distinct repositories.
+
+### State and interaction
+
+- Directory facet state and repository facet state are separate. Switching
+  between ordinary and super-repo modes cannot reinterpret or overwrite keys
+  from the other facet domain.
+- Previously unseen facets default to enabled. Temporarily absent facets retain
+  their selection so rediscovery does not reset user intent.
+- Facet toggles, ALL, and NONE update the existing picker in place without
+  changing its live search query.
+- NONE may produce an empty picker; the facet bar remains available so ALL can
+  restore the results.
+- The complete Markdown Finder query, including ordinary search text, and both
+  mode-specific facet selections persist across finder invocations within the
+  current Neovim session. Persistence across Neovim restarts is out of scope.
+
+### Architecture
+
+- Reuse `parley.finder_facets` as the canonical pure discover/state/filter/
+  projection model instead of maintaining a Markdown-specific copy
+  (`ARCH-DRY`, `ARCH-PURE`).
+- Keep scanning and picker updates as thin IO/UI adapters around that model.
+- Update the finder and super-repo atlas pages whose current text says Markdown
+  preserves only structured query fragments (`ARCH-PURPOSE`).
 
 ## Done when
 
--
+- Ordinary repo mode shows only top-level-directory facets.
+- Super-repo mode shows only stable repository facets in the requested
+  `[ALL] [NONE]   [repo…]` presentation.
+- Directory and repository choices persist independently across mode switches
+  and finder reopenings; newly discovered repos default on and absent repos keep
+  their prior choice.
+- Complete search text persists across reopenings and is unchanged by facet
+  repaint.
+- NONE remains recoverable through ALL from an empty picker.
+- Automated tests cover both modes, eligibility, persistence, mode switching,
+  ALL/NONE/toggle behavior, query independence, and empty-result recovery.
+- Atlas documentation describes the mode-specific facet and query behavior.
 
 ## Plan
 
-- [ ]
+- [ ] Write and approve the durable implementation plan.
+- [ ] Implement the mode-specific Markdown facet adapter with canonical helpers.
+- [ ] Add finder-level regressions for state, query, and picker behavior.
+- [ ] Update atlas documentation and run the full verification suite.
 
 ## Log
 
 ### 2026-07-14
+
+- Recovered the interrupted session at the design checkpoint. Inspection found
+  that super-repo scanning already overwrote directory tags with repo names, but
+  the behavior was implicit, untested, and shared state across two facet
+  domains. Chose an explicit contextual bar—directories in ordinary repo mode,
+  repositories in super-repo mode—reusing `finder_facets` and preserving the
+  complete in-session query.

--- a/workshop/issues/000187-markdown-finder-in-repo-mode-should-present-repo-facet-search.md
+++ b/workshop/issues/000187-markdown-finder-in-repo-mode-should-present-repo-facet-search.md
@@ -5,7 +5,7 @@ deps: []
 github_issue:
 created: 2026-07-14
 updated: 2026-07-14
-estimate_hours:
+estimate_hours: 1.70
 started: 2026-07-14T18:42:45-07:00
 ---
 
@@ -111,9 +111,30 @@ being to resume the same Markdown search and facet selection.
   ALL/NONE/toggle behavior, query independence, and empty-result recovery.
 - Atlas documentation describes the mode-specific facet and query behavior.
 
+## Estimate
+
+```estimate
+model: estimate-logic-v3.1
+familiarity: 1.0
+item: issue-spec         design=0.70 impl=0.04
+item: lua-neovim        design=0.20 impl=0.40
+item: atlas-docs        design=0.05 impl=0.04
+item: milestone-review  design=0.00 impl=0.12
+design-buffer: 0.15
+total: 1.70
+```
+
+Produced via `brain/data/life/42shots/velocity/estimate-logic-v3.1.md`
+against `baseline-v3.1.md`. Method A only. The focused Lua/Neovim primitive
+uses the thorough-spec design discount; v3.1 scales its midpoint implementation
+hour to 40%. The estimate includes the already completed issue-spec work and one
+single-pass close review. The calibration source is currently marked stale, so
+the derived total is provisional pending the repo-local recalibration tracked by
+that source.
+
 ## Plan
 
-- [ ] Write and approve the durable implementation plan.
+- [x] Write and approve the durable implementation plan.
 - [ ] Implement the mode-specific Markdown facet adapter with canonical helpers.
 - [ ] Add finder-level regressions for state, query, and picker behavior.
 - [ ] Update atlas documentation and run the full verification suite.
@@ -137,3 +158,16 @@ Clarified that shared eligibility belongs in `finder_facets`, named the pure
 policy and IO/UI shell, specified ineligible and empty super-repo behavior, and
 made complete-query persistence verbatim. Also anchored member discovery to the
 active `super_repo` runtime state API and scoped mode changes to finder reopen.
+
+### 2026-07-14T21:42:44-07:00 — implementation plan
+
+Added the calibrated v3.1 estimate and durable implementation plan after spec
+approval. The plan keeps one close boundary and threads TDD through shared
+eligibility, the pure contextual policy, the runtime adapter, and atlas updates.
+
+### 2026-07-14T21:46:57-07:00 — plan review
+
+Corrected focused test commands, made invalid member labels safe at the scan
+boundary, expanded picker traceability, and separated post-plan close artifact
+handling from implementation checkboxes. Noted that the current calibration
+source is stale, so the reconciled estimate remains provisional.

--- a/workshop/issues/000187-markdown-finder-in-repo-mode-should-present-repo-facet-search.md
+++ b/workshop/issues/000187-markdown-finder-in-repo-mode-should-present-repo-facet-search.md
@@ -1,12 +1,13 @@
 ---
 id: 000187
-status: working
+status: codecomplete
 deps: []
 github_issue:
 created: 2026-07-14
 updated: 2026-07-14
 estimate_hours: 2.96
 started: 2026-07-14T18:42:45-07:00
+actual_hours: 5.12
 ---
 
 # markdown finder in repo mode should present repo facet search
@@ -146,6 +147,7 @@ repo-local recalibration tracked by that source.
 ## Log
 
 ### 2026-07-14
+- 2026-07-14: closed — TDD RED evidence captured for shared eligibility, pure Markdown policy, and runtime adapter; fresh focused suites passed 74/74 assertions (finder_facets 17, markdown_finder 15, issue_finder 19, super_repo 23); make lint checked 270 files with 0 warnings/errors; make test passed all 105 unit and 40 integration/architecture spec files; git diff --check, issue validation, atlas traceability review, and stale-claim shadow search were clean. Atlas updated under modes/super_repo, ui/pickers, issues/issue-management, and traceability.; review verdict: FIX-THEN-SHIP
 
 - Recovered the interrupted session at the design checkpoint. Inspection found
   that super-repo scanning already overwrote directory tags with repo names, but
@@ -171,6 +173,13 @@ repo-local recalibration tracked by that source.
   errors; focused finder suites passed 74/74 assertions; `make test` passed all
   105 unit and 40 integration/architecture spec files; `git diff --check`, issue
   validation, and the stale-claim shadow search were clean.
+- Resolved the close review's `FIX-THEN-SHIP` findings by documenting
+  `:ParleyMarkdownFinder` / `<C-g>m` in README and correcting both stale module
+  comments. The review-run fixture flakes reproduced cleanly in isolation
+  (`chat_progress_process_spec.lua` 7/7 and `tools_builtin_find_spec.lua` 4/4),
+  then a fresh complete `make test` passed all 105 unit and 40
+  integration/architecture spec files. Compacted the generated review sidecar
+  to durable findings, resolutions, verdict, and evidence before commit.
 
 ## Revisions
 

--- a/workshop/issues/000187-markdown-finder-in-repo-mode-should-present-repo-facet-search.md
+++ b/workshop/issues/000187-markdown-finder-in-repo-mode-should-present-repo-facet-search.md
@@ -139,9 +139,9 @@ repo-local recalibration tracked by that source.
 ## Plan
 
 - [x] Write and approve the durable implementation plan.
-- [ ] Implement the mode-specific Markdown facet adapter with canonical helpers.
-- [ ] Add finder-level regressions for state, query, and picker behavior.
-- [ ] Update atlas documentation and run the full verification suite.
+- [x] Implement the mode-specific Markdown facet adapter with canonical helpers.
+- [x] Add finder-level regressions for state, query, and picker behavior.
+- [x] Update atlas documentation and run the full verification suite.
 
 ## Log
 
@@ -157,6 +157,20 @@ repo-local recalibration tracked by that source.
   the extensive test/verification surface, example commits omitted required
   trailers, and ordinary directory ordering was not pinned. Revised the plan
   and estimate rather than bypassing the gate.
+- Implemented canonical labelled-facet eligibility and source-order discovery,
+  then moved Markdown Finder onto a pure contextual policy with a thin runtime
+  adapter (`ARCH-DRY`, `ARCH-PURE`). Ordinary mode retains source-ordered
+  directory facets; super-repo mode uses root-derived alphabetical repo facets,
+  with invalid expansions unfiltered and zero-row/NONE states recoverable.
+- Finder-entry regressions drive real temporary Markdown trees, picker updates,
+  runtime mode switches, exact whitespace/cleared queries, empty results, and
+  source-window selection. Per-task spec and quality reviews passed after adding
+  the missing picker identity/selection assertions and correcting two atlas
+  eligibility descriptions.
+- Verification at `550b180`: `make lint` checked 270 files with zero warnings or
+  errors; focused finder suites passed 74/74 assertions; `make test` passed all
+  105 unit and 40 integration/architecture spec files; `git diff --check`, issue
+  validation, and the stale-claim shadow search were clean.
 
 ## Revisions
 
@@ -186,3 +200,11 @@ Raised the v3.1 estimate from 1.70 to 2.96 hours using separate
 cross-cutting-refactor and high-end focused Lua primitives, made every planned
 commit policy-compliant, and specified that ordinary directory facets retain
 their existing first-appearance order while repo facets remain alphabetized.
+
+### 2026-07-14T22:28:48-07:00 — implementation complete
+
+Landed the shared facet policy, pure Markdown policy, runtime adapter, 15-test
+Markdown suite, and picker/super-repo atlas mappings. Reconciled all durable
+plan checkboxes after independent lint, focused, full-suite, diff, schema, and
+shadow-search verification; the remaining transition is the binary-owned close
+review and close-artifact commit.

--- a/workshop/issues/000187-markdown-finder-in-repo-mode-should-present-repo-facet-search.md
+++ b/workshop/issues/000187-markdown-finder-in-repo-mode-should-present-repo-facet-search.md
@@ -43,11 +43,18 @@ being to resume the same Markdown search and facet selection.
 - In super-repo mode, the same bar represents repositories exclusively and is
   rendered as `[ALL] [NONE]   [repo…]`; top-level-directory facets are not mixed
   into that bar.
-- Repository facets are derived from the configured super-repo member roots,
-  not only from the current Markdown result rows. A member with no matching
-  Markdown files therefore remains a stable facet choice.
+- Repository roots and labels come from the active `parley.super_repo` runtime
+  state API, not by independently interpreting its transient config cache.
+  Facets are derived from those roots, not only from the current Markdown result
+  rows. A member with no matching Markdown files therefore remains a stable
+  facet choice.
 - The repo facet bar appears only for a valid multi-repo expansion: member
   labels must be complete and there must be at least two distinct repositories.
+- When an active expansion is ineligible for repository facets, keep all rows
+  scanned successfully from its members unfiltered and omit the bar. Do not
+  substitute directory facets or fall back to single-repo scanning.
+- An eligible expansion with no Markdown rows still opens an empty picker with
+  its repository bar. A member containing no Markdown files is not an error.
 
 ### State and interaction
 
@@ -60,16 +67,30 @@ being to resume the same Markdown search and facet selection.
   changing its live search query.
 - NONE may produce an empty picker; the facet bar remains available so ALL can
   restore the results.
-- The complete Markdown Finder query, including ordinary search text, and both
-  mode-specific facet selections persist across finder invocations within the
-  current Neovim session. Persistence across Neovim restarts is out of scope.
+- Store the complete prompt query verbatim on every query change, including
+  leading/trailing whitespace and the empty string, and pass that exact value as
+  the next invocation's `initial_query`. Do not normalize it through
+  `finder_sticky`. A facet repaint neither rewrites nor re-emits the query.
+- Both mode-specific facet selections persist across finder invocations within
+  the current Neovim session. Persistence across Neovim restarts is out of
+  scope.
+- Mode changes take effect on the next Markdown Finder invocation; live
+  reclassification of an already-open picker is out of scope. Both domain
+  states remain retained across those invocations.
 
 ### Architecture
 
-- Reuse `parley.finder_facets` as the canonical pure discover/state/filter/
-  projection model instead of maintaining a Markdown-specific copy
-  (`ARCH-DRY`, `ARCH-PURE`).
-- Keep scanning and picker updates as thin IO/UI adapters around that model.
+- Reuse `parley.finder_facets` for discovery, state merging, immutable
+  transitions, filtering, projection, and shared facet-set eligibility. Move
+  Issue Finder's existing complete-label/multiple-distinct-label eligibility
+  rule into that canonical model rather than copying it (`ARCH-DRY`).
+- The deterministic Markdown policy accepts the active mode, scanned entries,
+  member roots, directory state, and repository state; it returns visible
+  entries, projected tags, updated states, and the eligible facet domain without
+  reading `_parley`, Vim, or module-local state (`ARCH-PURE`). Filesystem
+  scanning, super-repo state lookup, session-state assignment, and
+  `float_picker.open/update` remain the thin IO/UI shell. Unit-test the policy
+  directly and cover that shell through finder-entry tests.
 - Update the finder and super-repo atlas pages whose current text says Markdown
   preserves only structured query fragments (`ARCH-PURPOSE`).
 
@@ -82,8 +103,10 @@ being to resume the same Markdown search and facet selection.
   and finder reopenings; newly discovered repos default on and absent repos keep
   their prior choice.
 - Complete search text persists across reopenings and is unchanged by facet
-  repaint.
+  repaint, including exact whitespace and explicit clearing.
 - NONE remains recoverable through ALL from an empty picker.
+- Ineligible super-repo expansions remain aggregated but unfiltered, while an
+  eligible expansion with zero Markdown rows retains its recoverable repo bar.
 - Automated tests cover both modes, eligibility, persistence, mode switching,
   ALL/NONE/toggle behavior, query independence, and empty-result recovery.
 - Atlas documentation describes the mode-specific facet and query behavior.
@@ -105,3 +128,12 @@ being to resume the same Markdown search and facet selection.
   domains. Chose an explicit contextual bar—directories in ordinary repo mode,
   repositories in super-repo mode—reusing `finder_facets` and preserving the
   complete in-session query.
+
+## Revisions
+
+### 2026-07-14T20:35:46-07:00 — fresh spec review
+
+Clarified that shared eligibility belongs in `finder_facets`, named the pure
+policy and IO/UI shell, specified ineligible and empty super-repo behavior, and
+made complete-query persistence verbatim. Also anchored member discovery to the
+active `super_repo` runtime state API and scoped mode changes to finder reopen.

--- a/workshop/issues/000187-markdown-finder-in-repo-mode-should-present-repo-facet-search.md
+++ b/workshop/issues/000187-markdown-finder-in-repo-mode-should-present-repo-facet-search.md
@@ -5,7 +5,7 @@ deps: []
 github_issue:
 created: 2026-07-14
 updated: 2026-07-14
-estimate_hours: 1.70
+estimate_hours: 2.96
 started: 2026-07-14T18:42:45-07:00
 ---
 
@@ -39,7 +39,8 @@ being to resume the same Markdown search and facet selection.
 ### Mode-specific facet bar
 
 - In ordinary repo mode, Markdown Finder keeps its existing top-level-directory
-  facet bar.
+  facet bar, including the current first-appearance order derived from
+  mtime-sorted entries.
 - In super-repo mode, the same bar represents repositories exclusively and is
   rendered as `[ALL] [NONE]   [repo…]`; top-level-directory facets are not mixed
   into that bar.
@@ -117,20 +118,23 @@ being to resume the same Markdown search and facet selection.
 model: estimate-logic-v3.1
 familiarity: 1.0
 item: issue-spec         design=0.70 impl=0.04
-item: lua-neovim        design=0.20 impl=0.40
-item: atlas-docs        design=0.05 impl=0.04
-item: milestone-review  design=0.00 impl=0.12
+item: cross-cutting-refactor design=0.20 impl=0.20
+item: lua-neovim        design=0.60 impl=0.60
+item: atlas-docs        design=0.10 impl=0.08
+item: milestone-review  design=0.00 impl=0.20
 design-buffer: 0.15
-total: 1.70
+total: 2.96
 ```
 
 Produced via `brain/data/life/42shots/velocity/estimate-logic-v3.1.md`
 against `baseline-v3.1.md`. Method A only. The focused Lua/Neovim primitive
-uses the thorough-spec design discount; v3.1 scales its midpoint implementation
-hour to 40%. The estimate includes the already completed issue-spec work and one
-single-pass close review. The calibration source is currently marked stale, so
-the derived total is provisional pending the repo-local recalibration tracked by
-that source.
+uses the thorough-spec design discount; the cross-cutting primitive covers the
+shared eligibility API and Issue Finder migration; and v3.1 scales the selected
+high-end implementation hours to 40%. The estimate includes the already
+completed issue-spec work, the extensive finder-entry test surface, full
+verification, and one single-pass close review. The calibration source is
+currently marked stale, so the derived total is provisional pending the
+repo-local recalibration tracked by that source.
 
 ## Plan
 
@@ -149,6 +153,10 @@ that source.
   domains. Chose an explicit contextual bar—directories in ordinary repo mode,
   repositories in super-repo mode—reusing `finder_facets` and preserving the
   complete in-session query.
+- `sdlc change-code` refused the first plan-quality pass: the estimate compressed
+  the extensive test/verification surface, example commits omitted required
+  trailers, and ordinary directory ordering was not pinned. Revised the plan
+  and estimate rather than bypassing the gate.
 
 ## Revisions
 
@@ -171,3 +179,10 @@ Corrected focused test commands, made invalid member labels safe at the scan
 boundary, expanded picker traceability, and separated post-plan close artifact
 handling from implementation checkboxes. Noted that the current calibration
 source is stale, so the reconciled estimate remains provisional.
+
+### 2026-07-14T21:50:25-07:00 — change-code refusal
+
+Raised the v3.1 estimate from 1.70 to 2.96 hours using separate
+cross-cutting-refactor and high-end focused Lua primitives, made every planned
+commit policy-compliant, and specified that ordinary directory facets retain
+their existing first-appearance order while repo facets remain alphabetized.

--- a/workshop/lessons.md
+++ b/workshop/lessons.md
@@ -1,5 +1,21 @@
 # Lessons
 
+## 2026-07-14 (#187)
+
+- **A changed user-facing command needs a README discoverability check even when
+  README has no stale sentence to grep.** #187 updated Markdown Finder's facet
+  and query behavior and corrected every atlas consumer, but the close review
+  found that README did not mention `:ParleyMarkdownFinder` / `<C-g>m` at all.
+  Rule: for every visible command or keybinding changed, search README for the
+  command and key; absence is a documentation gap, not evidence that no update
+  is needed.
+- **A readiness file is ready only when its payload validates, not merely when
+  it exists.** The close review's full suite intermittently observed the fake
+  SSE server's port file after `open()` but before its write/close, producing a
+  readable empty file and `port=nil`; a clean retry passed. Rule: process-fixture
+  readiness polling must parse and validate the announced value inside the wait
+  predicate before consumers proceed.
+
 ## 2026-07-12 (#170)
 - **Making terminal failure explicit in an async callback changes every consumer contract.** `generate_topic` began calling `callback(nil, reason)` on abort/empty so the response leg could finalize exactly once, but `ChatPrune` still concatenated its callback argument as a guaranteed string. Rule: whenever a callback gains a failure invocation or return shape, grep every consumer and add one real-entry-point test per terminal outcome; shared-producer tests do not prove consumer glue handles the new contract.
 - **A bounded-work API must measure actual traversal/copying, not merely report a bounded logical row count.** A successful one-row structural replacement reported one row while deep-copying arrays proportional to the whole document, and reasoning openers each rescanned a suffix. Rule: performance tests must pin implementation-observable visits/sharing at multiple document sizes and adversarial repeated-marker fixtures; use persistent sharing and linear indexing where derived state is unchanged.

--- a/workshop/plans/000187-markdown-finder-in-repo-mode-should-present-repo-facet-search-close-review.md
+++ b/workshop/plans/000187-markdown-finder-in-repo-mode-should-present-repo-facet-search-close-review.md
@@ -1,0 +1,94 @@
+# Boundary Review — parley.nvim#187 (whole-issue close)
+
+| field | value |
+|-------|-------|
+| issue | 187 — markdown finder in repo mode should present repo facet search |
+| repo | parley.nvim |
+| issue file | workshop/issues/000187-markdown-finder-in-repo-mode-should-present-repo-facet-search.md |
+| boundary | whole-issue close |
+| milestone | — |
+| window | 6c0579776239fa26c78d2faf9d03d9739a791e5c..HEAD |
+| command | `sdlc close --issue 187` |
+| reviewer | codex |
+| timestamp | 2026-07-14T22:31:54-07:00 |
+| verdict | FIX-THEN-SHIP |
+
+## Summary
+
+The implementation fulfills #187's behavioral and architectural purpose:
+contextual facets are explicit, session states are separate, runtime
+super-repo state is authoritative, and query persistence is verbatim. No
+correctness or architectural blocker was found. Shipping was sanctioned after
+adding README discoverability and recording a clean full-suite rerun.
+
+## Strengths
+
+- Shared eligibility replaces Issue Finder's private implementation without
+  changing its behavior.
+- `markdown_finder.build_picker_data` is deterministic and side-effect free;
+  runtime state and filesystem/UI work remain in `open`.
+- Super-repo facets derive from active member roots, retain zero-row
+  repositories, reject incomplete identity domains, and avoid partial
+  filtering.
+- Query callbacks preserve exact whitespace and clearing, while facet repaint
+  passes only items and tags to the picker.
+- Atlas pages and traceability mappings cover the new flow and terminology.
+
+## Findings and resolutions
+
+### Important — README discoverability
+
+`README.md` did not mention `:ParleyMarkdownFinder` / `<C-g>m`, its contextual
+directory/repository facet bar, or in-session query persistence.
+
+Resolution: added the keybinding and corresponding command to README's basic
+command surfaces, including the contextual facet and persistence behavior.
+
+### Minor — stale module comments
+
+The Markdown Finder header described only directory facets, and `_scan_members`
+documented the display as `<repo>/<relative>` instead of `{repo} <relative>`.
+
+Resolution: corrected both comments to match the implementation.
+
+### Verification retry
+
+The review's independent `make test` run hit an unchanged process-fixture race:
+the fake SSE server's ready file became readable after `open()` but before the
+port write/close, so one attempt read `port=nil`. The review's immediate retry
+then encountered temporary swap-file errors left by the failed run. A clean
+standalone retry of `chat_progress_process_spec.lua` passed 7/7. No #187 code
+participates in that fixture path; the final close commit records a fresh clean
+full-suite run.
+
+A subsequent full run exposed another unchanged parallel-test race in
+`tools_builtin_find_spec.lua` while `find .` traversed files being created or
+deleted by other suites; its isolated rerun passed 4/4. The final fresh
+`make test` run then passed all 105 unit and 40 integration/architecture spec
+files, including both process and find suites.
+
+## Test coverage notes
+
+- Focused suites independently passed: `finder_facets_spec.lua` 17/17,
+  `markdown_finder_spec.lua` 15/15, `issue_finder_spec.lua` 19/19, and
+  `super_repo_spec.lua` 23/23.
+- `make lint` passed across 270 files.
+- Coverage pins both facet domains, runtime mode switching, root-derived empty
+  facets, ineligible aggregation, NONE recovery, immutable policy inputs, exact
+  query persistence, and selection/window behavior.
+
+## Architecture
+
+- `ARCH-DRY`: pass. Discovery, eligibility, transitions, filtering, and
+  projection remain canonical in `finder_facets`; no parallel Markdown state
+  machine remains.
+- `ARCH-PURE`: pass. All pure entities are greppable and tested directly
+  without filesystem or UI dependencies; the integration entities match their
+  declared locations and responsibilities.
+- `ARCH-PURPOSE`: pass. The complete contextual-facet and query-persistence
+  purpose ships, and both Issue and Markdown consumers use the shared
+  eligibility source.
+
+## Plan revision recommendations
+
+None. The durable plan matches the delivered entities and behavior.

--- a/workshop/plans/000187-markdown-finder-in-repo-mode-should-present-repo-facet-search-plan.md
+++ b/workshop/plans/000187-markdown-finder-in-repo-mode-should-present-repo-facet-search-plan.md
@@ -61,7 +61,7 @@
 - Test: `tests/unit/finder_facets_spec.lua`
 - Test: `tests/unit/issue_finder_spec.lua`
 
-- [ ] **Step 1: Write failing pure eligibility tests**
+- [x] **Step 1: Write failing pure eligibility tests**
 
 Add cases proving `discover` retains its sorted default and can preserve stable
 first appearance when explicitly requested. Add eligibility cases proving
@@ -74,13 +74,13 @@ assert.is_nil(finder_facets.eligible_labels({ { repo_name = "alpha" }, {} }, tru
 assert.same({ "alpha", "beta" }, finder_facets.eligible_labels(valid_roots, true, labels))
 ```
 
-- [ ] **Step 2: Run the focused test and verify RED**
+- [x] **Step 2: Run the focused test and verify RED**
 
 Run: `nvim -n --headless --noplugin -u tests/minimal_init.vim -c "PlenaryBustedFile tests/unit/finder_facets_spec.lua" -c "qa!"`
 
 Expected: FAIL because `eligible_labels` does not exist.
 
-- [ ] **Step 3: Implement ordered discovery and `eligible_labels` minimally**
+- [x] **Step 3: Implement ordered discovery and `eligible_labels` minimally**
 
 Extend `discover` with an optional ordering argument whose default remains
 alphabetical and whose explicit source-order mode preserves first appearance.
@@ -88,11 +88,11 @@ Validate every projected eligibility label as a non-empty string, use the
 default `discover` behavior for sorted/deduplicated output, and require at least
 two labels. Do not mutate roots or store state.
 
-- [ ] **Step 4: Replace Issue Finder's private eligibility helper**
+- [x] **Step 4: Replace Issue Finder's private eligibility helper**
 
 Delete `eligible_repo_facets`; call the shared helper with `root.repo_name`. Keep existing #186 behavior byte-for-byte and add/retain the integration assertions for incomplete, duplicated, and valid roots.
 
-- [ ] **Step 5: Run focused regressions and verify GREEN**
+- [x] **Step 5: Run focused regressions and verify GREEN**
 
 Run: `nvim -n --headless --noplugin -u tests/minimal_init.vim -c "PlenaryBustedFile tests/unit/finder_facets_spec.lua" -c "qa!"`
 
@@ -100,7 +100,7 @@ Run: `nvim -n --headless --noplugin -u tests/minimal_init.vim -c "PlenaryBustedF
 
 Expected: PASS.
 
-- [ ] **Step 6: Commit the shared policy**
+- [x] **Step 6: Commit the shared policy**
 
 ```bash
 git add lua/parley/finder_facets.lua lua/parley/issue_finder.lua tests/unit/finder_facets_spec.lua tests/unit/issue_finder_spec.lua
@@ -113,7 +113,7 @@ git commit -m "finder: #187 share facet eligibility" -m "Centralize labelled-roo
 - Modify: `lua/parley/markdown_finder.lua`
 - Create: `tests/unit/markdown_finder_spec.lua`
 
-- [ ] **Step 1: Write failing policy tests**
+- [x] **Step 1: Write failing policy tests**
 
 Drive `markdown_finder.build_picker_data` with plain Lua tables and assert:
 
@@ -136,13 +136,13 @@ alphabetical order; stable empty-member labels; ineligible active expansion
 returning all rows with no bar; eligible zero-row expansion retaining its bar;
 new labels default-on; absent labels retain state; and input/state non-mutation.
 
-- [ ] **Step 2: Run the new test and verify RED**
+- [x] **Step 2: Run the new test and verify RED**
 
 Run: `nvim -n --headless --noplugin -u tests/minimal_init.vim -c "PlenaryBustedFile tests/unit/markdown_finder_spec.lua" -c "qa!"`
 
 Expected: FAIL because `build_picker_data` is not exported.
 
-- [ ] **Step 3: Implement the pure policy**
+- [x] **Step 3: Implement the pure policy**
 
 Use `finder_facets.eligible_labels`, `discover`, `merge_state`, `filter`, and
 `project`. Return fresh `{ items, tags, facet_domain, directory_state,
@@ -152,7 +152,7 @@ sorting, and appear only when at least two distinct directories exist.
 Super-repo facets come from eligible runtime member roots in canonical sorted
 order and never mix directory keys.
 
-- [ ] **Step 4: Run policy and canonical helper suites**
+- [x] **Step 4: Run policy and canonical helper suites**
 
 Run: `nvim -n --headless --noplugin -u tests/minimal_init.vim -c "PlenaryBustedFile tests/unit/markdown_finder_spec.lua" -c "qa!"`
 
@@ -160,7 +160,7 @@ Run: `nvim -n --headless --noplugin -u tests/minimal_init.vim -c "PlenaryBustedF
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit the pure policy**
+- [x] **Step 5: Commit the pure policy**
 
 ```bash
 git add lua/parley/markdown_finder.lua tests/unit/markdown_finder_spec.lua
@@ -175,7 +175,7 @@ git commit -m "finder: #187 model contextual markdown facets" -m "Compose the sh
 - Test: `tests/unit/markdown_finder_spec.lua`
 - Test: `tests/unit/super_repo_spec.lua`
 
-- [ ] **Step 1: Add failing finder-entry tests with a fake picker**
+- [x] **Step 1: Add failing finder-entry tests with a fake picker**
 
 Set up a fake Parley shell and runtime `super_repo.get_state`. Assert the actual `open` options/callbacks provide:
 
@@ -193,13 +193,13 @@ valid member path independently of label validity and uses a safe display/search
 prefix only when the label is a non-empty string. It must not concatenate an
 invalid label or discard that member's successfully scanned rows.
 
-- [ ] **Step 2: Run the finder-entry suite and verify RED**
+- [x] **Step 2: Run the finder-entry suite and verify RED**
 
 Run: `nvim -n --headless --noplugin -u tests/minimal_init.vim -c "PlenaryBustedFile tests/unit/markdown_finder_spec.lua" -c "qa!"`
 
 Expected: FAIL against the module-local `_tag_state`, structured-only sticky query, and config-cache member lookup.
 
-- [ ] **Step 3: Replace hidden state with `_markdown_finder` session fields**
+- [x] **Step 3: Replace hidden state with `_markdown_finder` session fields**
 
 Initialize in `lua/parley/init.lua`:
 
@@ -213,15 +213,15 @@ M._markdown_finder = {
 
 Remove `_tag_state` and Markdown's `finder_sticky` dependency. Store every query callback value verbatim, including `""`, and pass the exact stored value as `initial_query`.
 
-- [ ] **Step 4: Make `open` a thin adapter**
+- [x] **Step 4: Make `open` a thin adapter**
 
 Read active members from `_parley.super_repo.get_state()`; scan those member paths when active, otherwise scan the ordinary repo root. Pass plain inputs to `build_picker_data`, assign returned states to `_parley._markdown_finder`, and use `finder_facets.toggle/set_all` on the active domain before recomputing. Preserve the live picker query by using only `picker.update(items, tags)`.
 
-- [ ] **Step 5: Reconcile scan tests with explicit repo identity**
+- [x] **Step 5: Reconcile scan tests with explicit repo identity**
 
 Keep `_scan_members` coverage for display/search repo prefixes and adjust assertions to the policy's entry facet field if it changes. Confirm scanning stays IO-only and does not decide bar eligibility.
 
-- [ ] **Step 6: Run focused integration suites and verify GREEN**
+- [x] **Step 6: Run focused integration suites and verify GREEN**
 
 Run: `nvim -n --headless --noplugin -u tests/minimal_init.vim -c "PlenaryBustedFile tests/unit/markdown_finder_spec.lua" -c "qa!"`
 
@@ -231,7 +231,7 @@ Run: `nvim -n --headless --noplugin -u tests/minimal_init.vim -c "PlenaryBustedF
 
 Expected: PASS.
 
-- [ ] **Step 7: Commit the adapter**
+- [x] **Step 7: Commit the adapter**
 
 ```bash
 git add lua/parley/markdown_finder.lua lua/parley/init.lua tests/unit/markdown_finder_spec.lua tests/unit/super_repo_spec.lua
@@ -247,11 +247,11 @@ git commit -m "finder: #187 persist contextual markdown facets" -m "Move Markdow
 - Modify: `atlas/traceability.yaml`
 - Modify: `workshop/issues/000187-markdown-finder-in-repo-mode-should-present-repo-facet-search.md`
 
-- [ ] **Step 1: Update the atlas at the changed boundaries**
+- [x] **Step 1: Update the atlas at the changed boundaries**
 
 Document the contextual Markdown bar, shared eligibility policy, separate session states, verbatim complete-query behavior, and empty/ineligible expansion behavior. Add `lua/parley/markdown_finder.lua` and `tests/unit/markdown_finder_spec.lua` to the `ui/pickers` traceability surface, and retain/add both under `modes/super_repo`. Keep `atlas/index.md` unchanged because all edited pages are already linked.
 
-- [ ] **Step 2: Run formatting/static checks**
+- [x] **Step 2: Run formatting/static checks**
 
 Run: `make lint`
 
@@ -259,7 +259,7 @@ Run: `git diff --check`
 
 Expected: PASS with no warnings or whitespace errors.
 
-- [ ] **Step 3: Run focused and full verification**
+- [x] **Step 3: Run focused and full verification**
 
 Run: `nvim -n --headless --noplugin -u tests/minimal_init.vim -c "PlenaryBustedFile tests/unit/finder_facets_spec.lua" -c "qa!"`
 
@@ -273,11 +273,11 @@ Run: `make test`
 
 Expected: all PASS.
 
-- [ ] **Step 4: Reconcile durable checkboxes and log evidence**
+- [x] **Step 4: Reconcile durable checkboxes and log evidence**
 
 Tick completed steps in this plan and the issue summary plan; append verification commands/results and any architecture decisions to `## Log`. Do not mark the close step complete before the boundary gate succeeds.
 
-- [ ] **Step 5: Commit documentation and issue evidence**
+- [x] **Step 5: Commit documentation and issue evidence**
 
 ```bash
 git add atlas/modes/super_repo.md atlas/ui/pickers.md atlas/issues/issue-management.md atlas/traceability.yaml workshop/issues/000187-markdown-finder-in-repo-mode-should-present-repo-facet-search.md workshop/plans/000187-markdown-finder-in-repo-mode-should-present-repo-facet-search-plan.md

--- a/workshop/plans/000187-markdown-finder-in-repo-mode-should-present-repo-facet-search-plan.md
+++ b/workshop/plans/000187-markdown-finder-in-repo-mode-should-present-repo-facet-search-plan.md
@@ -1,0 +1,269 @@
+# Contextual Markdown Finder Facets Implementation Plan
+
+> **For agentic workers:** Consult AGENTS.md Section 3 (Subagent Strategy) to determine the appropriate execution approach: use superpowers-subagent-driven-development (if subagents are suitable per AGENTS.md) or superpowers-executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep directory facets in ordinary repo mode while making Markdown Finder use stable repository-only facets and verbatim query persistence in super-repo mode.
+
+**Architecture:** Extend the canonical pure `finder_facets` model with shared labelled-root eligibility, then make `markdown_finder.build_picker_data` a pure contextual policy over scanned entries and two independent state maps. `markdown_finder.open` remains a thin shell that obtains runtime super-repo state, scans files, stores session state, and adapts the policy result to `float_picker`.
+
+**Tech Stack:** Lua, Neovim Lua API, busted/plenary test harness, Parley `float_picker` and `super_repo` runtime APIs.
+
+---
+
+## Core concepts
+
+### Pure entities
+
+| Name | Lives in | Status |
+|------|----------|--------|
+| `finder_facets.eligible_labels` | `lua/parley/finder_facets.lua` | new |
+| `markdown_finder.build_picker_data` | `lua/parley/markdown_finder.lua` | new |
+
+- **`finder_facets.eligible_labels`** — validates a labelled facet universe and returns its canonical sorted distinct labels only when the caller declares the contextual facet domain active and at least two complete labels exist.
+  - **Relationships:** N input roots produce 0-or-1 eligible label set; Issue Finder and Markdown Finder both consume the same helper.
+  - **DRY rationale:** replaces Issue Finder's private `eligible_repo_facets` and prevents Markdown Finder from copying the same complete-label/multi-label rule (`ARCH-DRY`).
+  - **Future extensions:** accept a label projection callback, already sufficient for other labelled-root finders without embedding repo vocabulary.
+- **`markdown_finder.build_picker_data`** — selects the contextual facet domain, merges only that domain's state, filters scanned entries, and projects picker items/tags without Vim, `_parley`, filesystem, or module-local state.
+  - **Relationships:** one active mode chooses exactly one of two state domains; N entries map to N-or-fewer visible picker items plus one projected tag set.
+  - **DRY rationale:** composes canonical `finder_facets` operations instead of preserving Markdown's bespoke discover/toggle/filter implementation (`ARCH-DRY`, `ARCH-PURE`).
+  - **Future extensions:** a new contextual facet domain widens the explicit input/result tables rather than adding hidden module state.
+
+### Integration points
+
+| Name | Lives in | Status | Wraps |
+|------|----------|--------|-------|
+| `markdown_finder.open` | `lua/parley/markdown_finder.lua` | modified | Vim filesystem scan, `super_repo.get_state`, session state, `float_picker.open/update` |
+| `_markdown_finder` session state | `lua/parley/init.lua` | modified | Neovim-session query and facet ownership |
+
+- **`markdown_finder.open`** — obtains the active runtime mode/member roots, invokes filesystem scanning, applies the pure policy, and wires tag-bar callbacks to immutable state transitions and picker repaint.
+  - **Injected into:** passes plain data into `markdown_finder.build_picker_data`; no IO dependency enters the pure function.
+  - **Future extensions:** scanning strategy may change independently while preserving the policy contract.
+- **`_markdown_finder` session state** — owns `query`, `directory_facet_state`, and `repo_facet_state` for the lifetime of the current Parley/Neovim session.
+  - **Injected into:** read/written only by the `open` shell; state maps are values passed to the pure policy.
+  - **Future extensions:** disk persistence would be a separate explicit integration and is out of scope.
+
+## Chunk 1: Contextual facet policy and adapter
+
+### Task 1: Canonical shared facet eligibility
+
+**Files:**
+- Modify: `lua/parley/finder_facets.lua`
+- Modify: `lua/parley/issue_finder.lua`
+- Test: `tests/unit/finder_facets_spec.lua`
+- Test: `tests/unit/issue_finder_spec.lua`
+
+- [ ] **Step 1: Write failing pure eligibility tests**
+
+Add cases proving inactive context, nil/empty labels, and fewer than two distinct labels return `nil`, while complete duplicated inputs return sorted distinct labels:
+
+```lua
+assert.is_nil(finder_facets.eligible_labels(roots, false, labels))
+assert.is_nil(finder_facets.eligible_labels({ { repo_name = "alpha" }, {} }, true, labels))
+assert.same({ "alpha", "beta" }, finder_facets.eligible_labels(valid_roots, true, labels))
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run: `nvim -n --headless --noplugin -u tests/minimal_init.vim -c "PlenaryBustedFile tests/unit/finder_facets_spec.lua" -c "qa!"`
+
+Expected: FAIL because `eligible_labels` does not exist.
+
+- [ ] **Step 3: Implement `finder_facets.eligible_labels` minimally**
+
+Validate every projected label as a non-empty string, use `discover` for sorted/deduplicated output, and require at least two labels. Do not mutate roots or store state.
+
+- [ ] **Step 4: Replace Issue Finder's private eligibility helper**
+
+Delete `eligible_repo_facets`; call the shared helper with `root.repo_name`. Keep existing #186 behavior byte-for-byte and add/retain the integration assertions for incomplete, duplicated, and valid roots.
+
+- [ ] **Step 5: Run focused regressions and verify GREEN**
+
+Run: `nvim -n --headless --noplugin -u tests/minimal_init.vim -c "PlenaryBustedFile tests/unit/finder_facets_spec.lua" -c "qa!"`
+
+Run: `nvim -n --headless --noplugin -u tests/minimal_init.vim -c "PlenaryBustedFile tests/unit/issue_finder_spec.lua" -c "qa!"`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the shared policy**
+
+```bash
+git add lua/parley/finder_facets.lua lua/parley/issue_finder.lua tests/unit/finder_facets_spec.lua tests/unit/issue_finder_spec.lua
+git commit -m "finder: #187 share facet eligibility"
+```
+
+### Task 2: Pure contextual Markdown policy
+
+**Files:**
+- Modify: `lua/parley/markdown_finder.lua`
+- Create: `tests/unit/markdown_finder_spec.lua`
+
+- [ ] **Step 1: Write failing policy tests**
+
+Drive `markdown_finder.build_picker_data` with plain Lua tables and assert:
+
+```lua
+local result = markdown_finder.build_picker_data({
+  mode = "super_repo",
+  entries = entries,
+  member_roots = roots,
+  directory_state = { workshop = false },
+  repo_state = { alpha = false },
+})
+assert.equals("repo", result.facet_domain)
+assert.same({ { label = "alpha", enabled = false }, { label = "beta", enabled = true } }, result.tags)
+assert.is_false(result.directory_state.workshop)
+```
+
+Cover ordinary mode directory-only facets; eligible super-repo repository-only facets; stable empty-member labels; ineligible active expansion returning all rows with no bar; eligible zero-row expansion retaining its bar; new labels default-on; absent labels retain state; and input/state non-mutation.
+
+- [ ] **Step 2: Run the new test and verify RED**
+
+Run: `nvim -n --headless --noplugin -u tests/minimal_init.vim -c "PlenaryBustedFile tests/unit/markdown_finder_spec.lua" -c "qa!"`
+
+Expected: FAIL because `build_picker_data` is not exported.
+
+- [ ] **Step 3: Implement the pure policy**
+
+Use `finder_facets.eligible_labels`, `discover`, `merge_state`, `filter`, and `project`. Return fresh `{ items, tags, facet_domain, directory_state, repo_state }`; never read `_parley`, Vim, or module-local variables. Directory facets remain row-derived and appear only when at least two distinct directories exist. Super-repo facets come from eligible runtime member roots and never mix directory keys.
+
+- [ ] **Step 4: Run policy and canonical helper suites**
+
+Run: `nvim -n --headless --noplugin -u tests/minimal_init.vim -c "PlenaryBustedFile tests/unit/markdown_finder_spec.lua" -c "qa!"`
+
+Run: `nvim -n --headless --noplugin -u tests/minimal_init.vim -c "PlenaryBustedFile tests/unit/finder_facets_spec.lua" -c "qa!"`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the pure policy**
+
+```bash
+git add lua/parley/markdown_finder.lua tests/unit/markdown_finder_spec.lua
+git commit -m "finder: #187 model contextual markdown facets"
+```
+
+### Task 3: Wire runtime state, verbatim query, and picker repaint
+
+**Files:**
+- Modify: `lua/parley/markdown_finder.lua`
+- Modify: `lua/parley/init.lua`
+- Test: `tests/unit/markdown_finder_spec.lua`
+- Test: `tests/unit/super_repo_spec.lua`
+
+- [ ] **Step 1: Add failing finder-entry tests with a fake picker**
+
+Set up a fake Parley shell and runtime `super_repo.get_state`. Assert the actual `open` options/callbacks provide:
+
+- ordinary mode directory tags only;
+- super-repo mode sorted repo tags only, including a member with no rows;
+- verbatim `initial_query` after whitespace-bearing input and exact empty-string clearing;
+- facet toggle/ALL/NONE repaint through `picker.update` without calling `on_query_change` or altering `query`;
+- separate directory/repo states across close, mode switch, and reopen;
+- NONE reopening with zero items and ALL restoring rows;
+- invalid labels retaining aggregated rows without a bar;
+- eligible zero-row expansion retaining its bar.
+
+The invalid-label case must reach the policy: member scanning accepts every
+valid member path independently of label validity and uses a safe display/search
+prefix only when the label is a non-empty string. It must not concatenate an
+invalid label or discard that member's successfully scanned rows.
+
+- [ ] **Step 2: Run the finder-entry suite and verify RED**
+
+Run: `nvim -n --headless --noplugin -u tests/minimal_init.vim -c "PlenaryBustedFile tests/unit/markdown_finder_spec.lua" -c "qa!"`
+
+Expected: FAIL against the module-local `_tag_state`, structured-only sticky query, and config-cache member lookup.
+
+- [ ] **Step 3: Replace hidden state with `_markdown_finder` session fields**
+
+Initialize in `lua/parley/init.lua`:
+
+```lua
+M._markdown_finder = {
+  query = nil,
+  directory_facet_state = nil,
+  repo_facet_state = nil,
+}
+```
+
+Remove `_tag_state` and Markdown's `finder_sticky` dependency. Store every query callback value verbatim, including `""`, and pass the exact stored value as `initial_query`.
+
+- [ ] **Step 4: Make `open` a thin adapter**
+
+Read active members from `_parley.super_repo.get_state()`; scan those member paths when active, otherwise scan the ordinary repo root. Pass plain inputs to `build_picker_data`, assign returned states to `_parley._markdown_finder`, and use `finder_facets.toggle/set_all` on the active domain before recomputing. Preserve the live picker query by using only `picker.update(items, tags)`.
+
+- [ ] **Step 5: Reconcile scan tests with explicit repo identity**
+
+Keep `_scan_members` coverage for display/search repo prefixes and adjust assertions to the policy's entry facet field if it changes. Confirm scanning stays IO-only and does not decide bar eligibility.
+
+- [ ] **Step 6: Run focused integration suites and verify GREEN**
+
+Run: `nvim -n --headless --noplugin -u tests/minimal_init.vim -c "PlenaryBustedFile tests/unit/markdown_finder_spec.lua" -c "qa!"`
+
+Run: `nvim -n --headless --noplugin -u tests/minimal_init.vim -c "PlenaryBustedFile tests/unit/super_repo_spec.lua" -c "qa!"`
+
+Run: `nvim -n --headless --noplugin -u tests/minimal_init.vim -c "PlenaryBustedFile tests/unit/issue_finder_spec.lua" -c "qa!"`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit the adapter**
+
+```bash
+git add lua/parley/markdown_finder.lua lua/parley/init.lua tests/unit/markdown_finder_spec.lua tests/unit/super_repo_spec.lua
+git commit -m "finder: #187 persist contextual markdown facets"
+```
+
+### Task 4: Documentation and full verification
+
+**Files:**
+- Modify: `atlas/modes/super_repo.md`
+- Modify: `atlas/ui/pickers.md`
+- Modify: `atlas/issues/issue-management.md`
+- Modify: `atlas/traceability.yaml`
+- Modify: `workshop/issues/000187-markdown-finder-in-repo-mode-should-present-repo-facet-search.md`
+
+- [ ] **Step 1: Update the atlas at the changed boundaries**
+
+Document the contextual Markdown bar, shared eligibility policy, separate session states, verbatim complete-query behavior, and empty/ineligible expansion behavior. Add `lua/parley/markdown_finder.lua` and `tests/unit/markdown_finder_spec.lua` to the `ui/pickers` traceability surface, and retain/add both under `modes/super_repo`. Keep `atlas/index.md` unchanged because all edited pages are already linked.
+
+- [ ] **Step 2: Run formatting/static checks**
+
+Run: `make lint`
+
+Run: `git diff --check`
+
+Expected: PASS with no warnings or whitespace errors.
+
+- [ ] **Step 3: Run focused and full verification**
+
+Run: `nvim -n --headless --noplugin -u tests/minimal_init.vim -c "PlenaryBustedFile tests/unit/finder_facets_spec.lua" -c "qa!"`
+
+Run: `nvim -n --headless --noplugin -u tests/minimal_init.vim -c "PlenaryBustedFile tests/unit/markdown_finder_spec.lua" -c "qa!"`
+
+Run: `nvim -n --headless --noplugin -u tests/minimal_init.vim -c "PlenaryBustedFile tests/unit/issue_finder_spec.lua" -c "qa!"`
+
+Run: `nvim -n --headless --noplugin -u tests/minimal_init.vim -c "PlenaryBustedFile tests/unit/super_repo_spec.lua" -c "qa!"`
+
+Run: `make test`
+
+Expected: all PASS.
+
+- [ ] **Step 4: Reconcile durable checkboxes and log evidence**
+
+Tick completed steps in this plan and the issue summary plan; append verification commands/results and any architecture decisions to `## Log`. Do not mark the close step complete before the boundary gate succeeds.
+
+- [ ] **Step 5: Commit documentation and issue evidence**
+
+```bash
+git add atlas/modes/super_repo.md atlas/ui/pickers.md atlas/issues/issue-management.md atlas/traceability.yaml workshop/issues/000187-markdown-finder-in-repo-mode-should-present-repo-facet-search.md workshop/plans/000187-markdown-finder-in-repo-mode-should-present-repo-facet-search-plan.md
+git commit -m "docs: #187 map contextual markdown facets"
+```
+
+## Boundary procedure after every implementation checkbox is complete
+
+This is gate metadata, not an implementation checkbox: leaving the close itself
+unchecked would make the durable plan appear incomplete to its own reviewer.
+
+1. Run `sdlc actual --issue 187`, then `sdlc close --issue 187 --verified '<focused suites, full make test, lint, diff-check, and behavior evidence>'`. Let the binary dispatch the mandatory fresh-context review; fix Critical/Important findings and rerun the same gate.
+2. Inspect the gate-produced issue/log and review sidecar. If the sidecar contains a raw transcript, ANSI plumbing, or generated bulk, compact it to durable metadata, findings, resolutions, verdict, and evidence while preserving the review result.
+3. Run `git diff --check` and the relevant focused test if a review fix changed code.
+4. Commit the close mutations and normalized sidecar with the required `Co-Authored-By:` trailer; do not leave gate-generated artifacts uncommitted.

--- a/workshop/plans/000187-markdown-finder-in-repo-mode-should-present-repo-facet-search-plan.md
+++ b/workshop/plans/000187-markdown-finder-in-repo-mode-should-present-repo-facet-search-plan.md
@@ -16,9 +16,18 @@
 
 | Name | Lives in | Status |
 |------|----------|--------|
+| `finder_facets.discover` | `lua/parley/finder_facets.lua` | modified |
 | `finder_facets.eligible_labels` | `lua/parley/finder_facets.lua` | new |
 | `markdown_finder.build_picker_data` | `lua/parley/markdown_finder.lua` | new |
 
+- **`finder_facets.discover`** — keeps its sorted default for existing consumers
+  and gains an explicit option for stable first-appearance ordering.
+  - **Relationships:** every facet policy may choose canonical alphabetical or
+    source-order discovery without reimplementing collection/deduplication.
+  - **DRY rationale:** preserves Markdown's current directory presentation while
+    retaining one discovery implementation (`ARCH-DRY`).
+  - **Future extensions:** no additional ordering modes are anticipated; add
+    only when a concrete finder contract requires one.
 - **`finder_facets.eligible_labels`** — validates a labelled facet universe and returns its canonical sorted distinct labels only when the caller declares the contextual facet domain active and at least two complete labels exist.
   - **Relationships:** N input roots produce 0-or-1 eligible label set; Issue Finder and Markdown Finder both consume the same helper.
   - **DRY rationale:** replaces Issue Finder's private `eligible_repo_facets` and prevents Markdown Finder from copying the same complete-label/multi-label rule (`ARCH-DRY`).
@@ -54,7 +63,10 @@
 
 - [ ] **Step 1: Write failing pure eligibility tests**
 
-Add cases proving inactive context, nil/empty labels, and fewer than two distinct labels return `nil`, while complete duplicated inputs return sorted distinct labels:
+Add cases proving `discover` retains its sorted default and can preserve stable
+first appearance when explicitly requested. Add eligibility cases proving
+inactive context, nil/empty labels, and fewer than two distinct labels return
+`nil`, while complete duplicated inputs return sorted distinct labels:
 
 ```lua
 assert.is_nil(finder_facets.eligible_labels(roots, false, labels))
@@ -68,9 +80,13 @@ Run: `nvim -n --headless --noplugin -u tests/minimal_init.vim -c "PlenaryBustedF
 
 Expected: FAIL because `eligible_labels` does not exist.
 
-- [ ] **Step 3: Implement `finder_facets.eligible_labels` minimally**
+- [ ] **Step 3: Implement ordered discovery and `eligible_labels` minimally**
 
-Validate every projected label as a non-empty string, use `discover` for sorted/deduplicated output, and require at least two labels. Do not mutate roots or store state.
+Extend `discover` with an optional ordering argument whose default remains
+alphabetical and whose explicit source-order mode preserves first appearance.
+Validate every projected eligibility label as a non-empty string, use the
+default `discover` behavior for sorted/deduplicated output, and require at least
+two labels. Do not mutate roots or store state.
 
 - [ ] **Step 4: Replace Issue Finder's private eligibility helper**
 
@@ -88,7 +104,7 @@ Expected: PASS.
 
 ```bash
 git add lua/parley/finder_facets.lua lua/parley/issue_finder.lua tests/unit/finder_facets_spec.lua tests/unit/issue_finder_spec.lua
-git commit -m "finder: #187 share facet eligibility"
+git commit -m "finder: #187 share facet eligibility" -m "Centralize labelled-root eligibility and preserve explicit source-order discovery for contextual finder consumers.\n\nCo-Authored-By: Codex <noreply@openai.com>"
 ```
 
 ### Task 2: Pure contextual Markdown policy
@@ -114,7 +130,11 @@ assert.same({ { label = "alpha", enabled = false }, { label = "beta", enabled = 
 assert.is_false(result.directory_state.workshop)
 ```
 
-Cover ordinary mode directory-only facets; eligible super-repo repository-only facets; stable empty-member labels; ineligible active expansion returning all rows with no bar; eligible zero-row expansion retaining its bar; new labels default-on; absent labels retain state; and input/state non-mutation.
+Cover ordinary mode directory-only facets in the existing first-appearance order
+of mtime-sorted entries; eligible super-repo repository-only facets in canonical
+alphabetical order; stable empty-member labels; ineligible active expansion
+returning all rows with no bar; eligible zero-row expansion retaining its bar;
+new labels default-on; absent labels retain state; and input/state non-mutation.
 
 - [ ] **Step 2: Run the new test and verify RED**
 
@@ -124,7 +144,13 @@ Expected: FAIL because `build_picker_data` is not exported.
 
 - [ ] **Step 3: Implement the pure policy**
 
-Use `finder_facets.eligible_labels`, `discover`, `merge_state`, `filter`, and `project`. Return fresh `{ items, tags, facet_domain, directory_state, repo_state }`; never read `_parley`, Vim, or module-local variables. Directory facets remain row-derived and appear only when at least two distinct directories exist. Super-repo facets come from eligible runtime member roots and never mix directory keys.
+Use `finder_facets.eligible_labels`, `discover`, `merge_state`, `filter`, and
+`project`. Return fresh `{ items, tags, facet_domain, directory_state,
+repo_state }`; never read `_parley`, Vim, or module-local variables. Directory
+facets remain row-derived, preserve first appearance by opting out of discovery
+sorting, and appear only when at least two distinct directories exist.
+Super-repo facets come from eligible runtime member roots in canonical sorted
+order and never mix directory keys.
 
 - [ ] **Step 4: Run policy and canonical helper suites**
 
@@ -138,7 +164,7 @@ Expected: PASS.
 
 ```bash
 git add lua/parley/markdown_finder.lua tests/unit/markdown_finder_spec.lua
-git commit -m "finder: #187 model contextual markdown facets"
+git commit -m "finder: #187 model contextual markdown facets" -m "Compose the shared pure facet model into explicit directory and repository domains without changing ordinary directory ordering.\n\nCo-Authored-By: Codex <noreply@openai.com>"
 ```
 
 ### Task 3: Wire runtime state, verbatim query, and picker repaint
@@ -209,7 +235,7 @@ Expected: PASS.
 
 ```bash
 git add lua/parley/markdown_finder.lua lua/parley/init.lua tests/unit/markdown_finder_spec.lua tests/unit/super_repo_spec.lua
-git commit -m "finder: #187 persist contextual markdown facets"
+git commit -m "finder: #187 persist contextual markdown facets" -m "Move Markdown Finder state into the Parley session and preserve complete queries while picker facets repaint independently.\n\nCo-Authored-By: Codex <noreply@openai.com>"
 ```
 
 ### Task 4: Documentation and full verification
@@ -255,7 +281,7 @@ Tick completed steps in this plan and the issue summary plan; append verificatio
 
 ```bash
 git add atlas/modes/super_repo.md atlas/ui/pickers.md atlas/issues/issue-management.md atlas/traceability.yaml workshop/issues/000187-markdown-finder-in-repo-mode-should-present-repo-facet-search.md workshop/plans/000187-markdown-finder-in-repo-mode-should-present-repo-facet-search-plan.md
-git commit -m "docs: #187 map contextual markdown facets"
+git commit -m "docs: #187 map contextual markdown facets" -m "Document the mode-specific bar, verbatim query contract, and shared pure policy across picker and super-repo traceability.\n\nCo-Authored-By: Codex <noreply@openai.com>"
 ```
 
 ## Boundary procedure after every implementation checkbox is complete


### PR DESCRIPTION
- finder: #187 resolve close review
- issues: #187 record contextual facet evidence
- docs: #187 clarify markdown row eligibility
- docs: #187 clarify duplicate facet eligibility
- docs: #187 map contextual markdown facets
- test: #187 pin markdown picker selection context
- finder: #187 persist contextual markdown facets
- finder: #187 model contextual markdown facets
- finder: #187 share facet eligibility